### PR TITLE
Add Open Graph meta tags to have nice link sharing previews

### DIFF
--- a/views/header.html
+++ b/views/header.html
@@ -11,12 +11,28 @@
 <link href=/feeds/rss  rel=alternate type=application/rss+xml>
 <link href=/feeds/json rel=alternate type=application/json>
 
+{{ $title := "Code Golf" }}
+{{ with .Title }}{{ $title = (print . " | Code Golf") }}{{ end }}
+<title>{{ $title }}</title>
+<meta property="og:title" content="{{ $title }}">
+
 {{/* FIXME This won't change for dark themes :-( */}}
 <meta name=theme-color content=#343A40>
 <meta name=viewport    content="width=device-width">
-<meta name=description content="Code Golf is a game designed to let you show off your code-fu by solving problems in the least number of characters.">
+{{ $description := "Code Golf is a game designed to let you show off your code-fu by solving problems in the least number of characters." }}
+<meta name=description content="{{ $description }}">
+<meta property="og:description" content="{{ $description }}">
+<meta name="twitter:card" content="summary">
 
 <title>{{ with .Title }}{{ . }} | {{ end }}Code Golf</title>
+{{ if .GolferInfo }}
+<meta property="og:image" content="https://avatars.githubusercontent.com/{{ .GolferInfo.Name }}?s=200">
+{{ else }}
+<meta property="og:image" content="https://code.golf/icon-180.png">
+{{ end }}
+<meta property="og:image:width" content="200">
+<meta property="og:image:height" content="200">
+<meta property="og:url" content="https://code.golf{{ with .Path }}{{ . }}{{ end }}">
 
 {{/* TODO Kill JSExt, make codemirror a real module imported from hole.js */}}
 {{ $nonce := .Nonce }}


### PR DESCRIPTION
Fixes #268 

I tested this on Whatsapp & Telegram:

![image](https://user-images.githubusercontent.com/1018253/95132596-550b7080-0760-11eb-817c-a306c06557cc.png)

![image](https://user-images.githubusercontent.com/1018253/95132586-52108000-0760-11eb-9a2a-f3d8e6cdd8eb.png)

Do let me know if any improvements are needed :)