### PR TITLE
hole.js: Fixed an issue where the user could be repeatedly prompted to restore a local solution

### DIFF
--- a/assets/hole.js
+++ b/assets/hole.js
@@ -55,8 +55,11 @@ onload = () => {
         // Avoid future conflicts by only storing code locally that's different from the server's copy.
         const serverCode = lang in solutions ? solutions[lang] : '';
 
+        const key = 'code_' + hole + '_' + lang;
         if (code && code != serverCode)
-            localStorage.setItem('code_' + hole + '_' + lang, code);
+            localStorage.setItem(key, code);
+        else
+            localStorage.removeItem(key);
     });
 
     details.ontoggle = () =>


### PR DESCRIPTION
Before this change, if you are logged in and submit a solution and then delete a character from it, then each time you reload the page, it would prompt you to restore the solution from local storage. This is because the version of the solution with the deleted character would remain in local storage. After a recent change (designed to minimize unnecessary prompting, ironically), the solution wouldn't go to local storage, because it matched, so the version with the deleted character would remain. The fix is to remove the local storage item if it matches the server's version of the solution.

Tested on my local server.