### PR TITLE
COBOL: workaround a bug in 3.1.2 where "#include <math.h>" isn't emit…

### DIFF
--- a/langs/cobol/cobol.c
+++ b/langs/cobol/cobol.c
@@ -21,16 +21,36 @@ int main (int argc, char *argv[]) {
     if (WEXITSTATUS(status))
         return WEXITSTATUS(status);
 
+    char buffer[4096];
+    ssize_t nbytes;
+    FILE *fp1 = fopen("/tmp/code.c", "r");
+    FILE *fp2 = fopen("/tmp/code2.c", "w");
+
+    if (!fp1 || !fp2)
+        return 3;
+
+    const char *header = "#include <math.h>\n";
+
+    if (fwrite(header, sizeof(char), strlen(header), fp2) != strlen(header))
+        return 4;
+
+    while ((nbytes = fread(buffer, sizeof(char), sizeof(buffer), fp1)) > 0)
+        if (fwrite(buffer, sizeof(char), nbytes, fp2) != nbytes)
+            return 5;
+
+    fclose(fp1);
+    fclose(fp2);
+
     int ntcc = argc + 3;
     char **tcc = malloc(ntcc * sizeof(char*));
     tcc[0] = "/usr/bin/tcc";
     tcc[1] = "-lcob";
     tcc[2] = "-run";
-    tcc[3] = "/tmp/code.c";
+    tcc[3] = "/tmp/code2.c";
     memcpy(&tcc[4], &argv[2], (argc - 2) * sizeof(char*));
     tcc[ntcc - 1] = NULL;
 
     execv("/usr/bin/tcc", tcc);
     perror("execv");
-    return 3;
+    return 6;
 }


### PR DESCRIPTION
…ted.