### PR TITLE
COBOL: patch bizarre change in COBOL 3.1.2 that converts ' ' to -16 instead of 0.

### DIFF
--- a/langs/cobol/Dockerfile
+++ b/langs/cobol/Dockerfile
@@ -6,7 +6,10 @@ RUN apk add --no-cache build-base curl gmp-dev
 
 RUN curl https://ftp.gnu.org/gnu/gnucobol/gnucobol-3.1.2.tar.xz | tar xJf -
 
+COPY patch /
+
 RUN cd gnucobol-3.1.2                      \
+ && patch -p0 < /patch                     \
  && ./configure --prefix=/usr --without-db \
  && make -j`nproc` install                 \
  && strip /usr/bin/cobc /usr/lib/libcob.so.4.1.0

--- a/langs/cobol/patch
+++ b/langs/cobol/patch
@@ -1,0 +1,11 @@
+--- libcob/coblocal.h
++++ libcob/coblocal.h
+@@ -173,7 +173,7 @@
+ #endif
+ 
+ /* Convert between a digit and an integer (e.g., '0' <-> 0) */
+-#define COB_D2I(x)		((x) - '0')
++#define COB_D2I(x)		((x) & 0x0F)
+ #define COB_I2D(x)		(char) ((x) + '0')
+ 
+ #define	COB_MODULE_PTR		cobglobptr->cob_current_module


### PR DESCRIPTION
This fixes my Lucky tickets. I will probably submit a bug for this.