### PR TITLE
codemirror: Use MIME types for all languages for easier maintenance.

### DIFF
--- a/assets/hole.js
+++ b/assets/hole.js
@@ -58,11 +58,7 @@ onload = () => {
         if (!langs.find(l => l.id == lang))
             location.hash = lang = 'python';
 
-        if (lang == 'c' || lang == 'java')
-            cm.setOption('mode', {name: 'text/x-' + lang, startOpen: true});
-        else
-            cm.setOption('mode', {name: lang, startOpen: true});
-
+        cm.setOption('mode', {name: 'text/x-' + lang, startOpen: true});
         cm.setValue(lang in solutions ? solutions[lang] : '');
 
         localStorage.setItem('lang', location.hash = lang);

--- a/assets/includes/vendor/codemirror-bash.js
+++ b/assets/includes/vendor/codemirror-bash.js
@@ -133,3 +133,5 @@ CodeMirror.defineMode('bash', function() {
     fold: "brace"
   };
 });
+
+CodeMirror.defineMIME('text/x-bash', 'bash');

--- a/assets/includes/vendor/codemirror-brainfuck.js
+++ b/assets/includes/vendor/codemirror-brainfuck.js
@@ -73,3 +73,5 @@
       }
     };
   });
+
+CodeMirror.defineMIME("text/x-brainfuck", "brainfuck");

--- a/assets/includes/vendor/codemirror-fortran.js
+++ b/assets/includes/vendor/codemirror-fortran.js
@@ -172,3 +172,5 @@ CodeMirror.defineMode("fortran", function() {
     }
   };
 });
+
+CodeMirror.defineMIME("text/x-fortran", "fortran");

--- a/assets/includes/vendor/codemirror-go.js
+++ b/assets/includes/vendor/codemirror-go.js
@@ -171,3 +171,5 @@ CodeMirror.defineMode("go", function(config) {
     lineComment: "//"
   };
 });
+
+CodeMirror.defineMIME("text/x-go", "go");

--- a/assets/includes/vendor/codemirror-haskell.js
+++ b/assets/includes/vendor/codemirror-haskell.js
@@ -252,3 +252,5 @@ CodeMirror.defineMode("haskell", function(_config, modeConfig) {
   };
 
 });
+
+CodeMirror.defineMIME("text/x-haskell", "haskell");

--- a/assets/includes/vendor/codemirror-javascript.js
+++ b/assets/includes/vendor/codemirror-javascript.js
@@ -1,11 +1,6 @@
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: https://codemirror.net/LICENSE
 
-(function(mod) {
-    mod(CodeMirror);
-})(function(CodeMirror) {
-"use strict";
-
 CodeMirror.defineMode("javascript", function(config, parserConfig) {
   var indentUnit = config.indentUnit;
   var statementIndent = parserConfig.statementIndent;
@@ -910,5 +905,4 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
 });
 
 CodeMirror.registerHelper("wordChars", "javascript", /[\w$]/);
-
-});
+CodeMirror.defineMIME("text/x-javascript", "javascript");

--- a/assets/includes/vendor/codemirror-julia.js
+++ b/assets/includes/vendor/codemirror-julia.js
@@ -1,11 +1,6 @@
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: https://codemirror.net/LICENSE
 
-(function(mod) {
-    mod(CodeMirror);
-})(function(CodeMirror) {
-"use strict";
-
 CodeMirror.defineMode("julia", function(config, parserConf) {
   function wordRegexp(words, end) {
     if (typeof end === "undefined") { end = "\\b"; }
@@ -413,4 +408,5 @@ CodeMirror.defineMode("julia", function(config, parserConf) {
   };
   return external;
 });
-});
+
+CodeMirror.defineMIME("text/x-julia", "julia");

--- a/assets/includes/vendor/codemirror-lisp.js
+++ b/assets/includes/vendor/codemirror-lisp.js
@@ -1,11 +1,6 @@
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: https://codemirror.net/LICENSE
 
-(function(mod) {
-    mod(CodeMirror);
-})(function(CodeMirror) {
-"use strict";
-
 CodeMirror.defineMode("lisp", function (config) {
   var specialForm = /^(block|let*|return-from|catch|load-time-value|setq|eval-when|locally|symbol-macrolet|flet|macrolet|tagbody|function|multiple-value-call|the|go|multiple-value-prog1|throw|if|progn|unwind-protect|labels|progv|let|quote)$/;
   var assumeBody = /^with|^def|^do|^prog|case$|^cond$|bind$|when$|unless$/;
@@ -113,4 +108,5 @@ CodeMirror.defineMode("lisp", function (config) {
     blockCommentEnd: "|#"
   };
 });
-});
+
+CodeMirror.defineMIME("text/x-lisp", "lisp");

--- a/assets/includes/vendor/codemirror-lua.js
+++ b/assets/includes/vendor/codemirror-lua.js
@@ -5,11 +5,6 @@
 // CodeMirror 1 mode.
 // highlights keywords, strings, comments (no leveling supported! ("[==[")), tokens, basic indenting
 
-(function(mod) {
-    mod(CodeMirror);
-})(function(CodeMirror) {
-"use strict";
-
 CodeMirror.defineMode("lua", function(config, parserConfig) {
   var indentUnit = config.indentUnit;
 
@@ -148,4 +143,5 @@ CodeMirror.defineMode("lua", function(config, parserConfig) {
     blockCommentEnd: "]]"
   };
 });
-});
+
+CodeMirror.defineMIME("text/x-lua", "lua");

--- a/assets/includes/vendor/codemirror-nim.js
+++ b/assets/includes/vendor/codemirror-nim.js
@@ -370,3 +370,5 @@ CodeMirror.defineMode("nim", function(conf, parserConf) {
 
   return external;
 });
+
+CodeMirror.defineMIME("text/x-nim", "nim");

--- a/assets/includes/vendor/codemirror-perl.js
+++ b/assets/includes/vendor/codemirror-perl.js
@@ -793,6 +793,8 @@ CodeMirror.defineMode("perl",function(){
 
 CodeMirror.registerHelper("wordChars", "perl", /[\w$]/);
 
+CodeMirror.defineMIME("text/x-perl", "perl");
+
 // it's like "peek", but need for look-ahead or look-behind if index < 0
 function look(stream, c){
   return stream.string.charAt(stream.pos+(c||0));

--- a/assets/includes/vendor/codemirror-php.js
+++ b/assets/includes/vendor/codemirror-php.js
@@ -222,4 +222,6 @@
       innerMode: function(state) { return {state: state.curState, mode: state.curMode}; }
     };
   }, "htmlmixed", "clike");
+
+  CodeMirror.defineMIME("text/x-php", phpConfig);
 });

--- a/assets/includes/vendor/codemirror-python.js
+++ b/assets/includes/vendor/codemirror-python.js
@@ -379,4 +379,6 @@
     };
     return external;
   });
+
+  CodeMirror.defineMIME("text/x-python", "python");
 });

--- a/assets/includes/vendor/codemirror-raku.js
+++ b/assets/includes/vendor/codemirror-raku.js
@@ -690,3 +690,5 @@ CodeMirror.StringStream.prototype.eatSuffix=function(c){
 		this.pos=y;
 	else
 		this.pos=x;};
+
+CodeMirror.defineMIME("text/x-raku", "raku");

--- a/assets/includes/vendor/codemirror-ruby.js
+++ b/assets/includes/vendor/codemirror-ruby.js
@@ -1,11 +1,6 @@
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: https://codemirror.net/LICENSE
 
-(function(mod) {
-    mod(CodeMirror);
-})(function(CodeMirror) {
-"use strict";
-
 CodeMirror.defineMode("ruby", function(config) {
   function wordObj(words) {
     var o = {};
@@ -287,4 +282,5 @@ CodeMirror.defineMode("ruby", function(config) {
     fold: "indent"
   };
 });
-});
+
+CodeMirror.defineMIME("text/x-ruby", "ruby");

--- a/assets/includes/vendor/codemirror-rust.js
+++ b/assets/includes/vendor/codemirror-rust.js
@@ -55,3 +55,5 @@ CodeMirror.defineSimpleMode("rust",{
     fold: "brace"
   }
 });
+
+CodeMirror.defineMIME("text/x-rust", "rust");

--- a/assets/includes/vendor/codemirror-swift.js
+++ b/assets/includes/vendor/codemirror-swift.js
@@ -213,4 +213,6 @@
       closeBrackets: "()[]{}''\"\"``"
     }
   })
+
+  CodeMirror.defineMIME("text/x-swift", "swift")
 });


### PR DESCRIPTION
+ This removes special case code in hole.js and makes it easier to add new languages.
+ Also remove some unnecessary code in codemirror files.