### PR TITLE
Add info box regarding ARGV for brainfuck

### DIFF
--- a/views/hole.html
+++ b/views/hole.html
@@ -75,6 +75,9 @@
         For accurate byte counts and syntax highlighting, please use the
         <a href="/ng/{{ .Data.Hole.ID }}#assembly">new editor</a>.
     </div>
+    <div class="info brainfuck">
+        ARGV is available via STDIN, joined on NULL.
+    </div>
     <div class="info c-sharp">
         <a href=//devblogs.microsoft.com/dotnet/welcome-to-c-9-0/#top-level-programs>
             Top-level programs</a> are supported, <b>args</b> holds ARGV.

--- a/views/hole.html
+++ b/views/hole.html
@@ -76,7 +76,7 @@
         <a href="/ng/{{ .Data.Hole.ID }}#assembly">new editor</a>.
     </div>
     <div class="info brainfuck">
-        ARGV is available via STDIN, joined on NULL.
+        ARGV is available via STDIN, delimited by NULL.
     </div>
     <div class="info c-sharp">
         <a href=//devblogs.microsoft.com/dotnet/welcome-to-c-9-0/#top-level-programs>


### PR DESCRIPTION
I copied the info box from from ><> because brainfuck was missing one.