### PR TITLE
Switch to faster Hexagony interpreter.

### DIFF
--- a/hole/play.go
+++ b/hole/play.go
@@ -106,7 +106,7 @@ func Play(ctx context.Context, holeID, langID, code string) (score Scorecard) {
 	case "haskell", "php":
 		cmd.Args = []string{"/usr/bin/" + langID, "--"}
 	case "hexagony":
-		cmd.Args = []string{"ruby", "/usr/bin/hexagony/interpreter.rb"}
+		cmd.Args = []string{"/hexagony/Hexagony", "-d", "-"}
 	case "j":
 		cmd.Args = []string{"/usr/bin/j", "/tmp/code.ijs"}
 	case "javascript":

--- a/langs.toml
+++ b/langs.toml
@@ -162,8 +162,8 @@ website = '//www.haskell.org/ghc/'
 
 [Hexagony]
 size    = '14.5 MiB'
-version = 'f749e59'
-website = '//esolangs.org/wiki/Hexagony'
+version = 'b531c38'
+website = '//github.com/SirBogman/Hexagony'
 example = '''
           \ P r i n t i n g .
          \ H ; e ; l ; ; o ; \

--- a/langs/hexagony/Dockerfile
+++ b/langs/hexagony/Dockerfile
@@ -1,14 +1,27 @@
-FROM alpine:3.13 as builder
+FROM mcr.microsoft.com/dotnet/sdk:5.0.102-alpine3.12 as builder
 
-ENV VERSION=f749e59
+ENV COMMIT=b531c38
 
-RUN apk add --no-cache curl
+RUN mkdir /empty
 
-RUN curl -L https://github.com/m-ender/hexagony/tarball/$VERSION | tar xz \
- && mv /m-ender-hexagony-$VERSION /hexagony
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 
-FROM codegolf/lang-ruby
+RUN curl -L https://github.com/SirBogman/Hexagony/tarball/$COMMIT \
+  | tar xz
 
-COPY --from=0 /hexagony /usr/bin/hexagony
+WORKDIR /SirBogman-Hexagony-$COMMIT
 
-COPY interpreter.rb /usr/bin/hexagony/
+RUN dotnet publish -c Release -r linux-musl-x64 -o /hexagony \
+    -p:PublishReadyToRun=true -p:PublishTrimmed=true
+
+FROM scratch
+
+COPY --from=0 /lib/ld-musl-x86_64.so.1 \
+              /lib/libcrypto.so.1.1    \
+              /lib/libssl.so.1.1       /lib/
+COPY --from=0 /empty                   /proc
+COPY --from=0 /empty                   /tmp
+COPY --from=0 /usr/lib                 /usr/lib/
+COPY --from=0 /hexagony                /hexagony/
+
+ENTRYPOINT ["/hexagony/Hexagony"]

--- a/langs/hexagony/interpreter.rb
+++ b/langs/hexagony/interpreter.rb
@@ -1,9 +1,0 @@
-#!/usr/bin/env ruby
-
-require_relative 'hexagony'
-require 'stringio'
-
-input = StringIO.new ARGV*"\0"
-ARGV.clear
-
-Hexagony.run(ARGF.read, 0, input)


### PR DESCRIPTION
It can run my Pangram Grep solution in under 1 second, instead of over 7 seconds.

It also enables debug output when using the ` character, which goes to standard error so that it doesn't interfere with output checking.