### PR TITLE
Fix the input encoding for ><> and Hexagony

### DIFF
--- a/hole/play.go
+++ b/hole/play.go
@@ -161,14 +161,12 @@ func Play(ctx context.Context, holeID, langID, code string) (score Scorecard) {
 	// Args
 	switch langID {
 	// FIXME brainfuck and fish should be consistent.
-	case "brainfuck":
+	case "brainfuck", "fish":
 		args := ""
 		for _, arg := range score.Args {
 			args += arg + "\x00"
 		}
 		cmd.Stdin = strings.NewReader(args)
-	case "fish":
-		cmd.Stdin = strings.NewReader(strings.Join(score.Args, "\x00"))
 	default:
 		cmd.Args = append(cmd.Args, score.Args...)
 	}

--- a/hole/play.go
+++ b/hole/play.go
@@ -161,7 +161,7 @@ func Play(ctx context.Context, holeID, langID, code string) (score Scorecard) {
 	// Args
 	switch langID {
 	// FIXME brainfuck and fish should be consistent.
-	case "brainfuck", "fish":
+	case "brainfuck", "fish", "hexagony":
 		args := ""
 		for _, arg := range score.Args {
 			args += arg + "\x00"

--- a/views/hole.html
+++ b/views/hole.html
@@ -75,15 +75,18 @@
         For accurate byte counts and syntax highlighting, please use the
         <a href="/ng/{{ .Data.Hole.ID }}#assembly">new editor</a>.
     </div>
+    <div class="info brainfuck">
+        ARGV is available via STDIN, each argument is NULL terminated. EOF is -1, cells left of the starting cell are supported and cells are 8-bit with wrapping.
+    </div>
     <div class="info c-sharp">
         <a href=//devblogs.microsoft.com/dotnet/welcome-to-c-9-0/#top-level-programs>
             Top-level programs</a> are supported, <b>args</b> holds ARGV.
     </div>
     <div class="info fish">
-        ARGV is available via STDIN, joined on NULL. <b>x</b> is a no-op.
+        ARGV is available via STDIN, each argument is NULL terminated. <b>x</b> is a no-op.
     </div>
     <div class="info hexagony">
-        ARGV is available via STDIN, joined on NULL.
+        ARGV is available via STDIN, each argument is NULL terminated.
     </div>
     <div class="info javascript">
         <b>arguments</b> holds ARGV, <b>print()</b> to output with a newline,


### PR DESCRIPTION
This switches the input encoding for ><> and hexagony to be null delimited (so an example input would be "arg1\0arg2\0" instead of "arg1\0arg2"). This will unfortunately invalidate a lot of ><> and hexagony solutions that take input, but it's worth it to be more consistent with brainfuck. Luckily there aren't too many of these, and they are mostly by the same users.