### PR TITLE
First pass implementation of dual scoring system (Chars and Bytes)

### DIFF
--- a/routes/golfer_holes.go
+++ b/routes/golfer_holes.go
@@ -27,6 +27,7 @@ func GolferHoles(w http.ResponseWriter, r *http.Request) {
 		    FROM solutions
 		    JOIN code ON code_id = id
 		   WHERE NOT failing
+             AND scoring = 'chars'
 		) SELECT hole, lang, rank
 		    FROM matrix
 		   WHERE user_id = $1`,

--- a/routes/recent.go
+++ b/routes/recent.go
@@ -35,6 +35,7 @@ func Recent(w http.ResponseWriter, r *http.Request) {
           JOIN code  ON code_id = code.id
           JOIN users ON user_id = users.id
          WHERE NOT failing
+           AND scoring = 'chars'
            AND $1 IN ('all-langs', lang::text)
      )  SELECT t1.hole,
                t1.lang,

--- a/routes/solution.go
+++ b/routes/solution.go
@@ -68,7 +68,12 @@ func Solution(w http.ResponseWriter, r *http.Request) {
 		// Update the code if it's the same length or less, but only update
 		// the submitted time if the solution is shorter. This avoids a user
 		// moving down the leaderboard by matching their personal best.
-		for _, scoring := range []string{"bytes", "chars"} {
+		scoringList := []string{"chars"}
+		if session.Beta(r) {
+			scoringList = append(scoringList, "bytes")
+		}
+
+		for _, scoring := range scoringList {
 			if _, err := db.Exec(
 				`WITH new_code AS (
 				    SELECT id, `+scoring+` FROM code WHERE code = $1

--- a/routes/solution.go
+++ b/routes/solution.go
@@ -68,30 +68,32 @@ func Solution(w http.ResponseWriter, r *http.Request) {
 		// Update the code if it's the same length or less, but only update
 		// the submitted time if the solution is shorter. This avoids a user
 		// moving down the leaderboard by matching their personal best.
-		if _, err := db.Exec(
-			`WITH new_code AS (
-			    SELECT id, chars FROM code WHERE code = $1
-			) INSERT INTO solutions (code_id, user_id, hole, lang, scoring)
-			       SELECT id, $2, $3, $4, 'chars' FROM new_code
-			  ON CONFLICT ON CONSTRAINT solutions_pkey
-			DO UPDATE SET failing = false,
-			            submitted = CASE
-			                WHEN solutions.failing
-			                  OR (SELECT chars FROM new_code)
-			                   < (SELECT chars FROM code WHERE id = solutions.code_id)
-			                THEN excluded.submitted
-			                ELSE solutions.submitted
-			            END,
-			              code_id = CASE
-			                WHEN solutions.failing
-			                  OR (SELECT chars FROM new_code)
-			                  <= (SELECT chars FROM code WHERE id = solutions.code_id)
-			                THEN excluded.code_id
-			                ELSE solutions.code_id
-			            END`,
-			in.Code, userID, in.Hole, in.Lang,
-		); err != nil {
-			panic(err)
+		for _, scoring := range []string{"bytes", "chars"} {
+			if _, err := db.Exec(
+				`WITH new_code AS (
+				    SELECT id, `+scoring+` FROM code WHERE code = $1
+				) INSERT INTO solutions (code_id, user_id, hole, lang, scoring)
+				       SELECT id, $2, $3, $4, $5 FROM new_code
+				  ON CONFLICT ON CONSTRAINT solutions_pkey
+				DO UPDATE SET failing = false,
+				            submitted = CASE
+				                WHEN solutions.failing
+				                  OR (SELECT `+scoring+` FROM new_code)
+				                   < (SELECT `+scoring+` FROM code WHERE id = solutions.code_id)
+				                THEN excluded.submitted
+				                ELSE solutions.submitted
+				            END,
+				              code_id = CASE
+				                WHEN solutions.failing
+				                  OR (SELECT `+scoring+` FROM new_code)
+				                  <= (SELECT `+scoring+` FROM code WHERE id = solutions.code_id)
+				                THEN excluded.code_id
+				                ELSE solutions.code_id
+				            END`,
+				in.Code, userID, in.Hole, in.Lang, scoring,
+			); err != nil {
+				panic(err)
+			}
 		}
 
 		awardTrophy(db, userID, "hello-world")

--- a/views/css/base.css
+++ b/views/css/base.css
@@ -239,6 +239,8 @@ thead th {
     grid-gap: 1rem;
 }
 
+.inactive { opacity: 0.6 }
+
 /* TODO Need a dark version */
 .me { background: var(--blue) !important }
 

--- a/views/css/hole.css
+++ b/views/css/hole.css
@@ -44,7 +44,20 @@ h3 {
     margin-top: 10px;
 }
 
+.scoringModePicker {
+    font-weight: normal;
+    padding: 0 .5rem;
+}
+
+.scoringModePicker:hover,
+.scoringModePicker:not([href]) {
+    background: var(--color);
+    color: var(--background);
+}
+
 .text-red { color: var(--red) }
+
+#all { float: right }
 
 #arg, #err { display: none }
 
@@ -92,8 +105,6 @@ h3 {
 #header span { margin: 0 .5rem }
 
 #header .purple { margin: 0 1rem }
-
-#hole thead a { float: right }
 
 #hole .scores td { border-left: 0 }
 

--- a/views/hole.html
+++ b/views/hole.html
@@ -77,5 +77,6 @@
     </div>
 </main>
 
-<script id=langs     type=application/json>{{ .Data.Langs     }}</script>
-<script id=solutions type=application/json>{{ .Data.Solutions }}</script>
+<script id=langs        type=application/json>{{ .Data.Langs        }}</script>
+<script id=solutions    type=application/json>{{ .Data.Solutions    }}</script>
+<script id=scoringModes type=application/json>{{ .Data.ScoringModes }}</script>

--- a/views/hole.html
+++ b/views/hole.html
@@ -35,6 +35,7 @@
         <div class=grid>{{ .Data.Hole.Preamble }}</div>
     </details>
     <div class=nav id=picker></div>
+    <div class=nav id=slotPicker></div>
     <div id=wrapper>
         <div id=chars>0 characters</div>
         <table class="scores wide">

--- a/views/js/hole.js
+++ b/views/js/hole.js
@@ -1,15 +1,29 @@
-const chars     = document.querySelector('#chars');
-const details   = document.querySelector('#details');
-const editor    = document.querySelector('#editor');
-const hole      = decodeURI(location.pathname.slice(1));
-const langs     = JSON.parse(document.querySelector('#langs').innerText);
-const picker    = document.querySelector('#picker');
-const solutions = JSON.parse(document.querySelector('#solutions').innerText);
-const status    = document.querySelector('#status');
-const table     = document.querySelector('.scores');
+const chars      = document.querySelector('#chars');
+const details    = document.querySelector('#details');
+const editor     = document.querySelector('#editor');
+const hole       = decodeURI(location.pathname.slice(1));
+const langs      = JSON.parse(document.querySelector('#langs').innerText);
+const picker     = document.querySelector('#picker');
+const slotPicker = document.querySelector('#slotPicker');
+const solutions  = JSON.parse(document.querySelector('#solutions').innerText);
+const status     = document.querySelector('#status');
+const table      = document.querySelector('.scores');
+
+const scoringModes = ['Chars', 'Bytes'];
 
 let lang;
+let slot = localStorage.getItem('slot') ? parseInt(localStorage.getItem('slot')) : 0;
+let scoringMode = localStorage.getItem('scoringMode') ? parseInt(localStorage.getItem('scoringMode')) : 0;
+let setCodeForLangAndSlot;
 let latestSubmissionID = 0;
+
+function setSlot(value) {
+    localStorage.setItem('slot', slot = value);
+}
+
+function setScoringMode(value) {
+    localStorage.setItem('scoringMode', scoringMode = value);
+}
 
 onload = () => {
     // Lock the editor's height in so we scroll.
@@ -20,13 +34,15 @@ onload = () => {
     cm.on('change', () => {
         const code = cm.getValue();
         const len = strlen(code);
-
+        const bytes = utf8ByteCount(code);
         chars.innerText = `${len.toLocaleString('en')} character${len - 1 ? 's' : ''}`;
+        if (len != bytes)
+            chars.innerText += `, ${bytes.toLocaleString('en')} byte${bytes - 1 ? 's' : ''}`;
 
         // Avoid future conflicts by only storing code locally that's different from the server's copy.
-        const serverCode = lang in solutions ? solutions[lang] : '';
+        const serverCode = lang in solutions[slot] ? solutions[slot][lang] : '';
 
-        const key = 'code_' + hole + '_' + lang;
+        const key = `code_${hole}_${lang}_${slot}`;
         if (code && code != serverCode)
             localStorage.setItem(key, code);
         else
@@ -36,22 +52,12 @@ onload = () => {
     details.ontoggle = () =>
         document.cookie = 'hide-details=' + (details.open ? ';Max-Age=0' : '');
 
-    (onhashchange = () => {
-        lang = location.hash.slice(1) || localStorage.getItem('lang');
-
-        // Kick 'em to Python if we don't know the chosen language.
-        if (!langs.find(l => l.id == lang))
-            lang = 'python';
-
-        const code = lang in solutions ? solutions[lang] : '';
-        const previousCode = localStorage.getItem('code_' + hole + '_' + lang);
+    setCodeForLangAndSlot = () => {
+        const code = lang in solutions[slot] ? solutions[slot][lang] : '';
+        const previousCode = localStorage.getItem(`code_${hole}_${lang}_${slot}`);
 
         cm.setOption('mode', {name: 'text/x-' + lang, startOpen: true});
         cm.setValue(code);
-
-        localStorage.setItem('lang', lang);
-
-        history.replaceState(null, '', '#' + lang);
 
         refreshScores();
 
@@ -61,6 +67,20 @@ onload = () => {
 
         for (let info of document.querySelectorAll('.info'))
             info.style.display = info.classList.contains(lang) ? 'block' : '';
+    };
+
+    (onhashchange = () => {
+        lang = location.hash.slice(1) || localStorage.getItem('lang');
+
+        // Kick 'em to Python if we don't know the chosen language.
+        if (!langs.find(l => l.id == lang))
+            lang = 'python';
+
+        localStorage.setItem('lang', lang);
+
+        history.replaceState(null, '', '#' + lang);
+
+        setCodeForLangAndSlot();
     })();
 
     const submit = document.querySelector('#run a').onclick = async () => {
@@ -84,14 +104,21 @@ onload = () => {
         if (submissionID != latestSubmissionID)
             return;
 
-        if (data.Pass && (!(codeLang in solutions) || strlen(code) <= strlen(solutions[codeLang]))) {
-            solutions[codeLang] = code;
+        for (let i = 0; i < 2; i++) {
+            const lengthFunc = i ? utf8ByteCount : strlen;
+            if (data.Pass && (!(codeLang in solutions[i]) || lengthFunc(code) <= lengthFunc(solutions[i][codeLang])))
+                solutions[i][codeLang] = code;
 
             // Don't need to keep solution in local storage because it's stored on the site.
             // This prevents conflicts when the solution is improved on another browser.
             if (data.LoggedIn)
-                localStorage.removeItem('code_' + hole + '_' + codeLang);
+                localStorage.removeItem(`code_${hole}_${codeLang}_${i}`);
         }
+
+        // Automatically switch to the slot whose code matches the current code after a new solution is submitted.
+        // Don't change scoringMode. refreshScores will update the slot picker.
+        if (data.Pass && solutions[slot][lang] != code && solutions[1 - slot][lang] == code)
+            setSlot(1 - slot);
 
         document.querySelector('h2').innerText
             = data.Pass ? 'Pass 😀' : 'Fail ☹️';
@@ -142,17 +169,49 @@ async function refreshScores() {
     for (const l of langs) {
         let name = l.name;
 
-        if (l.id in solutions)
-            name += ` <sup>${strlen(solutions[l.id]).toLocaleString('en')}</sup>`;
+        if (l.id in solutions[0]) {
+            const chars = strlen(solutions[0][l.id])
+            const bytes = utf8ByteCount(solutions[1][l.id])
+            if (chars != bytes)
+                name += ` <sup>${chars.toLocaleString('en')}/${bytes.toLocaleString('en')}</sup>`;
+            else
+               name += ` <sup>${chars.toLocaleString('en')}</sup>`;
+        }
 
         picker.innerHTML += l.id == lang
             ? `<a>${name}</a>` : `<a href=#${l.id}>${name}</a>`;
     }
 
-    const url    = `/scores/${hole}/${lang}`;
-    const scores = await (await fetch(`${url}/mini`)).json();
+    while (slotPicker.firstChild)
+        slotPicker.removeChild(slotPicker.firstChild);
 
-    let html = `<thead><tr><th colspan=3>Scores<a href=${url}>all</a><tbody>`;
+    // Only show the slot picker when both slots are actually used.
+    if (lang in solutions[0] && lang in solutions[1] && solutions[0][lang] != solutions[1][lang]) {
+        for (let i = 0; i < 2; i++) {
+            name = i == 0 ? 'Fewest Chars' : 'Fewest Bytes';
+
+            if (lang in solutions[i]) {
+                name += ` <sup>${[strlen,utf8ByteCount][i](solutions[i][lang]).toLocaleString('en')}</sup>`;
+            }
+
+            const child = document.createElement('a');
+            child.innerHTML = name;
+            if (i != slot) {
+                child.href = 'javascript:void(0)';
+                child.onclick = () => { setSlot(i); setCodeForLangAndSlot(); };
+            }
+            slotPicker.appendChild(child);
+        }
+    }
+
+    const url    = `/scores/${hole}/${lang}`;
+    const scores = await (await fetch(`${url}/${scoringMode ? 'minibytes' : 'mini'}`)).json();
+
+    let html = `<thead><tr><th colspan=4>
+        <a class=modePicker id=Chars>Chars</a>
+        <a class=modePicker id=Bytes>Bytes</a>
+        <a href=${url} id=all>all</a><tbody>
+        <tbody>`;
 
     // Ordinal from https://codegolf.stackexchange.com/a/119563
     for (let i = 0; i < 7; i++) {
@@ -163,10 +222,29 @@ async function refreshScores() {
             <td><a href=/golfers/${s.login}>
                 <img src="//avatars.githubusercontent.com/${s.login}?s=24">${s.login}
             </a>
-            <td class=right>${s.strokes.toLocaleString('en')}` : '<tr><td colspan=3>&nbsp;';
+            <td class=right><span${scoringMode != 0 ? ' class=inactive' : ''}>${s.chars.toLocaleString('en')}</span>
+            <td class=right><span${scoringMode != 1 ? ' class=inactive' : ''}>${s.bytes.toLocaleString('en')}</span>` : '<tr><td colspan=4>&nbsp;';
     }
 
     table.innerHTML = html;
+
+    const otherScoringMode = 1 - scoringMode;
+    const switchMode = table.querySelector(`#${scoringModes[otherScoringMode]}`);
+    switchMode.href = 'javascript:void(0)';
+    switchMode.onclick = () => { setScoringMode(otherScoringMode); refreshScores(); };
+}
+
+function bytesForCodePoint(codePoint) {
+    if ((codePoint & 0xFFFFFF80) == 0) {
+        return 1;
+    }
+    if ((codePoint & 0xFFFFF800) == 0) {
+        return 2;
+    }
+    else if ((codePoint & 0xFFFF0000) == 0) {
+        return 3;
+    }
+    return 4;
 }
 
 // Adapted from https://mths.be/punycode
@@ -195,4 +273,32 @@ function strlen(str) {
     }
 
     return len;
+}
+
+// Adapted from https://mths.be/punycode
+function utf8ByteCount(str) {
+    let i = 0, byteCount = 0;
+
+    while (i < str.length) {
+        const value = str.charCodeAt(i++);
+
+        if (value >= 0xD800 && value <= 0xDBFF && i < str.length) {
+            // It's a high surrogate, and there is a next character.
+            const extra = str.charCodeAt(i++);
+
+            // Low surrogate.
+            if ((extra & 0xFC00) == 0xDC00) {
+                byteCount += bytesForCodePoint(((value & 0x3FF) << 10) + (extra & 0x3FF) + 0x10000);
+            } else {
+                // It's an unmatched surrogate; only append this code unit, in case the
+                // next code unit is the high surrogate of a surrogate pair.
+                byteCount += bytesForCodePoint(value);
+                i--;
+            }
+        } else {
+            byteCount += bytesForCodePoint(value);
+        }
+    }
+
+    return byteCount;
 }

--- a/views/js/hole.js
+++ b/views/js/hole.js
@@ -222,7 +222,7 @@ async function refreshScores() {
     if (beta) {
         html += `<thead><tr><th colspan=4>`;
         for (let i = 0; i < 2; i++)
-            html += `<a class=scoringModePicker id=${scoringModes[i]}>${scoringModes[i]}</a>`;
+            html += `<a class="scoringModePicker${scoringMode != i ? ' inactive' : ''}" id=${scoringModes[i]}>${scoringModes[i]}</a>`;
     }
     else
         html += `<th colspan=3>Scores`;


### PR DESCRIPTION
# Summary
This is a prototype of a dual-scoring-mode system — chars (Unicode codepoints) and bytes (UTF-8 encoded bytes) — designed to explorer the UX implications. This is not complete and it's not ready to merge. I would like to get as much feedback as possible on the design and the open questions.

Why can't we just pick one scoring metric and drop the other? Because both of the scoring metrics are fun to minimize. We already have chars as a scoring metric. Some of the best solutions according to that metric would be very poor when evaluated against the other metric (bytes). If we simply switched the metric, it would be unfair to everyone who has already submitted a solution. Dropping the chars scoring metric is not a viable option. Lately, an increasing number of users have stated that they would prefer the solutions to be evaluated in terms of bytes, rather than chars. There are various reasons for this. It's a common scoring metric for code golf in general. Users have noticed that others use the higher Unicode codepoints to encode data and these users may not be interested in learning enough about character encodings to do the same or they simply may not have enough time available to do so. Before I did code golf, I found character encodings to be a very boring subject, but now I know a lot about it, which can't be a bad thing. It can feel like two different games though — one to find the best solution for a hole and the other to find the best encoding method for a language. It's not quite that simple, but the perception is real and not all users want to play both games, which is fair.

There are some cases where I'm in the first few ranks on a hole/language leaderboard because I've taken advantage of the scoring metric by using higher (than ASCII) codepoints. Knowing how long my solution was before I encoded it and suspecting that many of the solutions are not similarly encoded, I believe my best solution would rank significantly worse if bytes were the metric used on the site. Assuming that the majority of users will not try to take advantage of the chars scoring metric, this means that if I want to compete more directly with most users, I have to do it using bytes as a scoring metric. This would be fun for me, because I like code golf. It would be an opportunity for me to improve my solutions further. I currently don't have that opportunity, because chars is the only scoring metric. If I want more competition — more scores that are close to mine that I feel are attainable — I can only wait and hope that more users exploit that. Because we can't just drop chars as the scoring metric and switch to bytes, I decided to explore the UX implications of having both scoring metrics.

# Design Notes
This design adds a slot picker and a scoring mode picker.

(Scoring) Mode Picker: Chars / Bytes
Slot Picker: Fewest Chars / Fewest Bytes

This change introduces two scoring metrics, Chars (Unicode codepoints) and Bytes (UTF-8 encoding). This is referred to as the scoring mode, or just the mode.

I propose keeping the two sets of leaderboards for the two metrics completely separate. I don't think we should try to have an overall rank that combines the ranks from the two scoring metrics. We should just allow them to be separate, because it makes the scoring clearer and it has no negative effect on the overall scores of users who have already tried to optimize the current scoring metric and who may not come back to optimize the new metric (bytes).

Users may need up to two slots per hole/language to store two different solutions — one with the fewest chars and one with the fewest bytes. When visible, the slot picker shows the two slots as "Fewest Chars" and "Fewest Bytes". Most users will never need both slots and will not see the slot picker. Their solutions for each slot would be the same. In order to reduce confusion, I have hidden the slot picker by default. It will appear when a user has entered two different solutions for a hole where one has the minimum chars and the other has the minimum bytes. The slot picker has an effect similar to the language picker, in that it can change the solution code displayed in the code editor. Because it has a similar effect, I felt that its visual elements should have the same look and visual prominence as the elements of the language picker. This led to a large and bulky design and a desire to hide it from casual users, who don't need it.

There is a scoring mode picker (Chars/Bytes) above the mini-scoreboard next to the code entry text box to sort solutions by Chars or Bytes. Both Char and Byte values are shown in the mini-scoreboard so that the user doesn't have to keep switching back and forth to see them. Chars is always shown on the left and bytes on the right. The inactive score is faded out a bit. Sorting is different for each though. If two users are tied, for both Chars and Bytes, the order in which they are displayed in the mini-scoreboard may be different for each. It's based on the submission timestamp for each slot. The scoring mode picker was designed to be smaller than the slot picker and more out of the way. It's near the mini-scoreboard, because this is where users will see its effect. It doesn't have the effect of changing the code in the code editor, so it can be smaller and less visually prominent than elements which do have this effect. This should reduce confusion for causal users.

## Why add both a slot picker and a scoring mode picker?

Why did I decide to add both a slot picker and a scoring mode picker, rather than one or the other? Because I wanted the slot to change automatically based on the solution a user enters. Regardless of which slot is active, when a user enters a solution that is their best solution for one scoring mode, but not the other, the slot is automatically changed to the one containing the solution that minimizes that metric. The user can switch to the other slot to see their solution that minimizes the other metric. This is shown in an example below.

If we have both a slot picker and a scoring mode picker:
- :+1: We can hide the slot picker from most users, who will not enter two solutions such that each is better than the other according to one of the metrics.
- :+1: We can have a small scoring mode picker whose meaning is obvious to users.
- :+1: We can switch slots automatically when necessary, so that the user doesn't have to think about whether they are trying to achieve the best score in chars or bytes at any one time.
- :-1: There would be two pickers, instead of one.

If we only add a scoring mode picker and linked both the scoring mode and the active slot to it:
- :+1: There would be one picker, instead of two.
- :-1: The scoring mode picker as designed is very small and out of the way, to reduce confusion for casual users. If it caused the solution code to change when you switched it, it would be very confusing. I think that it would need to be larger and more obvious that it could have that kind of effect, which is against the design goal of having it be small, simple, and out of the way.

If we only add a slot picker and linked both the scoring mode and the active slot to it:
- :+1: There would be one picker, instead of two.
- :-1: All users would see the slot picker and it would likely confuse them. I wanted to make the slot picker big and bulky so that it's obvious to the user that multiple slots exist. But most users don't need to know this.
- :-1: I feel the slot needs to change automatically when a user enters a solution that minimizes one metric, but not the other. The user shouldn't have to think about going to the "Fewest Bytes" slot before they enter their solution with the fewest bytes. If we had automatic slot switching and didn't have a scoring mode picker, that would mean that the scoring mode would change automatically as well, because it would be tied to the slot picker. Changing the mode would change the displayed results in the mini-scoreboard and I feel that it would be very confusing for this to change automatically. I think that the user should have to change the scoring mode manually. If we didn't change the slot automatically, it would be more work for users to keep track of which slot they should be in. We could just call the slots something like one and two and not require that the user stored their best solution for chars in a specific slot and their best solution for bytes in the other slot. This would confuse users and it's very difficult to implement, because the site is designed not to let you lose your best solution for the scoring metric, even if you enter another solution. If we let users decide what to put in each slot, we would have no way to enforce it, unless we have users designate each slot as minimizing a specific metric, in which case we should just label the slots for the user. Additionally, it wouldn't even make sense to link slot one and two to the scoring mode, so we would need a scoring mode picker.

# Example

## 1. The slot picker is hidden by default.
Golf4 enters a relatively long solution (122 chars/bytes).

<img width="1280" alt="p1" src="https://user-images.githubusercontent.com/53135437/86502097-7594ea80-bd6d-11ea-8c9d-aa6455ef6ec5.png">

## 2. The slot picker appears automatically.
Golf4 discovers an encoding method and encodes their solution. This solution is shorter in characters and longer in bytes. They are now using both slots, so the slot picker is displayed and the "Fewest Chars" slot is automatically activated, because the solution they entered minimized that criteria.

<img width="1280" alt="p2" src="https://user-images.githubusercontent.com/53135437/86502100-87768d80-bd6d-11ea-9025-e3a6be6a46f3.png">

## 3. The user can manually pick the slot.
Golf4 switches to the "Fewest Bytes" slot and sees their previous solution.

<img width="1280" alt="p3" src="https://user-images.githubusercontent.com/53135437/86502105-92312280-bd6d-11ea-8060-f7d5498c4ec1.png">

## 4. Before the slot switches automatically.
Golf4 is looking at the "Fewest Chars" slot and is about to enter a 110 chars/bytes solution. It's longer in chars than their best solution, but it's shorter in bytes.

<img width="1280" alt="p4" src="https://user-images.githubusercontent.com/53135437/86502108-96f5d680-bd6d-11ea-9034-037ee1f62363.png">

## 5. After the slot switches automatically.
After the solution from the previous image is run, the "Fewest Bytes" slot is automatically activated. If the user switches back to the "Fewest Chars" slot, they will see their 88 char solution.

<img width="1280" alt="p5" src="https://user-images.githubusercontent.com/53135437/86502110-99f0c700-bd6d-11ea-8cd3-f4efa97fe565.png">

## 6. The slot picker disappears automatically.
Golf4 has a stroke of inspiration and enters a 59 char solution, which is their best solution yet in terms of both chars and bytes. The slot picker automatically closes, because the same solution occupies both slots. Golf4 and Golf1 are tied for first and Golf1 is listed first, because they submitted first.

<img width="1280" alt="p6" src="https://user-images.githubusercontent.com/53135437/86502112-9eb57b00-bd6d-11ea-855d-ce99c049bb84.png">

## 7. The slot picker reappears automatically.
Golf4 remembers their encoding method and applies it to their solution. Golf4 now has the only 1st place solution for "Chars". The slot picker has reappeared, because their solution with 57 chars has 117 bytes, which is not their best.

<img width="1280" alt="p7" src="https://user-images.githubusercontent.com/53135437/86502115-a1b06b80-bd6d-11ea-8f2e-f28b298f3d0d.png">

## 8. The scoring mode picker updates the mini-scoreboard.
Golf4 switches to the "Bytes" scoring mode. Golf1 and Golf4 are tied for first and Golf1 is listed first, because they submitted first.

<img width="1280" alt="p8" src="https://user-images.githubusercontent.com/53135437/86502118-a543f280-bd6d-11ea-82a2-8250979451dd.png">

## 9. Each scoring mode has its own sorting by submission time.
Golf1 sees the new low score in chars and figures out how to match it. Golf1 and Golf4 are tied for first for chars, but Golf4 is listed first.

<img width="1280" alt="p9" src="https://user-images.githubusercontent.com/53135437/86502124-a83ee300-bd6d-11ea-8602-4d98fbe5ccf4.png">

## 10. Each scoring mode has its own sorting by submission time.
Golf1 switches to the "Bytes" scoring mode and sees that they are still listed first. Golf4 and Golf1 are tied for first for bytes, but Golf1 is listed first.

<img width="1280" alt="p10" src="https://user-images.githubusercontent.com/53135437/86502125-ac6b0080-bd6d-11ea-9c21-b431323d7cd6.png">

## 11. Encoding a solution won't automatically show two slots.
Golf5 enters the 57 char encoded solution. This is the only solution they have entered. Although it has different numbers of characters and bytes, the slot picker isn't not shown, because the solution is the user's best for both metrics.

<img width="1280" alt="p11" src="https://user-images.githubusercontent.com/53135437/86502132-ba208600-bd6d-11ea-91fc-e84f41f0588b.png">

## 12. Users might only optimize one metric.
Golf5 is tied for first for chars, but is last place for bytes.

<img width="1280" alt="p12" src="https://user-images.githubusercontent.com/53135437/86502133-bc82e000-bd6d-11ea-9dad-e048564c56cf.png">

## 13. Users can decode their encoded solution.
Golf5 has changed exec to print to decode their solution.

<img width="1280" alt="p13" src="https://user-images.githubusercontent.com/53135437/86502136-c1479400-bd6d-11ea-8e8f-ae0cf02e2d65.png">

## 14. Users must manually enter a second solution to use two slots.
Golf5 has pasted the decoded solution into the code editor and submitted it. They are now tied for first for both metrics.

<img width="1280" alt="p14" src="https://user-images.githubusercontent.com/53135437/86502140-c573b180-bd6d-11ea-99ab-55bfc321af0c.png">

# Unimplemented
The scores, recent, and golfers routes only show scores in chars, not bytes.

I think it would make sense to have a Chars/Bytes selector for the scores and golfers routes.

For the recent route, I think it would make sense for a row to show the minimum number of chars and the minimum number of bytes the user has obtained for the language/hole. It will not be obvious to someone viewing this whether a user has different solutions in their two slots. There would be two sets of medals and downward chart emojis, one for each scoring metric.

When sorting holes by rank on the index page, only scores in chars are considered. I don't think it's worth having a Chars/Bytes picker here. It may make sense to use a combination of localStorage, which stores the last used scoring mode, and a user setting here.

The about page would need to be updated with a description of the scoring system.

# Open Questions
Do we attempt to combine scores for chars and bytes in some way to obtain an overall score? My preference is not to do this and to maintain two completely separate sets of leaderboards, but it's not clear how to implement this in some places. For example, you can sort holes by rank in the index, but I don't think it would be appropriate to add a Chars/Bytes selector here. Maybe we could use a combination of localStorage, which stores the last used scoring mode, and a user setting here.

# Implementation Notes
This is implemented by adding a slot column to the solutions table. Slot 0 is the user's best solution by chars and slot 1 is the user's best solution by bytes.

I'm not sure how important of a consideration this is, but this implementation may double the size of the database. It would be possible to store code in a separate table and reference it from the solutions table to reduce the amount of storage in the common case where users have the same solution in both slots.

With two slots per user/hole/language, the concept of failing solutions is more complicated. The user is currently notified on the home page when a solution is failing. We may want to update the message to indicate whether all of their solutions for a hole/language are failing, or just one of their two slots. If only one of the two slots is failing, should we use the other slot in various places to derive the other metric so that the user can remain on both leaderboards?

I have used a PostgreSQL trigger to compute the number of chars and bytes and store it in the database to allow for more efficient queries.

# Testing Notes

It's relatively easy to clone the code and try this out. Users need the same software required for the site itself: docker, docker-compose, and mkcert.

Edit: the testing procedure has been updated. The steps go along with the above images.

* Add fake users to db/a-schema.sql, after the users table is created:
```
INSERT INTO users (id, login) VALUES (1, 'Golf1');
INSERT INTO users (id, login) VALUES (2, 'Golf2');
INSERT INTO users (id, login) VALUES (3, 'Golf3');
INSERT INTO users (id, login) VALUES (4, 'Golf4');
INSERT INTO users (id, login) VALUES (5, 'Golf5');
```
and remove (it breaks things and is disabled on the site):
```
CREATE TRIGGER delete_orphaned_code
 AFTER UPDATE ON solutions EXECUTE FUNCTION delete_orphaned_code();
````
* Reset database via the command:
```
docker-compose rm -f && docker-compose up
```

* In session/session.go, set beta to true:
```
func Beta(r *http.Request) bool {
	return true
}
```
* Switch to user Golf1 by modifying session/session.go:
```
func Golfer(r *http.Request) *golfer.Golfer {
	golfer := golfer.Golfer{false, 1, "Golf1"}
	//golfer := golfer.Golfer{false, 4, "Golf4"}
	return &golfer
}
```
* Go to Fizz Buzz. Set Language to Python and Scoring Mode to Chars. Reload the page if already loaded.
```
https://localhost/fizz-buzz#python
```
* For FizzBuzz, Python, enter 59 chars:
```
for i in range(100):print(i%3//2*'Fizz'+i%5//4*'Buzz'or-~i)
```
* Switch to user Golf4 and reload the page.
* Enter 121 char:
```
for x in range(1,101):
 if x%15==0:print('FizzBuzz')
 elif x%3==0:print('Fizz')
 elif x%5==0:print('Buzz')
 else:print(x)
```
* Verify that the slot picker is still hidden.
* Enter 88 chars (210 bytes):
```
exec('景爠砠楮⁲慮来⠱ⰱ〱⤺ਠ楦⁸┱㔽㴰㩰物湴⠧䙩空䉵空✩ਠ敬楦⁸┳㴽〺灲楮琨❆楺稧⤊⁥汩映砥㔽㴰㩰物湴⠧䉵空✩ਠ敬獥㩰物湴⡸⤠'.encode('utf-16be'))
```
* Verify that the slot picker has appeared and "Fewest Chars 88" is selected.
* Switch to "Fewest Bytes 121" and see previous solution.
* Switch back to "Fewest Chars 88" and see that solution.
* Enter 110 char solution:
```
p=print
for x in range(1,101):
 if x%15<1:p('FizzBuzz')
 elif x%3<1:p('Fizz')
 elif x%5<1:p('Buzz')
 else:p(x)
```
* Verify that the slot automatically changed to "Fewest Bytes 110".
* Verify that the numbers in the mini-scoreboard for Golf4 are 88 and 110 (This fails if trigger delete_orphaned_code is active).
* Verify that the numbers in the slot picker are shown as "Fewest Chars 88" and "Fewest Bytes 110".
* Verify that the numbers in the Lang picker are shown as "88/110".
* Optionally, verify that nothing changes when reloading the page.
* Enter 59 char solution:
```
for i in range(100):print(i%3//2*'Fizz'+i%5//4*'Buzz'or-~i)
```
* Verify that the slot picker has automatically disappeared.
* Enter 57 char 117 byte solution:
```
exec('景爠椠楮⁲慮来⠱〰⤺灲楮琨椥㌯⼲⨧䙩空✫椥㔯⼴⨧䉵空❯爭繩⤠'.encode('utf-16be'))
```
* Verify that the slot picker has reappeared and "Fewest Chars 57" is selected.
* Verify that the scoring mode is chars and Golf4 is listed first and their rank is 1st.
* Switch to the Bytes scoring mode. Verify that Golf4 is listed second and their rank is 1st.
* Switch to user Golf1 and reload the page.
* Enter 57 char 117 byte solution:
```
exec('景爠椠楮⁲慮来⠱〰⤺灲楮琨椥㌯⼲⨧䙩空✫椥㔯⼴⨧䉵空❯爭繩⤠'.encode('utf-16be'))
```
* Note that the slot picker appears and the "Feweset Chars 57" slot is selected.
* The mode picker is still on "Bytes" because that doesn't change automatically.
* In the mini-scoreboard, Golf1 is listed first and their rank is 1st.
* Switch the scoring mode to Chars. Golf1 is listed second and their rank is 1st (because their submission time was later for this mode).
