### PR TITLE
Mark assets/include/vendor as vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+assets/includes/vendor/* linguist-vendored


### PR DESCRIPTION
As documented at https://github.com/github/linguist/blob/master/docs/overrides.md, this excludes `assets/include/vendor` from linguist stats, which makes the project show up as go language on github.

Example:
![image](https://user-images.githubusercontent.com/2089783/116667354-6dcec280-a9df-11eb-9d47-08e133bff77c.png)
