### PR TITLE
Alert powershell users that write-host is no longer required

### DIFF
--- a/assets/hole.js
+++ b/assets/hole.js
@@ -178,6 +178,13 @@ async function refreshScores() {
                 <img src="//avatars.githubusercontent.com/${s.login}?s=24">${s.login}
             </a>
             <td class=right>${s.strokes.toLocaleString('en')}` : '<tr><td colspan=3>&nbsp;';
+
+        // If the user's solution is from before the powershell change (b79e88ca)
+        if (lang == 'powershell' && hole != 'quine' && s.me && s.submitted < '2020-06-04T19:56:49') {
+            const info = document.querySelector('.info.special');
+            info.innerHTML = '<b>Write-Host</b> is no longer required for output.';
+            info.style.display = 'block';
+        }
     }
 
     table.innerHTML = html;

--- a/routes/scores.go
+++ b/routes/scores.go
@@ -20,7 +20,8 @@ func scoresMini(w http.ResponseWriter, r *http.Request) {
 		           RANK()       OVER (ORDER BY LENGTH(code)),
 		           user_id,
 		           LENGTH(code) strokes,
-		           user_id = $1 me
+		           user_id = $1 me,
+		           submitted
 		      FROM solutions
 		     WHERE hole = $2
 		       AND lang = $3
@@ -29,7 +30,8 @@ func scoresMini(w http.ResponseWriter, r *http.Request) {
 		    SELECT rank,
 		           login,
 		           me,
-		           strokes
+		           strokes,
+		           submitted
 		      FROM leaderboard
 		      JOIN users on user_id = id
 		     WHERE row_number >

--- a/views/hole.html
+++ b/views/hole.html
@@ -47,6 +47,7 @@
     <div class="quine info powershell">
         Implicit output is disabled for this hole. Use <b>Write-Host</b> for output.
     </div>
+    <div class="info special"></div>
     <div class=right id=run>
         ctrl + enter
         <span>or</span>


### PR DESCRIPTION
Shows an info box if the user has a powershell solution from before we enabled implicit output. I'm not able to properly test as a logged in user but it works when i comment out the s.me check