### PR TITLE
PowerShell: Allow implicit output for holes other than Quine.

### DIFF
--- a/assets/hole.js
+++ b/assets/hole.js
@@ -39,8 +39,7 @@ let latestSubmissionID = 0;
 
 onload = () => {
     if (hole != 'quine')
-        for (let info of document.querySelectorAll('.quine'))
-            info.parentNode.removeChild(info);
+        document.querySelectorAll('.quine').forEach(e => e.remove());
 
     // Lock the editor's height in so we scroll.
     editor.style.height = `${editor.offsetHeight}px`;

--- a/assets/hole.js
+++ b/assets/hole.js
@@ -38,6 +38,10 @@ let lang;
 let latestSubmissionID = 0;
 
 onload = () => {
+    if (hole != 'quine')
+        for (let info of document.querySelectorAll('.quine'))
+            info.parentNode.removeChild(info);
+
     // Lock the editor's height in so we scroll.
     editor.style.height = `${editor.offsetHeight}px`;
 

--- a/hole/hole.go
+++ b/hole/hole.go
@@ -95,7 +95,11 @@ func Play(ctx context.Context, holeID, langID, code string) (score Scorecard) {
 	case "julia":
 		cmd.Args = []string{"/usr/bin/run-julia", "/tmp/code.jl"}
 	case "powershell":
-		cmd.Args = []string{"/interpreter/Interpreter", "-"}
+		cmd.Args = []string{"/interpreter/Interpreter"}
+		if holeID == "quine" {
+			// Require explicit output for the Quine hole to prevent trivial solutions.
+			cmd.Args = append(cmd.Args, "--explicit")
+		}
 	case "nim":
 		// Pass a dummy argument to work around a nim bug.
 		// See https://github.com/code-golf/code-golf/issues/136

--- a/t/args.t
+++ b/t/args.t
@@ -100,7 +100,7 @@ php
 while($a = next($argv)) echo "$a\n"
 
 powershell
-$args | Write-Host
+$args
 
 python
 import sys

--- a/views/hole.html
+++ b/views/hole.html
@@ -44,8 +44,8 @@
     <div class="info perl">
         <b>say()</b> is available without any import.
     </div>
-    <div class="info powershell">
-        <b>$args</b> holds ARGV, use <b>Write-Host</b> for output. Ex: 1..10|Write-Host
+    <div class="quine info powershell">
+        Implicit output is disabled for this hole. Use <b>Write-Host</b> for output.
     </div>
     <div class=right id=run>
         ctrl + enter


### PR DESCRIPTION
This feels more natural for PowerShell. See #205.