### PR TITLE
Update recent route for chars/bytes.

### DIFF
--- a/views/recent.html
+++ b/views/recent.html
@@ -1,5 +1,7 @@
 {{ template "header" . }}
 
+{{ $beta := .Beta }}
+
 <main>
     <h1>Recent Solutions</h1>
 
@@ -27,8 +29,13 @@
                 <th>Hole
                 <th>Golfer
                 <th class=wide>Lang
-                <th class="right wide">Bytes
-                <th class="right wide">Chars
+                {{ if .Beta }}
+                    <th class="right wide">Strokes
+                    <th class="wide">Scoring
+                {{ else }}
+                    <th class="right wide">Bytes
+                    <th class="right wide">Chars
+                {{ end }}
                 <th class=wide>
                 <th class=right>Submitted
         <tbody>
@@ -48,9 +55,15 @@
                     </a>
                 <td class=wide>
                     <a href="/recent/{{ .Lang.ID }}">{{ .Lang.Name }}</a>
-                <td class="right wide">{{ comma .Bytes }}
-                <td class="right wide" title="Rank: {{ .Rank }}{{ ord .Rank }}">
-                    {{ comma .Chars }}
+                {{ if $beta }}
+                    <td class="right wide" title="Rank: {{ .Rank }}{{ ord .Rank }}">
+                        {{ comma .Strokes }}
+                    <td class="wide">{{ .Scoring }}
+                {{ else }}
+                    <td class="right wide">{{ comma .Bytes }}
+                    <td class="right wide" title="Rank: {{ .Rank }}{{ ord .Rank }}">
+                        {{ comma .Chars }}
+                {{ end }}
                 <td class=wide
                     {{ if not .TieCount }}
                         title="Shorter than previous {{ .Rank }}{{ ord .Rank }} place solutions"


### PR DESCRIPTION
Use one row per scoring so that the rank and the downward chart icon can be displayed properly.

Example:

<img width="674" alt="Screen Shot 2020-09-11 at 12 51 23 PM" src="https://user-images.githubusercontent.com/53135437/92952273-b2482680-f42d-11ea-9dc6-ed6a5e85adff.png">
