### PR TITLE
Fortran: remove the line length limit.

### DIFF
--- a/langs/fortran/fortran
+++ b/langs/fortran/fortran
@@ -2,7 +2,7 @@
 
 export PATH
 cat - > /tmp/code.f90
-/fortran/bin/gfortran -fbackslash /tmp/code.f90 -o /tmp/code
+/fortran/bin/gfortran -fbackslash -ffree-line-length-0 /tmp/code.f90 -o /tmp/code
 rm /tmp/code.f90
 shift
 /tmp/code "$@"


### PR DESCRIPTION
It's too annoying to have to reformat everything to satisfy the 132 char default line length when making changes.