### PR TITLE
Limit solution output to 128 KiB. Fixes #201.

### DIFF
--- a/hole/hole.go
+++ b/hole/hole.go
@@ -116,15 +116,17 @@ func Play(ctx context.Context, holeID, langID, code string) (score Scorecard) {
 		}
 	}
 
+	const maxLength = 128 * 1024 // 128 KiB
+
 	// Trim trailing whitespace.
-	score.Stderr = bytes.TrimRightFunc(stderr.Bytes(), unicode.IsSpace)
+	score.Stderr = bytes.TrimRightFunc(stderr.Next(maxLength), unicode.IsSpace)
 
 	if holeID == "quine" {
-		score.Stdout = stdout.Bytes()
+		score.Stdout = stdout.Next(maxLength)
 	} else {
 		// Trim trailing spaces per line.
 		// FIXME This is all very hacky, but needed for Sierpiński.
-		scanner := bufio.NewScanner(bytes.NewReader(stdout.Bytes()))
+		scanner := bufio.NewScanner(bytes.NewReader(stdout.Next(maxLength)))
 		for scanner.Scan() {
 			score.Stdout = append(
 				score.Stdout, bytes.TrimRightFunc(scanner.Bytes(), unicode.IsSpace)...)

--- a/t/truncate.t
+++ b/t/truncate.t
@@ -1,0 +1,22 @@
+use HTTP::Tiny;
+use JSON::PP;
+use Test2::V0;
+
+my $res = HTTP::Tiny->new->post(
+    'https://code-golf.io/solution',
+    {   content => encode_json {
+            Code => 'say "a" x 1024 and say STDERR "b" x 1024 for 0..128',
+            Hole => 'fizz-buzz',
+            Lang => 'perl',
+        },
+    },
+);
+
+die $res->{content} unless $res->{success};
+
+$res = decode_json $res->{content};
+
+is length $res->{Err}, 128 * 1024, 'Stderr is limited to 128 KiB';
+is length $res->{Out}, 128 * 1024, 'Stdout is limited to 128 KiB';
+
+done_testing;


### PR DESCRIPTION
This prevents poor performance when solutions generate a large amount of output.