### PR TITLE
Disable bracket matching/line wrapping on certain langs in /ng

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -86,19 +86,21 @@ const defaultTheme = EditorView.theme({
 }, { dark: false });
 
 export const defaultExtensions = [
-    EditorView.lineWrapping,
-    bracketMatching(),
-    closeBrackets(),
     defaultHighlightStyle,
     defaultTheme,
     history(),
     indentOnInput(),
     keymap.of([
-        ...closeBracketsKeymap, defaultTabBinding,
-        ...historyKeymap, ...standardKeymap,
+        defaultTabBinding, ...historyKeymap, ...standardKeymap,
     ]),
     lineNumbers(),
 ];
+
+export const bracketExtensions = [
+    bracketMatching(),
+    closeBrackets(),
+    keymap.of(closeBracketsKeymap)
+]
 
 export const languages = {
     'assembly':   assembly(),

--- a/public/editor.js
+++ b/public/editor.js
@@ -23915,20 +23915,21 @@ var defaultTheme = EditorView.theme({
   ".cm-asm-error-tooltip": asmErrorTooltip
 }, { dark: false });
 var defaultExtensions = [
-  EditorView.lineWrapping,
-  bracketMatching(),
-  closeBrackets(),
   defaultHighlightStyle,
   defaultTheme,
   history(),
   indentOnInput(),
   keymap.of([
-    ...closeBracketsKeymap,
     defaultTabBinding,
     ...historyKeymap,
     ...standardKeymap
   ]),
   lineNumbers()
+];
+var bracketExtensions = [
+  bracketMatching(),
+  closeBrackets(),
+  keymap.of(closeBracketsKeymap)
 ];
 var languages = {
   "assembly": assembly(),
@@ -23961,6 +23962,7 @@ export {
   EditorState,
   EditorView,
   export_LZString as LZString,
+  bracketExtensions,
   darkThemeExtensions,
   defaultExtensions,
   languages

--- a/views/js/hole-ng.js
+++ b/views/js/hole-ng.js
@@ -1,6 +1,6 @@
 // TODO Set #rankings height to editor on expand/shrink.
 
-import { darkThemeExtensions, defaultExtensions, EditorView, EditorState, languages, LZString } from '/editor.js';
+import { bracketExtensions, darkThemeExtensions, defaultExtensions, EditorView, EditorState, languages, LZString } from '/editor.js';
 
 let lang;
 let result = {};
@@ -127,7 +127,11 @@ const switchLang = onhashchange = () => {
     editor.setState(
         EditorState.create({
             doc:        solutions[lang]?.[scoring] ?? langs[lang].example,
-            extensions: [...extensions, languages[lang] || []],
+            extensions: [
+                ['brainfuck', 'fish', 'j', 'hexagony'].includes(lang) ? [] : bracketExtensions,
+                ['assembly', 'fish', 'hexagony'].includes(lang) ? [] : EditorView.lineWrapping,
+                ...extensions,
+                languages[lang] || []],
         }),
     );
 


### PR DESCRIPTION
This is behavior present in the current editor but not yet ported to the new one. Also added Assembly and Hexagony as languages that don't need line wrapping (the former because the byte dumps can become misaligned, the latter because it's a 2D language).