### PR TITLE
Build Ruby with Clang.

### DIFF
--- a/langs/ruby/Dockerfile
+++ b/langs/ruby/Dockerfile
@@ -2,16 +2,20 @@ FROM alpine:3.12 as builder
 
 RUN mkdir /empty
 
-RUN apk add --no-cache build-base curl openssl-dev
+RUN apk add --no-cache build-base clang curl openssl-dev
 
 RUN curl https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.xz \
   | tar xJf -
 
-RUN cd ruby-2.7.2            \
- && CFLAGS=-flto ./configure \
-    --disable-install-doc    \
-    --prefix=/usr            \
- && make -j`nproc` install   \
+# CC=clang produces the same executable size as using CFLAGS=-flto with default gcc, but
+# compiling with LTO with gcc leads to an issue where the stack size available for recursion
+# is significantly reduced. It may be worth trying to enable LTO for Clang. That appears
+# to require building the LLVMgold plugin.
+RUN cd ruby-2.7.2          \
+ && CC=clang ./configure   \
+    --disable-install-doc  \
+    --prefix=/usr          \
+ && make -j`nproc` install \
  && strip -s /usr/bin/ruby
 
 # Remove some big default gems


### PR DESCRIPTION
Makes the executable size comparable to gcc with LTO but without the issues related to limited stack size.