### PR TITLE
Update NuGet packages for .NET versions.

### DIFF
--- a/langs/c-sharp/Dockerfile
+++ b/langs/c-sharp/Dockerfile
@@ -1,14 +1,12 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1.300-alpine3.11 as builder
 
+ENV NUGET_VERSION=3.6.0-4.final
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 
 WORKDIR /source
 COPY Compiler.csproj Compiler.cs /source/
 
-# Note: the ReadyToRun optimization process failed for earlier versions
-# of the CSharp package.
-RUN /usr/bin/dotnet add package Microsoft.CodeAnalysis.CSharp -v 3.6.0-3.final
-
+RUN /usr/bin/dotnet add package Microsoft.CodeAnalysis.CSharp -v $NUGET_VERSION
 RUN /usr/bin/dotnet publish --runtime alpine.3.11-x64 -c Release -o /compiler
 
 RUN mkdir /empty

--- a/langs/f-sharp/Compiler.fs
+++ b/langs/f-sharp/Compiler.fs
@@ -52,9 +52,12 @@ let main args =
         fprintfn stderr "Arguments required."
         1
     elif args.[0] = "--version" then
-        let info = File.ReadAllText "/compiler/version.txt"
+        let assembly = Assembly.Load "FSharp.Compiler.Service"
+        let versionType = assembly.GetType "FSharp.Compiler.Features+LanguageVersion"
+        let field = versionType.GetField("latestVersion", BindingFlags.Static ||| BindingFlags.NonPublic)
+        let version = field.GetValue null :?> decimal
         let framework = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription
-        printfn "%s on %s" (info.Trim()) framework
+        printfn "F# %s on %s" (version.ToString "g") framework
         0
     else
         let codeFile = "/tmp/Code.fs"

--- a/langs/f-sharp/Dockerfile
+++ b/langs/f-sharp/Dockerfile
@@ -1,11 +1,12 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1.300-alpine3.11 as builder
 
-ENV SDK_VERSION=3.1.300
+ENV NUGET_VERSION=36.0.1
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 
 WORKDIR /source/
 COPY Compiler.fsproj Compiler.fs /source/
-RUN /usr/bin/dotnet add package FSharp.Compiler.Service -v 35.0.0
+
+RUN /usr/bin/dotnet add package FSharp.Compiler.Service -v $NUGET_VERSION
 RUN /usr/bin/dotnet publish --runtime alpine.3.11-x64 -c Release -o /compiler
 
 # Trim additional things to improve F# compiler startup performance.
@@ -14,8 +15,6 @@ COPY Trimmer.csproj Trimmer.cs ExtraTrimmingList.txt /trimmer/
 RUN /usr/bin/dotnet run
 
 RUN mkdir /empty
-
-RUN /usr/bin/dotnet exec /usr/share/dotnet/sdk/$SDK_VERSION/FSharp/fsc.exe --help | head -1 > /compiler/version.txt
 
 FROM scratch
 COPY --from=0 /bin/sh                  /bin/

--- a/langs/powershell/Dockerfile
+++ b/langs/powershell/Dockerfile
@@ -1,18 +1,17 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1.300-alpine3.11 as builder
 
+ENV NUGET_VERSION=7.0.2
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 
 WORKDIR /source
 COPY Interpreter.csproj Interpreter.cs /source/
 
-ENV VERSION=7.0.1
-
-RUN /usr/bin/dotnet add package System.Management.Automation -v $VERSION
-RUN /usr/bin/dotnet add package Microsoft.PowerShell.Commands.Diagnostics -v $VERSION
-RUN /usr/bin/dotnet add package Microsoft.PowerShell.Commands.Management -v $VERSION
-RUN /usr/bin/dotnet add package Microsoft.PowerShell.Commands.Utility -v $VERSION
-RUN /usr/bin/dotnet add package Microsoft.PowerShell.ConsoleHost -v $VERSION
-RUN /usr/bin/dotnet add package Microsoft.WSMan.Management -v $VERSION
+RUN /usr/bin/dotnet add package System.Management.Automation -v $NUGET_VERSION
+RUN /usr/bin/dotnet add package Microsoft.PowerShell.Commands.Diagnostics -v $NUGET_VERSION
+RUN /usr/bin/dotnet add package Microsoft.PowerShell.Commands.Management -v $NUGET_VERSION
+RUN /usr/bin/dotnet add package Microsoft.PowerShell.Commands.Utility -v $NUGET_VERSION
+RUN /usr/bin/dotnet add package Microsoft.PowerShell.ConsoleHost -v $NUGET_VERSION
+RUN /usr/bin/dotnet add package Microsoft.WSMan.Management -v $NUGET_VERSION
 
 RUN /usr/bin/dotnet publish --runtime alpine.3.11-x64 -c Release -o /interpreter
 

--- a/latest-langs
+++ b/latest-langs
@@ -6,6 +6,10 @@ use Cro::HTTP::Client;
 # https://hub.docker.com/_/microsoft-dotnet-core-sdk/
 # https://mcr.microsoft.com/v2/dotnet/core/sdk/tags/list
 # The version string from code-golf contains the SDK version.
+# Check these pages for NuGet versions:
+# https://www.nuget.org/packages/FSharp.Compiler.Service/
+# https://www.nuget.org/packages/System.Management.Automation/
+# https://www.nuget.org/packages/Microsoft.CodeAnalysis.CSharp/
 
 constant @langs = (
     'C',

--- a/routes/versions.go
+++ b/routes/versions.go
@@ -6,7 +6,7 @@ const versionTable = "" +
 	"<tr><th class=c>C<td>Tiny C Compiler 0.9.27<td class=wide><a href=//bellard.org/tcc/>website</a>" +
 	"<tr><th class=c-sharp>C#<td>C# 8.0 on .NET Core 3.1.4<td class=wide><a href=//docs.microsoft.com/dotnet/csharp/>website</a>" +
 	"<tr><th class=fortran>Fortran<td>9.3.0<td class=wide><a href=//gcc.gnu.org/fortran/>website</a>" +
-	"<tr><th class=f-sharp>F#<td>F# Compiler 10.9.1.0 for F# 4.7 on .NET Core 3.1.4<td class=wide><a href=//fsharp.org/>website</a>" +
+	"<tr><th class=f-sharp>F#<td>F# 4.7 on .NET Core 3.1.4<td class=wide><a href=//fsharp.org/>website</a>" +
 	"<tr><th class=go>Go<td>1.14.4<td class=wide><a href=//golang.org>website</a>" +
 	"<tr><th class=haskell>Haskell<td>Glasgow Haskell Compiler 8.8.3<td class=wide><a href=//www.haskell.org/ghc/>website</a>" +
 	"<tr><th class=j>J<td>8.07.07<td class=wide><a href=//www.jsoftware.com>website</a>" +
@@ -18,7 +18,7 @@ const versionTable = "" +
 	"<tr><th class=nim>Nim<td>1.2.0<td class=wide><a href=//nim-lang.org>website</a>" +
 	"<tr><th class=perl>Perl<td>5.30.3<td class=wide><a href=//www.perl.org>website</a>" +
 	"<tr><th class=php>PHP<td>7.4.6<td class=wide><a href=//secure.php.net>website</a>" +
-	"<tr><th class=powershell>PowerShell<td>PowerShell 7.0.1 on .NET Core 3.1.4<td class=wide><a href=//docs.microsoft.com/powershell/scripting/overview>website</a>" +
+	"<tr><th class=powershell>PowerShell<td>PowerShell 7.0.2 on .NET Core 3.1.4<td class=wide><a href=//docs.microsoft.com/powershell/scripting/overview>website</a>" +
 	"<tr><th class=python>Python<td>3.8.3<td class=wide><a href=//www.python.org>website</a>" +
 	"<tr><th class=raku>Raku<td>Rakudo 2020.05.1 on MoarVM 2020.05 implementing Raku 6.d<td class=wide><a href=//raku.org>website</a>" +
 	"<tr><th class=ruby>Ruby<td>2.7.1<td class=wide><a href=//www.ruby-lang.org>website</a>" +


### PR DESCRIPTION
F#: Get language version from the compiler library. This is more accurate than using the version from the compiler executable.