### PR TITLE
Display bytes/chars instead of points on compact /rankings/holes

### DIFF
--- a/views/css/rankings/holes.css
+++ b/views/css/rankings/holes.css
@@ -1,5 +1,7 @@
 @media (max-width: 34rem) {
-    td:nth-child(4) { border-right: 1px solid var(--color) }
+    .one-hole  td:nth-child(5),
+    .all-holes td:nth-child(4) { border-right: 1px solid var(--color) }
 
-    tr > :nth-child(n+5) { display: none }
+    .one-hole  tr > :nth-child(2n+4),
+    .all-holes tr > :nth-child(n+5) { display: none }
 }

--- a/views/rankings/holes.html
+++ b/views/rankings/holes.html
@@ -74,7 +74,7 @@
     {{ end }}
     </nav>
 
-    <table class="nowrap-second sticky">
+    <table class="nowrap-second sticky {{ if eq .Data.HoleID "all" }}all-holes{{ else }}one-hole{{ end }}">
         <thead>
             <tr>
                 <th>#


### PR DESCRIPTION
Only when a hole is selected.
"All Holes" page remains unchanged.

Before:
![before](https://user-images.githubusercontent.com/31797752/113912052-85f65c00-97fc-11eb-9c38-6fce4e5d5a22.png)

After:
![after](https://user-images.githubusercontent.com/31797752/113912064-8989e300-97fc-11eb-8666-f56783e28692.png)