### PR TITLE
Merge bytes/chars record announcements on Discord when they are identical

### DIFF
--- a/discord/bot.go
+++ b/discord/bot.go
@@ -64,7 +64,6 @@ func recAnnounceToEmbed(announce *RecAnnouncement) *discordgo.MessageEmbed {
 	}
 
 	// Now, we fill out the fields according to the updates of the announcement
-
 	fieldValues := make(map[string]string)
 	for _, pair := range announce.Updates {
 		for _, update := range pair {
@@ -78,8 +77,11 @@ func recAnnounceToEmbed(announce *RecAnnouncement) *discordgo.MessageEmbed {
 		}
 	}
 
+	if fieldValues["bytes"] == fieldValues["chars"] {
+		fieldValues = map[string]string{"bytes/chars": fieldValues["bytes"]}
+	}
 	// We iterate over the scorings rather than the map itself so that the order will be guaranteed
-	for _, scoring := range []string{"bytes", "chars"} {
+	for _, scoring := range []string{"bytes", "chars", "bytes/chars"} {
 		if fieldValues[scoring] != "" {
 			embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
 				Name:   strings.Title(scoring),


### PR DESCRIPTION
This is to prevent repeating the same record progression if it's identical for both chars and bytes (which is usually the case).
![image](https://user-images.githubusercontent.com/36775845/118338798-b3cb7080-b51f-11eb-9004-2ad0c5e0703b.png)
