### PR TITLE
Add a CSS property for .scoringPicker.

### DIFF
--- a/views/css/hole.css
+++ b/views/css/hole.css
@@ -47,6 +47,7 @@ h3 {
 .scoringPicker {
     font-weight: normal;
     padding: 0 .5rem;
+    color: var(--color);
 }
 
 .scoringPicker:hover,


### PR DESCRIPTION
Avoid using the new blue link color.