### PR TITLE
Show beat scores and previous records in Discord record announcements

### DIFF
--- a/db/a-schema.sql
+++ b/db/a-schema.sql
@@ -49,6 +49,13 @@ CREATE TABLE code (
     EXCLUDE USING hash(code WITH =)
 );
 
+CREATE TABLE discord_records (
+    hole    hole NOT NULL,
+    lang    lang NOT NULL,
+    message text NOT NULL,
+    PRIMARY KEY(hole, lang)
+);
+
 CREATE TABLE ideas (
     id          int  NOT NULL PRIMARY KEY,
     thumbs_down int  NOT NULL,
@@ -171,12 +178,13 @@ CREATE ROLE "code-golf" WITH LOGIN;
 -- Only owners can refresh.
 ALTER MATERIALIZED VIEW medals OWNER TO "code-golf";
 
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE    code         TO "code-golf";
-GRANT SELECT                         ON SEQUENCE code_id_seq  TO "code-golf";
-GRANT SELECT, INSERT, TRUNCATE       ON TABLE    ideas        TO "code-golf";
-GRANT SELECT                         ON TABLE    bytes_points TO "code-golf";
-GRANT SELECT                         ON TABLE    chars_points TO "code-golf";
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE    sessions     TO "code-golf";
-GRANT SELECT, INSERT, UPDATE         ON TABLE    solutions    TO "code-golf";
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE    trophies     TO "code-golf";
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE    users        TO "code-golf";
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE    code            TO "code-golf";
+GRANT SELECT, INSERT, UPDATE         ON TABLE    discord_records TO "code-golf";
+GRANT SELECT                         ON SEQUENCE code_id_seq     TO "code-golf";
+GRANT SELECT, INSERT, TRUNCATE       ON TABLE    ideas           TO "code-golf";
+GRANT SELECT                         ON TABLE    bytes_points    TO "code-golf";
+GRANT SELECT                         ON TABLE    chars_points    TO "code-golf";
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE    sessions        TO "code-golf";
+GRANT SELECT, INSERT, UPDATE         ON TABLE    solutions       TO "code-golf";
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE    trophies        TO "code-golf";
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE    users           TO "code-golf";

--- a/discord/bot.go
+++ b/discord/bot.go
@@ -66,9 +66,9 @@ func recAnnounceToEmbed(announce *RecAnnouncement) *discordgo.MessageEmbed {
 	fieldValues := make(map[string]string)
 	for _, pair := range announce.Updates {
 		for _, update := range pair {
-			if update.From.Strokes.Valid {
+			if update.Beat.Valid {
 				if fieldValues[update.Scoring] == "" {
-					fieldValues[update.Scoring] = pretty.Comma(int(update.From.Strokes.Int64))
+					fieldValues[update.Scoring] = pretty.Comma(int(update.Beat.Int64))
 				}
 				fieldValues[update.Scoring] += "  →  "
 			}

--- a/discord/bot.go
+++ b/discord/bot.go
@@ -1,6 +1,7 @@
 package discord
 
 import (
+	"database/sql"
 	"fmt"
 	"log"
 	"os"
@@ -99,7 +100,7 @@ func recAnnounceToEmbed(announce *RecAnnouncement) *discordgo.MessageEmbed {
 
 // LogNewRecord logs a record breaking solution in Discord.
 func LogNewRecord(
-	golfer *Golfer.Golfer, hole hole.Hole, lang lang.Lang, updates []Golfer.RankUpdate,
+	golfer *Golfer.Golfer, hole hole.Hole, lang lang.Lang, updates []Golfer.RankUpdate, db *sql.DB,
 ) {
 	if bot == nil {
 		return
@@ -126,8 +127,37 @@ func LogNewRecord(
 		}
 	}
 
-	if newMessage, err := bot.ChannelMessageSendEmbed(channelID, recAnnounceToEmbed(announcement)); err != nil {
+	var prevMessage string
+	var newMessage *discordgo.Message
+	var sendErr error
+
+	if err := db.QueryRow(
+		`SELECT message FROM discord_records WHERE hole = $1 AND lang = $2`,
+		hole.ID, lang.ID,
+	).Scan(&prevMessage); err != nil {
+		newMessage, sendErr = bot.ChannelMessageSendEmbed(channelID, recAnnounceToEmbed(announcement))
+	} else {
+		newMessage, sendErr = bot.ChannelMessageSendComplex(channelID, &discordgo.MessageSend{
+			Embed: recAnnounceToEmbed(announcement),
+			Reference: &discordgo.MessageReference{
+				MessageID: prevMessage,
+				ChannelID: channelID,
+			},
+		})
+	}
+
+	if _, err := db.Query(
+		`INSERT INTO discord_records (hole, lang, message) VALUES
+			($1, $2, $3)
+			ON CONFLICT ON CONSTRAINT discord_records_pkey
+			DO UPDATE SET message = $3`,
+		hole.ID, lang.ID, newMessage.ID,
+	); err != nil {
 		log.Println(err)
+	}
+
+	if sendErr != nil {
+		log.Println(sendErr)
 	} else {
 		lastAnnouncement = announcement
 		lastAnnouncement.Message = newMessage

--- a/golfer/golfer.go
+++ b/golfer/golfer.go
@@ -60,6 +60,7 @@ type RankUpdate struct {
 		Joint         null.Bool
 		Rank, Strokes null.Int
 	}
+	Beat null.Int
 }
 
 func GetInfo(db *sql.DB, name string) *GolferInfo {

--- a/routes/solution.go
+++ b/routes/solution.go
@@ -88,8 +88,10 @@ func Solution(w http.ResponseWriter, r *http.Request) {
 			`SELECT earned,
 			        old_bytes_joint, old_bytes_rank, old_bytes,
 			        new_bytes_joint, new_bytes_rank, new_bytes,
+					beat_bytes,
 			        old_chars_joint, old_chars_rank, old_chars,
-			        new_chars_joint, new_chars_rank, new_chars
+			        new_chars_joint, new_chars_rank, new_chars,
+					beat_chars
 			   FROM save_solution(code := $1, hole := $2, lang := $3, user_id := $4)`,
 			in.Code, in.Hole, in.Lang, golfer.ID,
 		).Scan(
@@ -100,12 +102,14 @@ func Solution(w http.ResponseWriter, r *http.Request) {
 			&out.RankUpdates[0].To.Joint,
 			&out.RankUpdates[0].To.Rank,
 			&out.RankUpdates[0].To.Strokes,
+			&out.RankUpdates[0].Beat,
 			&out.RankUpdates[1].From.Joint,
 			&out.RankUpdates[1].From.Rank,
 			&out.RankUpdates[1].From.Strokes,
 			&out.RankUpdates[1].To.Joint,
 			&out.RankUpdates[1].To.Rank,
 			&out.RankUpdates[1].To.Strokes,
+			&out.RankUpdates[1].Beat,
 		); err != nil {
 			panic(err)
 		}

--- a/routes/solution.go
+++ b/routes/solution.go
@@ -154,7 +154,7 @@ func Solution(w http.ResponseWriter, r *http.Request) {
 		// If any of the updates are record breakers, announce them on Discord
 		if len(recordUpdates) > 0 {
 			go discord.LogNewRecord(
-				golfer, hole.ByID[in.Hole], lang.ByID[in.Lang], recordUpdates,
+				golfer, hole.ByID[in.Hole], lang.ByID[in.Lang], recordUpdates, db,
 			)
 		}
 


### PR DESCRIPTION
Previously, a Discord record announcement displayed the golfer's previous score followed by their new score. If their previous score was higher than that of the last record-holder, the change in scores could be misinterpreted. This PR fixes this by instead displaying the score of the previous record-holder.

The second commit allows the bot to link to previous record announcements corresponding to the same hole/lang combination, creating chains of record breakers. The message IDs are stored in the `discord_records` table on the database.