### PR TITLE
Poker: Add one more edge case.

### DIFF
--- a/hole/poker.go
+++ b/hole/poker.go
@@ -152,6 +152,7 @@ func poker() (args []string, out string) {
 	// Straight Flush
 	lowCards = rand.Perm(9)
 	lowCards[0] = 0 // Ensure at least one low ace
+	lowCards[1] = 8 // Ensure at least one 9 through king, because it could be mistaken for a royal flush.
 	for _, lowCard := range lowCards[:handCount] {
 		suit := rand.Intn(4)
 		var hand []rune


### PR DESCRIPTION
Add a straight flush from 9 to king. Without this check, a program can usually get away with outputting royal flush if it's a flush containing 10, J, K, Q.