### PR TITLE
CodeMirror: set indentUnit to 1 to prevent red error text.

### DIFF
--- a/assets/hole.js
+++ b/assets/hole.js
@@ -44,7 +44,7 @@ onload = () => {
     // Lock the editor's height in so we scroll.
     editor.style.height = `${editor.offsetHeight}px`;
 
-    const cm = new CodeMirror(editor, {autofocus: true, lineNumbers: true, lineWrapping: true, smartIndent: false});
+    const cm = new CodeMirror(editor, {autofocus: true, lineNumbers: true, lineWrapping: true, smartIndent: false, indentUnit: 1});
 
     cm.on('change', () => {
         const code = cm.getValue();


### PR DESCRIPTION
Setting indentUnit to 1, instead of the default 2, prevents an issue for Python code, where lines that are indented with one space, which is the minimum required for certain constructs, will have their first token highlighted in red, indicating an error.

Also add .go/ to .gitignore. I'm not sure exactly where these files are coming from. They might be from Visual Studio Code.