### PR TITLE
Fix an issue in the beta where the solution picker should be hidden.

### DIFF
--- a/views/js/hole.js
+++ b/views/js/hole.js
@@ -250,7 +250,8 @@ async function refreshScores() {
 
         // Only show the solution picker when both solutions are actually used.
         if (code0 && code1 && code0 != code1 || autoSave0 && autoSave1 && autoSave0 != autoSave1 ||
-            code0 && autoSave1 && code0 != autoSave1 || autoSave0 && code1 && autoSave0 != code1) {
+            (solution == 0 && code0 && autoSave1 && code0 != autoSave1) ||
+            (solution == 1 && autoSave0 && code1 && autoSave0 != code1)) {
             for (let i = 0; i < scorings.length; i++) {
                 let name = `Fewest ${scorings[i]}`;
 


### PR DESCRIPTION
Fix an issue where the solution picker could become visible when a user enters a longer solution.
The intention for the code that controls solution picker visibility was to allow logged-in users to switch to an auto-saved solution they entered when they were logged out. This change makes it more clear that the conditions only apply for autosaves for the other solution.