### PR TITLE
Add Assembly lang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ live:
 	    --read-only                       \
 	    --restart      always             \
 	    --security-opt seccomp:unconfined \
+	    --ulimit       core=-1            \
 	    --volume       certs:/certs       \
 	    codegolf/code-golf &&             \
 	    docker system prune -f"

--- a/db/b-functions.sql
+++ b/db/b-functions.sql
@@ -58,81 +58,93 @@ BEGIN
     -- Ensure we're the only one messing with solutions.
     LOCK TABLE solutions IN EXCLUSIVE MODE;
 
-    rank                := hole_rank(hole, lang, 'bytes', user_id);
-    ret.old_bytes       := rank.strokes;
-    ret.old_bytes_joint := rank.joint;
-    ret.old_bytes_rank  := rank.rank;
+    IF bytes IS NOT NULL THEN
+        rank                := hole_rank(hole, lang, 'bytes', user_id);
+        ret.old_bytes       := rank.strokes;
+        ret.old_bytes_joint := rank.joint;
+        ret.old_bytes_rank  := rank.rank;
+    END IF;
 
-    rank                := hole_rank(hole, lang, 'chars', user_id);
-    ret.old_chars       := rank.strokes;
-    ret.old_chars_joint := rank.joint;
-    ret.old_chars_rank  := rank.rank;
+    IF chars IS NOT NULL THEN
+        rank                := hole_rank(hole, lang, 'chars', user_id);
+        ret.old_chars       := rank.strokes;
+        ret.old_chars_joint := rank.joint;
+        ret.old_chars_rank  := rank.rank;
+    END IF;
 
     -- Update the code if it's the same length or less, but only update the
     -- submitted time if the solution is shorter. This avoids a user moving
     -- down the leaderboard by matching their personal best.
-    INSERT INTO solutions (bytes, chars, code, hole, lang, scoring, user_id)
-         VALUES           (bytes, chars, code, hole, lang, 'bytes', user_id)
-    ON CONFLICT ON CONSTRAINT solutions_pkey
-    DO UPDATE SET failing = false,
-                    bytes = CASE
-                    WHEN solutions.failing OR excluded.bytes <= solutions.bytes
-                    THEN excluded.bytes ELSE solutions.bytes END,
-                    chars = CASE
-                    WHEN solutions.failing OR excluded.bytes <= solutions.bytes
-                    THEN excluded.chars ELSE solutions.chars END,
-                     code = CASE
-                    WHEN solutions.failing OR excluded.bytes <= solutions.bytes
-                    THEN excluded.code ELSE solutions.code END,
-                submitted = CASE
-                    WHEN solutions.failing OR excluded.bytes < solutions.bytes
-                    THEN excluded.submitted ELSE solutions.submitted END;
-
-    INSERT INTO solutions (bytes, chars, code, hole, lang, scoring, user_id)
-         VALUES           (bytes, chars, code, hole, lang, 'chars', user_id)
-    ON CONFLICT ON CONSTRAINT solutions_pkey
-    DO UPDATE SET failing = false,
-                    bytes = CASE
-                    WHEN solutions.failing OR excluded.chars <= solutions.chars
-                    THEN excluded.bytes ELSE solutions.bytes END,
-                    chars = CASE
-                    WHEN solutions.failing OR excluded.chars <= solutions.chars
-                    THEN excluded.chars ELSE solutions.chars END,
-                     code = CASE
-                    WHEN solutions.failing OR excluded.chars <= solutions.chars
-                    THEN excluded.code ELSE solutions.code END,
-                submitted = CASE
-                    WHEN solutions.failing OR excluded.chars < solutions.chars
-                    THEN excluded.submitted ELSE solutions.submitted END;
-
-    rank                := hole_rank(hole, lang, 'bytes', user_id);
-    ret.new_bytes       := rank.strokes;
-    ret.new_bytes_joint := rank.joint;
-    ret.new_bytes_rank  := rank.rank;
-
-    rank                := hole_rank(hole, lang, 'chars', user_id);
-    ret.new_chars       := rank.strokes;
-    ret.new_chars_joint := rank.joint;
-    ret.new_chars_rank  := rank.rank;
-
-    IF ret.new_bytes_rank = ret.old_bytes_rank THEN
-        ret.beat_bytes = ret.old_bytes;
-    ELSE
-        SELECT MIN(solutions.bytes) INTO ret.beat_bytes
-          FROM solutions
-         WHERE solutions.hole  = hole
-           AND solutions.lang  = lang
-           AND solutions.bytes > bytes;
+    IF bytes IS NOT NULL THEN
+        INSERT INTO solutions (bytes, chars, code, hole, lang, scoring, user_id)
+            VALUES           (bytes, chars, code, hole, lang, 'bytes', user_id)
+        ON CONFLICT ON CONSTRAINT solutions_pkey
+        DO UPDATE SET failing = false,
+                        bytes = CASE
+                        WHEN solutions.failing OR excluded.bytes <= solutions.bytes
+                        THEN excluded.bytes ELSE solutions.bytes END,
+                        chars = CASE
+                        WHEN solutions.failing OR excluded.bytes <= solutions.bytes
+                        THEN excluded.chars ELSE solutions.chars END,
+                        code = CASE
+                        WHEN solutions.failing OR excluded.bytes <= solutions.bytes
+                        THEN excluded.code ELSE solutions.code END,
+                    submitted = CASE
+                        WHEN solutions.failing OR excluded.bytes < solutions.bytes
+                        THEN excluded.submitted ELSE solutions.submitted END;
     END IF;
 
-    IF ret.new_chars_rank = ret.old_chars_rank THEN
-        ret.beat_chars = ret.old_chars;
-    ELSE
-        SELECT MIN(solutions.chars) INTO ret.beat_chars
-          FROM solutions
-         WHERE solutions.hole  = hole
-           AND solutions.lang  = lang
-           AND solutions.chars > chars;
+    IF chars IS NOT NULL THEN
+        INSERT INTO solutions (bytes, chars, code, hole, lang, scoring, user_id)
+            VALUES           (bytes, chars, code, hole, lang, 'chars', user_id)
+        ON CONFLICT ON CONSTRAINT solutions_pkey
+        DO UPDATE SET failing = false,
+                        bytes = CASE
+                        WHEN solutions.failing OR excluded.chars <= solutions.chars
+                        THEN excluded.bytes ELSE solutions.bytes END,
+                        chars = CASE
+                        WHEN solutions.failing OR excluded.chars <= solutions.chars
+                        THEN excluded.chars ELSE solutions.chars END,
+                        code = CASE
+                        WHEN solutions.failing OR excluded.chars <= solutions.chars
+                        THEN excluded.code ELSE solutions.code END,
+                    submitted = CASE
+                        WHEN solutions.failing OR excluded.chars < solutions.chars
+                        THEN excluded.submitted ELSE solutions.submitted END;
+    END IF;
+
+    IF bytes IS NOT NULL THEN
+        rank                := hole_rank(hole, lang, 'bytes', user_id);
+        ret.new_bytes       := rank.strokes;
+        ret.new_bytes_joint := rank.joint;
+        ret.new_bytes_rank  := rank.rank;
+
+        IF ret.new_bytes_rank = ret.old_bytes_rank THEN
+            ret.beat_bytes = ret.old_bytes;
+        ELSE
+            SELECT MIN(solutions.bytes) INTO ret.beat_bytes
+            FROM solutions
+            WHERE solutions.hole  = hole
+            AND solutions.lang  = lang
+            AND solutions.bytes > bytes;
+        END IF;
+    END IF;
+
+    IF chars IS NOT NULL THEN
+        rank                := hole_rank(hole, lang, 'chars', user_id);
+        ret.new_chars       := rank.strokes;
+        ret.new_chars_joint := rank.joint;
+        ret.new_chars_rank  := rank.rank;
+
+        IF ret.new_chars_rank = ret.old_chars_rank THEN
+            ret.beat_chars = ret.old_chars;
+        ELSE
+            SELECT MIN(solutions.chars) INTO ret.beat_chars
+            FROM solutions
+            WHERE solutions.hole  = hole
+            AND solutions.lang  = lang
+            AND solutions.chars > chars;
+        END IF;
     END IF;
 
     -- Earn cheevos.

--- a/docker/core.yml
+++ b/docker/core.yml
@@ -12,6 +12,8 @@ services:
       PGUSER:    code-golf
     pids_limit: 1024
     privileged: true
+    ulimits:
+      core: -1
     volumes:
       - ..:/go
   db:

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -41,5 +41,8 @@ COPY run-lang.c ./
 
 RUN gcc -Wall -Werror -Wextra -o /usr/bin/run-lang -s -static run-lang.c
 
+CMD \
+# Redirect core dumps to /tmp/core, for Assembly error analysis
+sysctl -w kernel.core_pattern="/tmp/core" && \
 # reflex reruns a command when files change.
-CMD reflex -sd none -r '\.(css|go|html|js|pem|svg|toml)$' -R '_test\.go$' -- go run -tags dev .
+reflex -sd none -r '\.(css|go|html|js|pem|svg|toml)$' -R '_test\.go$' -- go run -tags dev .

--- a/docker/live.Dockerfile
+++ b/docker/live.Dockerfile
@@ -55,4 +55,7 @@ COPY --from=0 /usr/bin/run-lang                  /usr/bin/
 COPY --from=0 /usr/share/zoneinfo                /usr/share/zoneinfo/
 COPY          /views                             /views/
 
-CMD ["/code-golf"]
+CMD \
+# Redirect core dumps to /tmp/core, for Assembly error analysis
+sysctl -w kernel.core_pattern="/tmp/core" && \
+/code-golf

--- a/hole/play.go
+++ b/hole/play.go
@@ -13,6 +13,8 @@ import (
 	"syscall"
 	"time"
 	"unicode"
+
+	"gopkg.in/guregu/null.v4"
 )
 
 const timeout = 7 * time.Second
@@ -30,7 +32,7 @@ type Scorecard struct {
 }
 
 type Solution struct {
-	Bytes, Chars int
+	Bytes, Chars null.Int
 	Code         string
 	Hole         string
 	Lang         string
@@ -219,10 +221,13 @@ func Play(ctx context.Context, solution *Solution) (score Scorecard) {
 
 	// Actual byte count is printed by the assembler
 	if langID == "assembly" {
-		if _, err := fmt.Fscanf(asmSizeRead, "%d", &solution.Bytes); err != nil {
+		var bytesNum int64
+		if _, err := fmt.Fscanf(asmSizeRead, "%d", &bytesNum); err != nil {
 			panic(err)
 		}
 		asmSizeRead.Close()
+		solution.Bytes.SetValid(bytesNum)
+		solution.Chars.Valid = false
 	}
 
 	// Trim trailing whitespace.

--- a/langs.toml
+++ b/langs.toml
@@ -19,7 +19,7 @@ v               ~<
 
 [Assembly]
 size    = '48.7 MiB'
-version = '1.3.3'
+version = '1.3.4'
 website = 'https://github.com/NewDefectus/defAsm'
 example = '''
 # Printing

--- a/langs/assembly/Dockerfile
+++ b/langs/assembly/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:16.1.0-alpine3.13 as builder
 
-ENV VERSION=1.3.3
+ENV VERSION=1.3.4
 
 RUN mkdir /empty
 

--- a/langs/assembly/Dockerfile
+++ b/langs/assembly/Dockerfile
@@ -15,4 +15,5 @@ FROM scratch
 COPY --from=0 /lib/ld-musl-x86_64.so.1 /lib/
 COPY --from=0 /empty                   /proc
 COPY --from=0 /empty                   /tmp
+COPY --from=0 /sbin/sysctl             /sbin/
 COPY --from=0 /defasm                  /usr/bin/

--- a/package-lock.json
+++ b/package-lock.json
@@ -271,9 +271,9 @@
       }
     },
     "node_modules/@defasm/codemirror": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@defasm/codemirror/-/codemirror-1.1.0.tgz",
-      "integrity": "sha512-ErXHeaW1F+tYmuqNQpu2nyvN1NBMQdjBQtIkhi5CPrpqzJoviUTaBi3cXkZZLX2fJD/q/sKLqMtdeBZh45qj/w==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@defasm/codemirror/-/codemirror-1.1.1.tgz",
+      "integrity": "sha512-an6FvEPAb9XyD4d4XhkfFWxumkdAEIqhyws/kPRCLHna9LjaDW1P05AfYqvczxwcEkU5V4s5hgdaL5jFIMqIrw==",
       "dependencies": {
         "@codemirror/highlight": "",
         "@codemirror/language": "",
@@ -284,9 +284,9 @@
       }
     },
     "node_modules/@defasm/core": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@defasm/core/-/core-1.3.3.tgz",
-      "integrity": "sha512-LANRu2lJQSNpCyyZDwh50v7Q0G/p70RFZs6EFM1t+JPHSH7ip337bNs4PXNv6gEEeWfHoFYVTqIGwc98/TKQ8g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@defasm/core/-/core-1.3.4.tgz",
+      "integrity": "sha512-rurzg84paSLK1qy+KuBx5a+c6e/45ZHLsNwm4kp2CWEI8h+iMyrP1D5mvP8qCajYQiI9y6D0nhk5CmX61g9FNA==",
       "bin": {
         "defasm": "main.js"
       }
@@ -625,9 +625,9 @@
       }
     },
     "@defasm/codemirror": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@defasm/codemirror/-/codemirror-1.1.0.tgz",
-      "integrity": "sha512-ErXHeaW1F+tYmuqNQpu2nyvN1NBMQdjBQtIkhi5CPrpqzJoviUTaBi3cXkZZLX2fJD/q/sKLqMtdeBZh45qj/w==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@defasm/codemirror/-/codemirror-1.1.1.tgz",
+      "integrity": "sha512-an6FvEPAb9XyD4d4XhkfFWxumkdAEIqhyws/kPRCLHna9LjaDW1P05AfYqvczxwcEkU5V4s5hgdaL5jFIMqIrw==",
       "requires": {
         "@codemirror/highlight": "",
         "@codemirror/language": "",
@@ -638,9 +638,9 @@
       }
     },
     "@defasm/core": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@defasm/core/-/core-1.3.3.tgz",
-      "integrity": "sha512-LANRu2lJQSNpCyyZDwh50v7Q0G/p70RFZs6EFM1t+JPHSH7ip337bNs4PXNv6gEEeWfHoFYVTqIGwc98/TKQ8g=="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@defasm/core/-/core-1.3.4.tgz",
+      "integrity": "sha512-rurzg84paSLK1qy+KuBx5a+c6e/45ZHLsNwm4kp2CWEI8h+iMyrP1D5mvP8qCajYQiI9y6D0nhk5CmX61g9FNA=="
     },
     "crelt": {
       "version": "1.0.5",

--- a/public/editor.js
+++ b/public/editor.js
@@ -12674,7 +12674,8 @@ function parseNumber(asFloat = false) {
       throw new ParserError("Expected value, got none");
     if (token[0] === "'" && token[token.length - 1] === "'") {
       let string3 = unescapeString(token);
-      for (let i = 0; i < string3.length; i++) {
+      let i = string3.length;
+      while (i--) {
         value <<= asFloat ? 8 : 8n;
         value += asFloat ? string3.charCodeAt(i) : BigInt(string3.charCodeAt(i));
       }
@@ -14431,7 +14432,7 @@ conditionals.forEach((names, i) => {
     hex(112 + i) + " jb",
     hex(3968 + i) + " jl"
   ];
-  mnemonics["cmov" + firstName] = [hex(3904 + i) + " Rwlq"];
+  mnemonics["cmov" + firstName] = [hex(3904 + i) + " r Rwlq"];
   mnemonics["set" + firstName] = [hex(3984 + i) + ".0 rB"];
   names.forEach((name2) => {
     mnemonics["j" + name2] = ["#j" + firstName];
@@ -19976,7 +19977,7 @@ var Snippet = class {
       while (m = /[#$]\{(?:(\d+)(?::([^}]*))?|([^}]*))\}/.exec(line)) {
         let seq = m[1] ? +m[1] : null, name2 = m[2] || m[3], found = -1;
         for (let i = 0; i < fields.length; i++) {
-          if (seq != null ? fields[i].seq == seq : name2 ? fields[i].name == name2 : false)
+          if (name2 ? fields[i].name == name2 : seq != null && fields[i].seq == seq)
             found = i;
         }
         if (found < 0) {
@@ -19985,9 +19986,6 @@ var Snippet = class {
             i++;
           fields.splice(i, 0, { seq, name: name2 || null });
           found = i;
-          for (let pos of positions)
-            if (pos.field >= found)
-              pos.field++;
         }
         positions.push(new FieldPos(found, lines2.length, m.index, m.index + name2.length));
         line = line.slice(0, m.index) + name2 + line.slice(m.index + m[0].length);
@@ -20057,15 +20055,9 @@ function snippet(template2) {
     if (ranges.length)
       spec.selection = fieldSelection(ranges, 0);
     if (ranges.length > 1) {
-      let active = new ActiveSnippet(ranges, 0);
-      let effects = spec.effects = [setActive.of(active)];
+      let effects = spec.effects = [setActive.of(new ActiveSnippet(ranges, 0))];
       if (editor.state.field(snippetState, false) === void 0)
-        effects.push(StateEffect.appendConfig.of([
-          snippetState.init(() => active),
-          addSnippetKeymap,
-          snippetPointerHandler,
-          baseTheme5
-        ]));
+        effects.push(StateEffect.appendConfig.of([snippetState, addSnippetKeymap, snippetPointerHandler, baseTheme5]));
     }
     editor.dispatch(editor.state.update(spec));
   };

--- a/routes/admin_solutions.go
+++ b/routes/admin_solutions.go
@@ -57,7 +57,11 @@ func AdminSolutionsRun(w http.ResponseWriter, r *http.Request) {
 
 				// Best of three runs.
 				for j := 0; passes < 2 && fails < 2; j++ {
-					score := hole.Play(r.Context(), s.HoleID, s.LangID, s.code)
+					score := hole.Play(r.Context(), &hole.Solution{
+						Hole: s.HoleID,
+						Lang: s.LangID,
+						Code: s.code,
+					})
 
 					s.Took = score.Took
 

--- a/routes/solution.go
+++ b/routes/solution.go
@@ -94,7 +94,7 @@ func Solution(w http.ResponseWriter, r *http.Request) {
 		ToFile:   "Out",
 	})
 
-	if out.Pass && golfer != nil && !experimental && in.Lang != "assembly" {
+	if out.Pass && golfer != nil && !experimental {
 		if err := db.QueryRowContext(
 			r.Context(),
 			`SELECT earned,

--- a/routes/solution.go
+++ b/routes/solution.go
@@ -27,8 +27,8 @@ func Solution(w http.ResponseWriter, r *http.Request) {
 	}
 	defer r.Body.Close()
 
-	in.Bytes = len(in.Code)
-	in.Chars = len([]rune(in.Code))
+	in.Bytes.SetValid(int64(len(in.Code)))
+	in.Chars.SetValid(int64(len([]rune(in.Code))))
 
 	experimental := false
 	if _, ok := hole.ByID[in.Hole]; !ok {
@@ -222,11 +222,11 @@ func Solution(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// FIXME Each one of these queries takes 50ms!
-		if queryBool(
+		if in.Chars.Valid && queryBool(
 			db,
 			"SELECT chars_points > 9000 FROM chars_points WHERE user_id = $1",
 			golfer.ID,
-		) || queryBool(
+		) || in.Bytes.Valid && queryBool(
 			db,
 			"SELECT bytes_points > 9000 FROM bytes_points WHERE user_id = $1",
 			golfer.ID,

--- a/views/hole-ng.html
+++ b/views/hole-ng.html
@@ -73,7 +73,6 @@
     </section>
 
     <div class="info assembly">
-        Assembly is in beta and as such no solutions will be saved.
         Compiled from
         <a href=//www.wikibooks.org/wiki/X86_Assembly/GAS_Syntax>
             AT&T syntax</a> to x86-64 Linux. Use

--- a/views/hole.html
+++ b/views/hole.html
@@ -67,7 +67,6 @@
         <div id=editor></div>
     </div>
     <div class="info assembly">
-        Assembly is in beta and as such no solutions will be saved.
         Compiled from
         <a href=//www.wikibooks.org/wiki/X86_Assembly/GAS_Syntax>
             AT&T syntax</a> to x86-64 Linux. Use


### PR DESCRIPTION
i.e. *Complete* Assembly lang, since it is currently partially implemented.

This PR consists of some minor tweaks to allow defasm to run properly, as well as some changes to the database structure - specifically that bytes and chars are no longer generated columns (so that bytes can be determined by defasm's output), and that they are nullable (so that in Assembly's case, solutions don't have a char count).

Assembly will remain available only on the ng editor, but solutions can be properly saved and recorded.

For testing purposes, here is an example Assembly solution for Pangram Grep:
```mov 8(%rsp), %rsi
prePangram:
push %rsi
mov $0,%rbx

pangramLoop:
xor %rcx, %rcx
lodsb
cmp $1, %al
jb postPangram
sub $64, %al
jc pangramLoop

xchg %eax, %ecx
cltd
mov $32, %dl
rol %cl, %edx
or %edx, %ebx
jnc pangramLoop

postPangram:
add $64, %ebx
jnc endPostPangram

push %rsi
inc %al
sub %rax, %rsi
addb $10, (%rsi)
pop %rdx
pop %rsi
push %rdx
sub %esi, %edx
push %rax
pop %rdi
syscall
pop %rsi
endPostPangram: jnz prePangram
```