### PR TITLE
Update monospace font families #191.

### DIFF
--- a/assets/hole.css
+++ b/assets/hole.css
@@ -16,11 +16,15 @@ aside {
     position: relative;
 }
 
+pre {
+    font-family: emoji, 'SFMono-Regular', Menlo, Consolas, 'Liberation Mono', Courier, monospace;
+}
+
 aside > div {
     background: var(--background);
     border: 1px solid var(--color);
     border-left: 0;
-    font-family: emoji, 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+    font-family: emoji, 'SFMono-Regular', Menlo, Consolas, 'Liberation Mono', Courier, monospace;
     height: 140px;
     overflow: auto;
     padding: 5px;
@@ -45,7 +49,7 @@ h3 {
 #arg span {
     background: #eee;
     border-radius: 10px;
-    font-family: emoji, 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+    font-family: emoji, 'SFMono-Regular', Menlo, Consolas, 'Liberation Mono', Courier, monospace;
     line-height: 30px;
     padding: 3px 7px;
     white-space: pre;

--- a/assets/includes/vendor/codemirror.css
+++ b/assets/includes/vendor/codemirror.css
@@ -2,7 +2,7 @@
 
 .CodeMirror {
   /* Set height, width, borders, and global font properties here */
-  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  font-family: 'SFMono-Regular', Menlo, Consolas, 'Liberation Mono', Courier, monospace;
   height: 100%;
 }
 


### PR DESCRIPTION
This worked best for me on the following, with default browser settings:
macOS Firefox/Chrome
Windows Firefox/Chrome
Linux Firefox
iOS Safari