### PR TITLE
Revamped Discord record announcements

### DIFF
--- a/discord/bot.go
+++ b/discord/bot.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/code-golf/code-golf/golfer"
@@ -13,12 +14,13 @@ import (
 
 var bot *discordgo.Session
 
-const channelID = "800680710964903946"
+var channelID string
 
 func init() {
-	// The authentication token of the bot should be stored in the .env file
-	// If it's not found, the bot is skipped
-	if token := os.Getenv("DISCORD_BOT_TOKEN"); token != "" {
+	/* The authentication token of the bot and the ID of the announcement channel (800680710964903946)
+	should be stored in the .env file. If either of them isn't found, the bot is skipped */
+	var token string
+	if token, channelID = os.Getenv("DISCORD_BOT_TOKEN"), os.Getenv("DISCORD_BOT_CHANNEL"); token != "" && channelID != "" {
 		go func() {
 			var err error
 			if bot, err = discordgo.New("Bot " + token); err != nil {
@@ -32,27 +34,39 @@ func init() {
 
 // LogNewRecord logs a record breaking solution in Discord.
 func LogNewRecord(
-	golfer *golfer.Golfer, hole hole.Hole, lang lang.Lang, scorings string,
-	bytes int64, chars int64,
+	golfer *golfer.Golfer, hole hole.Hole, lang lang.Lang, updates []golfer.RankUpdate,
 ) {
 	if bot == nil {
 		return
 	}
 
-	scoring := ""
-	if scorings != "byteschars" {
-		scoring = scorings[:len(scorings)-1] + " "
+	imageURL := "https://avatars.githubusercontent.com/" + golfer.Name
+	golferURL := "https://code.golf/golfers/" + golfer.Name
+
+	embed := &discordgo.MessageEmbed{
+		Title: fmt.Sprintf("New :first_place: on %s in %s!",
+			hole.Name,
+			lang.Name,
+		),
+		URL:    "https://code.golf/scores/" + hole.ID + "/" + lang.ID + "/" + updates[0].Scoring,
+		Fields: make([]*discordgo.MessageEmbedField, 0, 2),
+		Author: &discordgo.MessageEmbedAuthor{Name: golfer.Name, IconURL: imageURL, URL: golferURL},
 	}
 
-	_, err := bot.ChannelMessageSendEmbed(channelID, &discordgo.MessageEmbed{
-		Title:       fmt.Sprintf("New record on %s in %s!", hole.Name, lang.Name),
-		Description: fmt.Sprintf("A new %srecord has been set by %s!", scoring, golfer.Name),
-		Fields: []*discordgo.MessageEmbedField{
-			{Name: "Bytes", Inline: true, Value: fmt.Sprint(bytes)},
-			{Name: "Chars", Inline: true, Value: fmt.Sprint(chars)},
-		},
-	})
-	if err != nil {
+	// Add in the scorings (as necessary)
+	for _, update := range updates {
+		improveString := fmt.Sprint(update.To.Strokes.Int64)
+		if update.From.Strokes.Valid {
+			improveString = fmt.Sprint(update.From.Strokes.Int64) + "  →  " + improveString
+		}
+		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+			Name:   strings.Title(update.Scoring),
+			Value:  improveString,
+			Inline: true,
+		})
+	}
+
+	if _, err := bot.ChannelMessageSendEmbed(channelID, embed); err != nil {
 		log.Println(err)
 	}
 }

--- a/golfer/golfer.go
+++ b/golfer/golfer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/code-golf/code-golf/hole"
 	"github.com/code-golf/code-golf/lang"
 	"github.com/code-golf/code-golf/trophy"
+	"gopkg.in/guregu/null.v4"
 )
 
 type Golfer struct {
@@ -36,6 +37,14 @@ type GolferInfo struct {
 
 	// Start date
 	TeedOff time.Time
+}
+
+type RankUpdate struct {
+	Scoring  string
+	From, To struct {
+		Joint         null.Bool
+		Rank, Strokes null.Int
+	}
 }
 
 func GetInfo(db *sql.DB, name string) *GolferInfo {


### PR DESCRIPTION
Discord record announcements now contain the golfer's previous scorings, their avatar, and links to both the relevant leaderboard and the golfer's user page.