### PR TITLE
Simplify development workflow: build run-langs.c inside of the container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY pretty             ./pretty/
 COPY routes             ./routes/
 
 RUN go build -ldflags -s \
- && gcc -Wall -Werror -Wextra -o run-lang -s -static run-lang.c
+ && gcc -Wall -Werror -Wextra -o /usr/bin/run-lang -s -static run-lang.c
 
 RUN mkdir /empty
 
@@ -76,7 +76,8 @@ COPY --from=0 /empty       /langs/rust/rootfs/tmp/
 COPY --from=0 /empty      /langs/swift/rootfs/proc/
 COPY --from=0 /empty      /langs/swift/rootfs/tmp/
 
-COPY --from=0 /go/code-golf /go/run-lang         /
+COPY --from=0 /go/code-golf                      /
+COPY --from=0 /usr/bin/run-lang                  /usr/bin/
 COPY          holes.toml                         /
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY          views                              /views/

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,4 +4,9 @@ ENV CGO_ENABLED=0 GOPATH= TZ=Europe/London
 
 RUN GOBIN=/bin go get github.com/cespare/reflex
 
+COPY run-lang.c ./
+
+RUN gcc -Wall -Werror -Wextra -o /usr/bin/run-lang -s -static run-lang.c
+
+# reflex reruns a command when files change.
 CMD reflex -sd none -r '\.(go|html|pem|svg|toml)$' -R '_test\.go$' -- go run -tags dev .

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ deps:
 	@yay -S mkcert python-brotli python-fonttools
 
 dev:
-	@gcc -Wall -Werror -Wextra -o run-lang run-lang.c
 	@docker-compose rm -f
 	@docker-compose up --build
 

--- a/hole/hole.go
+++ b/hole/hole.go
@@ -62,7 +62,7 @@ func Play(ctx context.Context, holeID, langID, code string) (score Scorecard) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "../../run-lang")
+	cmd := exec.CommandContext(ctx, "/usr/bin/run-lang")
 	cmd.Dir = "langs/" + langID
 	cmd.Stderr = &stderr
 	cmd.Stdin = strings.NewReader(code)


### PR DESCRIPTION
This helps to avoid issues where the environment inside of the container doesn't match the environment outside of the container.

I'm not totally sure about the Dockerfile changes but I tested the Dockerfile.dev changes.