### PR TITLE
Disable CodeMirror smartIndent.

### DIFF
--- a/assets/hole.js
+++ b/assets/hole.js
@@ -38,7 +38,7 @@ onload = () => {
     // Lock the editor's height in so we scroll.
     editor.style.height = `${editor.offsetHeight}px`;
 
-    const cm = new CodeMirror(editor, {autofocus: true, lineNumbers: true, lineWrapping: true});
+    const cm = new CodeMirror(editor, {autofocus: true, lineNumbers: true, lineWrapping: true, smartIndent: false});
 
     cm.on('change', () => {
         const val = cm.getValue();


### PR DESCRIPTION
It works for Go and should work for the rest of the languages too.