### PR TITLE
Fix Grammarly extension appearing in ng editor

### DIFF
--- a/views/js/hole-ng.js
+++ b/views/js/hole-ng.js
@@ -3,7 +3,7 @@ import { EditorView, EditorState, extensions, languages } from '/editor.js';
 const langs  = JSON.parse(document.querySelector('#langs').innerText);
 const select = document.querySelector('select');
 const editor = new EditorView({ parent: document.querySelector('#editor') });
-editor.contentDOM.setAttribute("data-gramm", false);
+editor.contentDOM.setAttribute("data-gramm", "false"); // Disable Grammarly
 
 // Switch Lang
 const switchLang = onhashchange = () => {

--- a/views/js/hole-ng.js
+++ b/views/js/hole-ng.js
@@ -3,6 +3,7 @@ import { EditorView, EditorState, extensions, languages } from '/editor.js';
 const langs  = JSON.parse(document.querySelector('#langs').innerText);
 const select = document.querySelector('select');
 const editor = new EditorView({ parent: document.querySelector('#editor') });
+editor.contentDOM.setAttribute("data-gramm", false);
 
 // Switch Lang
 const switchLang = onhashchange = () => {


### PR DESCRIPTION
Grammarly is a browser extension whose purpose is to aid in writing texts. It's not meant to be used in coding, but the new editor doesn't disable it by default. This commit disables the extension manually.

# Before (Grammarly enabled)
![ng-grammarly-before](https://user-images.githubusercontent.com/36775845/111063977-40bf6280-84ba-11eb-863f-39b238e79d4d.png)

# After (Grammarly disabled)
![ng-grammarly-after](https://user-images.githubusercontent.com/36775845/111063978-43ba5300-84ba-11eb-9c5f-b9487fc3b795.png)
