### PR TITLE
PowerShell: Use the same default output formatting behavior as pwsh.exe.

### DIFF
--- a/langs/powershell/Interpreter.cs
+++ b/langs/powershell/Interpreter.cs
@@ -1,75 +1,233 @@
 using System;
-using System.IO;
-using System.Linq;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Management.Automation;
+using System.Management.Automation.Host;
 using System.Management.Automation.Runspaces;
+using System.Security;
 
 class Program
 {
-	static int Main(string[] args)
+    static int Main(string[] args)
+    {
+        if (args.Length > 0 && args[0] == "--version")
+        {
+            var framework = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
+            Console.WriteLine($"PowerShell {PSVersionInfo.PSVersion} on {framework}");
+            return 0;
+        }
+
+        var requireExplicitOutput = args.Length > 0 && args[0] == "--explicit";
+        if (requireExplicitOutput)
+        {
+            args = args[1..];
+        }
+
+        return Run(Console.In.ReadToEnd(), args, requireExplicitOutput);
+    }
+
+    static int Run(string code, string[] args, bool requireExplicitOutput)
+    {
+        var state = InitialSessionState.CreateDefault();
+        var host = new Host();
+        using var runspace = RunspaceFactory.CreateRunspace(host, state);
+        using var powerShell = PowerShell.Create();
+        runspace.Open();
+        powerShell.Runspace = runspace;
+        try
+        {
+            powerShell.AddScript(code);
+            foreach (var arg in args)
+            {
+                powerShell.AddArgument(arg);
+            }
+
+            if (!requireExplicitOutput)
+            {
+                powerShell.Commands.AddCommand("Out-Default");
+            }
+
+            powerShell.Invoke();
+
+            foreach (var item in powerShell.Streams.Error)
+            {
+                Console.Error.WriteLine(item);
+            }
+
+            return host.ExitCode;
+        }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"{e.GetType().FullName}: {e.Message}");
+            return 1;
+        }
+    }
+}
+
+class Host : PSHost
+{
+	public int ExitCode { get; private set; }
+
+	public override CultureInfo CurrentCulture => CultureInfo.CurrentCulture;
+
+	public override CultureInfo CurrentUICulture => CultureInfo.CurrentUICulture;
+
+    public override Guid InstanceId { get; } = Guid.NewGuid();
+
+	public override string Name => "CodeGolfHost";
+
+    public override PSHostUserInterface UI { get; } = new UserInterface();
+
+	public override Version Version => PSVersionInfo.PSVersion;
+
+	public override void EnterNestedPrompt()
 	{
-		if (args.Length > 0 && args[0] == "--version")
-		{
-			string version;
-			using (var powerShell = PowerShell.Create())
-			{
-				version = powerShell.AddScript("(Get-Host).Version.ToString()").Invoke()[0].ToString();
-			}
-			var framework = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
-			Console.WriteLine($"PowerShell {version} on {framework}");
-			return 0;
-		}
-
-		var requireExplicitOutput = args.Length > 0 && args[0] == "--explicit";
-		if (requireExplicitOutput)
-		{
-			args = args[1..];
-		}
-
-		return Run(Console.In.ReadToEnd(), args, requireExplicitOutput);
 	}
 
-	static int Run(string code, string[] args, bool requireExplicitOutput)
+	public override void ExitNestedPrompt()
 	{
-		var state = InitialSessionState.CreateDefault();
-		using (var runspace = RunspaceFactory.CreateRunspace(state))
-		using (var powerShell = PowerShell.Create())
-		{
-			runspace.Open();
-			powerShell.Runspace = runspace;
-			try
-			{
-				powerShell.AddScript(code);
-				foreach (var arg in args)
-				{
-					powerShell.AddArgument(arg);
-				}
-
-				var results = powerShell.Invoke();
-				if (!requireExplicitOutput)
-				{
-					foreach (var item in results)
-					{
-						Console.WriteLine(item);
-					}
-				}
-
-				foreach (var item in powerShell.Streams.Information)
-				{
-					Console.WriteLine(item);
-				}
-				foreach (var item in powerShell.Streams.Error)
-				{
-					Console.Error.WriteLine(item);
-				}
-
-				return 0;
-			}
-			catch (Exception e)
-			{
-				Console.Error.WriteLine($"{e.GetType().FullName}: {e.Message}");
-				return 1;
-			}
-		}
 	}
+
+	public override void NotifyBeginApplication()
+	{
+	}
+
+	public override void NotifyEndApplication()
+	{
+	}
+
+	public override void SetShouldExit(int exitCode)
+	{
+		ExitCode = exitCode;
+	}
+}
+
+class UserInterface : PSHostUserInterface
+{
+    public override PSHostRawUserInterface RawUI { get; } = new RawUserInterface();
+
+    public override Dictionary<string, PSObject> Prompt(string caption, string message, Collection<FieldDescription> descriptions)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override int PromptForChoice(string caption, string message, Collection<ChoiceDescription> choices, int defaultChoice)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override string ReadLine()
+    {
+        throw new NotImplementedException();
+    }
+
+    public override SecureString ReadLineAsSecureString()
+    {
+        throw new NotImplementedException();
+    }
+
+    public override void Write(ConsoleColor foregroundColor, ConsoleColor backgroundColor, string value)
+    {
+        Console.Write(value);
+    }
+
+    public override void Write(string value)
+    {
+        Console.Write(value);
+    }
+
+    public override void WriteDebugLine(string message)
+    {
+        // pwsh.exe doesn't show this by default.
+    }
+
+    public override void WriteErrorLine(string value)
+    {
+        Console.Error.WriteLine(value);
+    }
+
+    public override void WriteLine(string value)
+    {
+        Console.WriteLine(value);
+    }
+
+    public override void WriteProgress(long sourceId, ProgressRecord record)
+    {
+    }
+
+    public override void WriteVerboseLine(string message)
+    {
+        // pwsh.exe doesn't show this by default.
+    }
+
+    public override void WriteWarningLine(string message)
+    {
+        // Match behavior of pwsh.exe
+        Console.WriteLine($"WARNING: {message}");
+    }
+}
+
+class RawUserInterface : PSHostRawUserInterface
+{
+    public override void FlushInputBuffer()
+    {
+    }
+
+    public override BufferCell[,] GetBufferContents(Rectangle rectangle)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override KeyInfo ReadKey(ReadKeyOptions options)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override void ScrollBufferContents(Rectangle source, Coordinates destination, Rectangle clip, BufferCell fill)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override void SetBufferContents(Coordinates origin, BufferCell[,] contents)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override void SetBufferContents(Rectangle rectangle, BufferCell fill)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override ConsoleColor BackgroundColor { get; set; }
+
+    public override Size BufferSize { get; set; } = new Size(1000, 1000);
+
+    public override Coordinates CursorPosition { get; set; }
+
+    public override int CursorSize { get; set; }
+
+    public override ConsoleColor ForegroundColor { get; set; }
+
+    public override bool KeyAvailable => false;
+
+    public override Size MaxPhysicalWindowSize => new Size(1000, 1000);
+
+    public override Size MaxWindowSize => new Size(1000, 1000);
+
+    public override Coordinates WindowPosition { get; set; }
+
+    public override Size WindowSize { get; set; } = new Size(1000, 1000);
+
+    public override string WindowTitle { get; set; } = "";
 }

--- a/views/hole.html
+++ b/views/hole.html
@@ -45,7 +45,7 @@
         <b>say()</b> is available without any import.
     </div>
     <div class="quine info powershell">
-        Implicit output is disabled for this hole. Use <b>Write-Host</b> for output.
+        Implicit output is disabled for this hole. Use <b>Out-Host</b> or <b>Write-Host</b> for output.
     </div>
     <div class=right id=run>
         ctrl + enter


### PR DESCRIPTION
Out-Host is now available for use in Quine in addition to Write-Host.

This fixes an issue identified in the discussion for #220 where the behavior of the PowerShell wrapper didn't match the `pwsh` executable.

Some solutions will need to be invalidated. Hopefully, it won't be a lot and most of them will be from @primo-ppcg, @prplz, and me.

@JRaspass I'm emailing you some code to automatically remove Write-Host when possible, including changing Write-Host to Out-Host for Quine. Ideally, this change should be live on the site before running that code.