### PR TITLE
Recent route: show more info in the tooltip for "Both" rows.

### DIFF
--- a/routes/recent.go
+++ b/routes/recent.go
@@ -83,11 +83,11 @@ func Recent(w http.ResponseWriter, r *http.Request) {
 	defer rows.Close()
 
 	type recent struct {
-		Hole                                  hole.Hole
-		Lang                                  lang.Lang
-		Login, Scoring                        string
-		Bytes, Chars, Strokes, Rank, TieCount int
-		Submitted                             time.Time
+		Hole                                             hole.Hole
+		Lang                                             lang.Lang
+		Login, Scoring                                   string
+		Bytes, Chars, Strokes, OtherRank, Rank, TieCount int
+		Submitted                                        time.Time
 	}
 
 	var recents []recent
@@ -123,7 +123,15 @@ func Recent(w http.ResponseWriter, r *http.Request) {
 			previous.Strokes == r.Strokes &&
 			(previous.Rank == r.Rank || previous.Rank > 3 && r.Rank > 3) &&
 			(r.Rank > 3 || (previous.TieCount > 0) == (r.TieCount > 0)) {
-			recents[len(recents)-1].Scoring = "Both"
+			if r.Scoring == "Chars" {
+				previous.OtherRank = r.Rank
+			} else {
+				previous.OtherRank = previous.Rank
+				previous.Rank = r.Rank
+			}
+
+			previous.Scoring = "Both"
+			recents[len(recents)-1] = previous
 		} else {
 			recents = append(recents, r)
 			previous = r

--- a/views/recent.html
+++ b/views/recent.html
@@ -56,17 +56,21 @@
                 <td class=wide>
                     <a href="/recent/{{ .Lang.ID }}">{{ .Lang.Name }}</a>
                 {{ if $beta }}
-                    <td class="right wide" title="Rank: {{ .Rank }}{{ ord .Rank }}">
-                        {{ comma .Strokes }}
+                {{ if eq .OtherRank 0 }}
+                    <td class="right wide" data-tooltip="Rank: {{ .Rank }}{{ ord .Rank }}">
+                {{ else }}
+                    <td class="right wide" data-tooltip="Bytes rank is {{ .Rank }}{{ ord .Rank }}. Chars rank is {{ .OtherRank }}{{ ord .OtherRank }}.">
+                {{ end }}
+                    {{ comma .Strokes }}
                     <td class="wide">{{ .Scoring }}
                 {{ else }}
                     <td class="right wide">{{ comma .Bytes }}
-                    <td class="right wide" title="Rank: {{ .Rank }}{{ ord .Rank }}">
+                    <td class="right wide" data-tooltip="Rank: {{ .Rank }}{{ ord .Rank }}">
                         {{ comma .Chars }}
                 {{ end }}
                 <td class=wide
                     {{ if not .TieCount }}
-                        title="Shorter than previous {{ .Rank }}{{ ord .Rank }} place solutions"
+                        data-tooltip="Shorter than previous {{ .Rank }}{{ ord .Rank }} place solutions"
                     {{ end }}>
                     {{if eq .Rank 1}}🥇
                     {{else if eq .Rank 2}}🥈

--- a/views/recent.html
+++ b/views/recent.html
@@ -56,27 +56,27 @@
                 <td class=wide>
                     <a href="/recent/{{ .Lang.ID }}">{{ .Lang.Name }}</a>
                 {{ if $beta }}
+                    <td class="right wide">
                 {{ if eq .OtherRank 0 }}
-                    <td class="right wide" data-tooltip="Rank: {{ .Rank }}{{ ord .Rank }}">
+                    <span data-tooltip="Rank: {{ .Rank }}{{ ord .Rank }}">
                 {{ else }}
-                    <td class="right wide" data-tooltip="Bytes rank is {{ .Rank }}{{ ord .Rank }}. Chars rank is {{ .OtherRank }}{{ ord .OtherRank }}.">
+                    <span data-tooltip="Bytes rank is {{ .Rank }}{{ ord .Rank }}. Chars rank is {{ .OtherRank }}{{ ord .OtherRank }}.">
                 {{ end }}
                     {{ comma .Strokes }}
+                    </span>
                     <td class="wide">{{ .Scoring }}
                 {{ else }}
                     <td class="right wide">{{ comma .Bytes }}
-                    <td class="right wide" data-tooltip="Rank: {{ .Rank }}{{ ord .Rank }}">
-                        {{ comma .Chars }}
+                    <td class="right wide"><span data-tooltip="Rank: {{ .Rank }}{{ ord .Rank }}">{{ comma .Chars }}</span>
                 {{ end }}
-                <td class=wide
-                    {{ if not .TieCount }}
-                        data-tooltip="Shorter than previous {{ .Rank }}{{ ord .Rank }} place solutions"
-                    {{ end }}>
+                <td class=wide>
                     {{if eq .Rank 1}}🥇
                     {{else if eq .Rank 2}}🥈
                     {{else if eq .Rank 3}}🥉
                     {{end}}
-                    {{if and (not .TieCount) (le .Rank 3)}}📉{{end}}
+                    {{if and (not .TieCount) (le .Rank 3)}}
+                        <span data-tooltip="Shorter than previous {{ .Rank }}{{ ord .Rank }} place solutions">📉</span>
+                    {{end}}
                 <td class=right>{{ time .Submitted }}
         {{- end -}}
     </table>


### PR DESCRIPTION
<img width="749" alt="Screen Shot 2020-10-01 at 12 51 21 AM" src="https://user-images.githubusercontent.com/53135437/94769637-88c15180-0380-11eb-98ae-9e27a757d87b.png">
<img width="753" alt="Screen Shot 2020-10-01 at 12 48 46 AM" src="https://user-images.githubusercontent.com/53135437/94769640-89f27e80-0380-11eb-87d8-d0880adb2416.png">