### PR TITLE
Added Discord bot record announcement editing

### DIFF
--- a/discord/bot.go
+++ b/discord/bot.go
@@ -8,14 +8,25 @@ import (
 	"time"
 
 	"github.com/bwmarrin/discordgo"
-	"github.com/code-golf/code-golf/golfer"
+	Golfer "github.com/code-golf/code-golf/golfer"
 	"github.com/code-golf/code-golf/hole"
 	"github.com/code-golf/code-golf/lang"
 )
 
 var bot *discordgo.Session
-
 var channelID string
+
+// Represents a new record announcement message
+type RecAnnouncement struct {
+	Timestamp time.Time
+	Message   *discordgo.Message
+	Updates   [][]Golfer.RankUpdate
+	Golfer    *Golfer.Golfer
+	Hole      hole.Hole
+	Lang      lang.Lang
+}
+
+var lastAnnouncement *RecAnnouncement
 
 func init() {
 	/* The authentication token of the bot and the ID of the announcement channel (800680710964903946)
@@ -33,42 +44,92 @@ func init() {
 	}
 }
 
-// LogNewRecord logs a record breaking solution in Discord.
-func LogNewRecord(
-	golfer *golfer.Golfer, hole hole.Hole, lang lang.Lang, updates []golfer.RankUpdate,
-) {
-	if bot == nil {
-		return
-	}
-
+// recAnnounceToEmbed parses a recAnnouncement object and turns it into a Discord embed
+func recAnnounceToEmbed(announce *RecAnnouncement) *discordgo.MessageEmbed {
+	hole, lang, golfer := announce.Hole, announce.Lang, announce.Golfer
 	imageURL := "https://avatars.githubusercontent.com/" + golfer.Name
 	golferURL := "https://code.golf/golfers/" + golfer.Name
 
+	// Creating the basic embed
 	embed := &discordgo.MessageEmbed{
 		Title: fmt.Sprintf("New 🥇 on %s in %s!",
 			hole.Name,
 			lang.Name,
 		),
-		URL:       "https://code.golf/scores/" + hole.ID + "/" + lang.ID + "/" + updates[0].Scoring,
+		URL:       "https://code.golf/scores/" + hole.ID + "/" + lang.ID + "/",
 		Fields:    make([]*discordgo.MessageEmbedField, 0, 2),
 		Author:    &discordgo.MessageEmbedAuthor{Name: golfer.Name, IconURL: imageURL, URL: golferURL},
-		Timestamp: time.Now().Format(time.RFC3339),
+		Timestamp: announce.Timestamp.Format(time.RFC3339),
 	}
 
-	// Add in the scorings (as necessary)
-	for _, update := range updates {
-		improveString := fmt.Sprint(update.To.Strokes.Int64)
-		if update.From.Strokes.Valid {
-			improveString = fmt.Sprint(update.From.Strokes.Int64) + "  →  " + improveString
+	// Now, we fill out the fields according to the updates of the announcement
+	fieldValues := make(map[string]string)
+	for _, pair := range announce.Updates {
+		for _, update := range pair {
+			improveString := fmt.Sprint(update.To.Strokes.Int64)
+			if update.From.Strokes.Valid {
+				improveString = fmt.Sprint(update.From.Strokes.Int64) + "  →  " + improveString
+			}
+			fieldValues[update.Scoring] += improveString
 		}
-		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
-			Name:   strings.Title(update.Scoring),
-			Value:  improveString,
-			Inline: true,
-		})
+		// Use invisible Braille characters so that Discord won't truncate them
+		fieldValues["bytes"] += "⠀\n"
+		fieldValues["chars"] += "⠀\n"
 	}
 
-	if _, err := bot.ChannelMessageSendEmbed(channelID, embed); err != nil {
+	for _, scoring := range []string{"bytes", "chars"} {
+		if strings.ReplaceAll(fieldValues[scoring], "⠀\n", "") != "" {
+			embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+				Name:   strings.Title(scoring),
+				Value:  fieldValues[scoring],
+				Inline: true,
+			})
+		}
+	}
+
+	// Find the dominant scoring (only "chars" if there were no improvements on bytes)
+	if strings.ReplaceAll(fieldValues["bytes"], "⠀\n", "") == "" {
+		embed.URL += "chars"
+	} else {
+		embed.URL += "bytes"
+	}
+
+	return embed
+}
+
+// LogNewRecord logs a record breaking solution in Discord.
+func LogNewRecord(
+	golfer *Golfer.Golfer, hole hole.Hole, lang lang.Lang, updates []Golfer.RankUpdate,
+) {
+	if bot == nil {
+		return
+	}
+
+	announcement := &RecAnnouncement{
+		Timestamp: time.Now(),
+		Hole:      hole, Lang: lang, Golfer: golfer,
+		Updates: [][]Golfer.RankUpdate{updates},
+	}
+
+	if lastAnnouncement != nil &&
+		announcement.Lang.ID == lastAnnouncement.Lang.ID &&
+		announcement.Hole.ID == lastAnnouncement.Hole.ID &&
+		announcement.Golfer.ID == lastAnnouncement.Golfer.ID &&
+		announcement.Timestamp.Sub(lastAnnouncement.Timestamp) < time.Hour {
+		lastAnnouncement.Updates = append(lastAnnouncement.Updates, updates)
+		if _, err := bot.ChannelMessageEditEmbed(
+			lastAnnouncement.Message.ChannelID,
+			lastAnnouncement.Message.ID,
+			recAnnounceToEmbed(lastAnnouncement),
+		); err == nil { // Note that we only return if the embed was edited succesfully;
+			return // otherwise, we'll continue forward and send it as a new message
+		}
+	}
+
+	if newMessage, err := bot.ChannelMessageSendEmbed(channelID, recAnnounceToEmbed(announcement)); err != nil {
 		log.Println(err)
+	} else {
+		lastAnnouncement = announcement
+		lastAnnouncement.Message = newMessage
 	}
 }


### PR DESCRIPTION
The Discord bot now updates the last announcement it posted, whenever the record that that announcement represents is broken again. The updates show the progression of the record in both bytes and chars. Updating happens only to the very last message sent in the channel.
Additionally, timestamps on announcements have been removed.
![image](https://user-images.githubusercontent.com/36775845/105710688-1f151680-5f20-11eb-8937-ce505734a567.png)

