### PR TITLE
Recent Solutions: show 1st-3rd place rank and add language filter.

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ func main() {
 	r.Get("/log-out", routes.LogOut)
 	r.Get("/random", routes.Random)
 	r.Get("/recent", routes.Recent)
+	r.Get("/recent/{lang}", routes.Recent)
 	r.Get("/robots.txt", routes.Robots)
 	r.Get("/scores/{hole}/{lang}", routes.Scores)
 	r.Get("/scores/{hole}/{lang}/{suffix}", routes.Scores)

--- a/routes/recent.go
+++ b/routes/recent.go
@@ -8,9 +8,42 @@ import (
 // Recent serves GET /recent
 func Recent(w http.ResponseWriter, r *http.Request) {
 	rows, err := db(r).Query(
-		` SELECT hole, lang, login, LENGTH(code), submitted
-		    FROM solutions JOIN users ON id = user_id
-		ORDER BY submitted DESC LIMIT 100`,
+		`WITH solution_lengths AS (
+        SELECT hole,
+               lang,
+               login,
+               LENGTH(code) strokes,
+               submitted
+          FROM solutions
+          JOIN users on user_id = id
+         WHERE NOT failing
+     )  SELECT t1.hole,
+               t1.lang,
+               login,
+               t1.strokes,
+               rank,
+               COUNT(*) - 1 tie_count,
+               t1.submitted
+          FROM solution_lengths AS t1
+    INNER JOIN (
+        SELECT RANK() OVER (PARTITION BY hole, lang ORDER BY strokes) rank,
+               hole,
+               lang,
+               strokes,
+               submitted
+          FROM solution_lengths
+    ) AS t2
+            ON t1.hole = t2.hole
+           AND t1.lang = t2.lang
+           AND t1.strokes = t2.strokes
+           AND t2.submitted <= t1.submitted
+      GROUP BY t1.hole,
+               t1.lang,
+               login,
+               t1.strokes,
+               t1.submitted,
+               rank
+      ORDER BY t1.submitted DESC LIMIT 100`,
 	)
 	if err != nil {
 		panic(err)
@@ -23,6 +56,8 @@ func Recent(w http.ResponseWriter, r *http.Request) {
 		Lang      Lang
 		Login     string
 		Strokes   int
+		Rank      int
+		TieCount  int
 		Submitted time.Time
 	}
 
@@ -37,6 +72,8 @@ func Recent(w http.ResponseWriter, r *http.Request) {
 			&langID,
 			&r.Login,
 			&r.Strokes,
+			&r.Rank,
+			&r.TieCount,
 			&r.Submitted,
 		); err != nil {
 			panic(err)

--- a/views/header.html
+++ b/views/header.html
@@ -16,12 +16,12 @@
 
 <header>
     <nav>
-        <a {{ if ne             .Path "/"         }} href=/       title=Home                       {{ end }}></a>
-        <a {{ if ne             .Path "/about"    }} href=/about  title=About                      {{ end }}></a>
-        <a {{ if ne             .Path "/ideas"    }} href=/ideas  title=Ideas                      {{ end }}></a>
-        <a {{ if ne             .Path "/recent"   }} href=/recent title="Recent Solutions"         {{ end }}></a>
-        <a {{ if not (hasPrefix .Path "/scores/") }} href=/scores/all-holes/all-langs title=Scores {{ end }}></a>
-        <a {{ if ne             .Path "/stats"    }} href=/stats  title=Statistics                 {{ end }}></a>
+        <a {{ if ne             .Path "/"         }} href=/       title=Home                         {{ end }}></a>
+        <a {{ if ne             .Path "/about"    }} href=/about  title=About                        {{ end }}></a>
+        <a {{ if ne             .Path "/ideas"    }} href=/ideas  title=Ideas                        {{ end }}></a>
+        <a {{ if ne             .Path "/recent"   }} href=/recent/all-langs title="Recent Solutions" {{ end }}></a>
+        <a {{ if not (hasPrefix .Path "/scores/") }} href=/scores/all-holes/all-langs title=Scores   {{ end }}></a>
+        <a {{ if ne             .Path "/stats"    }} href=/stats  title=Statistics                   {{ end }}></a>
         <div></div>
     {{ if .Login }}
         {{ $profile := (print "/users/" .Login) }}

--- a/views/recent.html
+++ b/views/recent.html
@@ -1,9 +1,27 @@
 {{ template "header" . }}
 
+{{ $langID := .Data.LangID }}
 {{ $login  := .Login }}
 
 <main id=recent>
     <h1>Recent Solutions</h1>
+
+    <details class=nav>
+        {{ if eq $langID "all-langs" }}
+            <summary>All Langs</summary>
+        {{ else }}
+            <a href="/recent/all-langs">All Langs</a>
+        {{ end }}
+
+        {{ range .Data.Langs }}
+            {{ if eq $langID .ID }}
+                <summary>{{ .Name }}</summary>
+            {{ else }}
+                <a href="/recent/{{ .ID }}">{{ .Name }}</a>
+            {{ end }}
+        {{ end }}
+    </details>
+
     <table class="scores sticky">
         <thead>
             <tr>
@@ -14,7 +32,7 @@
                 <th class="wide">
                 <th class=right>Submitted
         <tbody>
-        {{- range .Data -}}
+        {{- range .Data.Recents -}}
             <tr{{ if eq $login .Login }} class="me"{{ end }}>
                 <td><a href={{ .Hole.ID }}#{{ .Lang.ID }}>{{ .Hole.Name }}</a>
                 <td>
@@ -24,7 +42,7 @@
                     </a>
                 <td class=wide>
                     <a href="/scores/all-holes/{{ .Lang.ID }}">{{ .Lang.Name }}</a>
-                <td class="right wide" title="{{ .Rank }}{{ ord .Rank }}">{{ comma .Strokes }}
+                <td class="right wide" title="Rank: {{ .Rank }}{{ ord .Rank }}">{{ comma .Strokes }}
                 <td class="wide"
                     {{if not .TieCount}}
                         {{if eq .Rank 1}}title="Shorter than previous 1st place solutions"

--- a/views/recent.html
+++ b/views/recent.html
@@ -11,6 +11,7 @@
                 <th>Golfer
                 <th class=wide>Lang
                 <th class="right wide">Strokes
+                <th class="wide">
                 <th class=right>Submitted
         <tbody>
         {{- range .Data -}}
@@ -23,7 +24,19 @@
                     </a>
                 <td class=wide>
                     <a href="/scores/all-holes/{{ .Lang.ID }}">{{ .Lang.Name }}</a>
-                <td class="right wide">{{ comma .Strokes }}
+                <td class="right wide" title="{{ .Rank }}{{ ord .Rank }}">{{ comma .Strokes }}
+                <td class="wide"
+                    {{if not .TieCount}}
+                        {{if eq .Rank 1}}title="Shorter than previous 1st place solutions"
+                        {{else if eq .Rank 2}}title="Shorter than previous 2nd place solutions"
+                        {{else if eq .Rank 3}}title="Shorter than previous 3rd place solutions"
+                        {{end}}
+                    {{end}}>
+                    {{if eq .Rank 1}}🥇
+                    {{else if eq .Rank 2}}🥈
+                    {{else if eq .Rank 3}}🥉
+                    {{end}}
+                    {{if and (not .TieCount) (le .Rank 3)}}📉{{end}}
                 <td class=right>{{ time .Submitted }}
         {{- end -}}
     </table>


### PR DESCRIPTION
If the solution set a new record for the hole/language at the time it was submitted, apply a yellow background to the stroke count to indicate this.

Here's an example of what it looks like, using two week old data loaded into my local database. Of course I don't have the full database, I just set code = 'a' * strokes.

You can tell the difference between first place scores that are shorter than previous first place scores and those that aren't.

<img width="758" alt="Screen Shot 2020-02-09 at 3 05 33 PM" src="https://user-images.githubusercontent.com/53135437/74109154-ff3de480-4b4e-11ea-8236-3f46dc7b8f05.png">
