### PR TITLE
Run javascript using -e instead of a temp file

### DIFF
--- a/hole/play.go
+++ b/hole/play.go
@@ -78,7 +78,9 @@ func Play(ctx context.Context, holeID, langID, code string) (score Scorecard) {
 	cmd := exec.CommandContext(ctx, "/usr/bin/run-lang")
 	cmd.Dir = "langs/" + langID
 	cmd.Stderr = &stderr
-	cmd.Stdin = strings.NewReader(code)
+	if langID != "javascript" {
+		cmd.Stdin = strings.NewReader(code)
+	}
 	cmd.Stdout = &stdout
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Cloneflags: syscall.CLONE_NEWIPC | syscall.CLONE_NEWNET | syscall.CLONE_NEWNS | syscall.CLONE_NEWPID | syscall.CLONE_NEWUTS,

--- a/hole/play.go
+++ b/hole/play.go
@@ -91,10 +91,12 @@ func Play(ctx context.Context, holeID, langID, code string) (score Scorecard) {
 		cmd.Args = []string{"/usr/bin/tcc", "-run", "-"}
 	case "c-sharp", "f-sharp":
 		cmd.Args = []string{"/compiler/Compiler", "-"}
-	case "haskell", "javascript", "php":
+	case "haskell", "php":
 		cmd.Args = []string{"/usr/bin/" + langID, "--"}
 	case "j":
 		cmd.Args = []string{"/usr/bin/j", "/tmp/code.ijs"}
+	case "javascript":
+		cmd.Args = []string{"/v8/out.gn/x64.release/d8", "-e", code, "--"}
 	case "julia":
 		cmd.Args = []string{"/usr/bin/run-julia", "/tmp/code.jl"}
 	case "powershell":

--- a/langs/javascript/Dockerfile
+++ b/langs/javascript/Dockerfile
@@ -90,19 +90,11 @@ RUN set -x \
   && : "---------- Build ----------" \
   && ninja d8 -C out.gn/x64.release/ -j $(getconf _NPROCESSORS_ONLN)
 
-RUN echo -e "#!/bin/sh -e\n\
-\n\
-/bin/cat - > /tmp/code.js\n\
-\n\
-exec /v8/out.gn/x64.release/d8 /tmp/code.js \"\$@\"" > /usr/bin/javascript \
- && chmod +x /usr/bin/javascript
-
 FROM scratch
 
 COPY --from=0 /bin/cat                                      \
               /bin/sh                                       /bin/
 COPY --from=0 /lib/ld-musl-x86_64.so.1                      /lib/
-COPY --from=0 /usr/bin/javascript                           /usr/bin/
 COPY --from=0 /usr/lib/libgcc_s.so.1                        \
               /usr/lib/libstdc++.so.6                       /usr/lib/
 COPY --from=0 /v8/out.gn/x64.release/d8                     /v8/out.gn/x64.release/

--- a/langs/javascript/Dockerfile
+++ b/langs/javascript/Dockerfile
@@ -92,8 +92,6 @@ RUN set -x \
 
 FROM scratch
 
-COPY --from=0 /bin/cat                                      \
-              /bin/sh                                       /bin/
 COPY --from=0 /lib/ld-musl-x86_64.so.1                      /lib/
 COPY --from=0 /usr/lib/libgcc_s.so.1                        \
               /usr/lib/libstdc++.so.6                       /usr/lib/


### PR DESCRIPTION
Fixes the cheating javascript quine and avoids having to write to a file.