### PR TITLE
Allow matrix SVGs to be slightly wider.

### DIFF
--- a/assets/common.css
+++ b/assets/common.css
@@ -406,7 +406,7 @@ thead th {
 
 #matrix svg {
     height: 1.5rem;
-    width: 1.5rem;
+    width: 2.0rem;
 }
 
 #matrix a svg {


### PR DESCRIPTION
This improves the apperance of SVGs which are wider than they are tall, including Go, Haskell, Nim, Perl, PHP, Raku, and Swift.

Here are some before/after images (note that they include placeholders for C# and F#).
## 1
<img width="1255" alt="Screen Shot 2020-05-03 at 12 30 53 PM" src="https://user-images.githubusercontent.com/53135437/80920210-4a295b80-8d3c-11ea-81a0-ed0e57d71d0b.png">
<img width="1255" alt="Screen Shot 2020-05-03 at 12 31 08 PM" src="https://user-images.githubusercontent.com/53135437/80920209-47c70180-8d3c-11ea-8af1-f49a1c822294.png">

## 2
![1](https://user-images.githubusercontent.com/53135437/80920403-afca1780-8d3d-11ea-97de-3547a42eb5ed.png)
![2](https://user-images.githubusercontent.com/53135437/80920371-72658a00-8d3d-11ea-9e75-0ac7e0e73323.png)

## 3
<img width="1076" alt="Screen Shot 2020-05-03 at 12 42 15 PM" src="https://user-images.githubusercontent.com/53135437/80920143-de46f300-8d3b-11ea-8a67-24a72a3da1c4.png">
<img width="1076" alt="Screen Shot 2020-05-03 at 12 42 50 PM" src="https://user-images.githubusercontent.com/53135437/80920110-a63fb000-8d3b-11ea-9fba-28bdf21fe718.png">

Edit: added images.