### PR TITLE
Fix scoring picker on Scores page

### DIFF
--- a/views/scores.html
+++ b/views/scores.html
@@ -74,8 +74,8 @@
     </details>
 
     <nav class=nav>
-        <a {{ if $charsScoring }} href=bytes {{ end }}>Bytes</a>
-        <a {{ if $bytesScoring }} href=chars {{ end }}>Chars</a>
+        <a {{ if $charsScoring }} href="/scores/{{ $holeID }}/{{ $langID }}/bytes" {{ end }}>Bytes</a>
+        <a {{ if $bytesScoring }} href="/scores/{{ $holeID }}/{{ $langID }}/chars" {{ end }}>Chars</a>
     </nav>
 
     <table class="nowrap-second sticky">


### PR DESCRIPTION
#### Steps to reproduce 
1. Click the "Next" button on [any Scores page](https://code.golf/scores/all-holes/all-langs/bytes)
2. Switch to another scoring

#### Expected URL
[https://code.golf/scores/{{ hole }}/{{ lang }}/{{ anotherScoring }}](https://code.golf/scores/all-holes/all-langs/chars)

#### Actual URL
[https://code.golf/scores/{{ hole }}/{{ lang }}/{{ scoring }}/{{ anotherScoring }}](https://code.golf/scores/all-holes/all-langs/bytes/chars)