### PR TITLE
Update language dockerfiles to be easier to run.

### DIFF
--- a/hole/play.go
+++ b/hole/play.go
@@ -143,11 +143,12 @@ func Play(ctx context.Context, holeID, langID, code string) (score Scorecard) {
 	case "julia":
 		cmd.Args = []string{"/usr/bin/run-julia", "/tmp/code.jl"}
 	case "powershell":
-		cmd.Args = []string{"/interpreter/Interpreter"}
+		cmd.Args = []string{"/interpreter/Interpreter", "-"}
 
 		// Require explicit output for Quine to prevent trivial solutions.
 		if holeID == "quine" {
-			cmd.Args = append(cmd.Args, "--explicit")
+			cmd.Args[1] = "--explicit"
+			cmd.Args = append(cmd.Args, "-")
 		}
 	case "python":
 		// Force the stdout and stderr streams to be unbuffered.

--- a/langs/assembly/Dockerfile
+++ b/langs/assembly/Dockerfile
@@ -16,3 +16,5 @@ COPY --from=0 /lib/ld-musl-x86_64.so.1 /lib/
 COPY --from=0 /empty                   /proc
 COPY --from=0 /empty                   /tmp
 COPY --from=0 /defasm                  /usr/bin/
+
+ENTRYPOINT ["/usr/bin/defasm"]

--- a/langs/bash/Dockerfile
+++ b/langs/bash/Dockerfile
@@ -28,4 +28,6 @@ COPY --from=0 /empty         /proc
 COPY --from=0 /empty         /tmp
 COPY --from=0 /bash-5.1/bash /usr/bin/
 
-ENTRYPOINT ["bash", "-c", "echo ${BASH_VERSION%\\([0-9]\\)-release}"]
+ENTRYPOINT ["bash"]
+
+CMD ["-c", "echo ${BASH_VERSION%\\([0-9]\\)-release}"]

--- a/langs/brainfuck/Dockerfile
+++ b/langs/brainfuck/Dockerfile
@@ -21,3 +21,5 @@ FROM scratch
 COPY --from=0 /empty    /proc
 COPY --from=0 /empty    /tmp
 COPY --from=0 /bf-jit-c /usr/bin/brainfuck
+
+ENTRYPOINT ["/usr/bin/brainfuck"]

--- a/langs/c-sharp/Dockerfile
+++ b/langs/c-sharp/Dockerfile
@@ -21,4 +21,6 @@ COPY --from=0 /empty                   /tmp
 COPY --from=0 /usr/lib                 /usr/lib/
 COPY --from=0 /compiler                /compiler/
 
-ENTRYPOINT ["/compiler/Compiler", "--version"]
+ENTRYPOINT ["/compiler/Compiler"]
+
+CMD ["--version"]

--- a/langs/c/Dockerfile
+++ b/langs/c/Dockerfile
@@ -60,4 +60,6 @@ COPY --from=0 /usr/include/bits          /usr/include/bits/
 COPY --from=0 /usr/lib/libc.so           /usr/lib/
 COPY --from=0 /usr/lib/tcc/libtcc1.a     /usr/lib/tcc/
 
-ENTRYPOINT ["tcc", "-v"]
+ENTRYPOINT ["tcc"]
+
+CMD ["-v"]

--- a/langs/cobol/Dockerfile
+++ b/langs/cobol/Dockerfile
@@ -32,4 +32,6 @@ COPY --from=0 /usr/include/gmp.h    \
 COPY --from=0 /usr/include/libcob   /usr/include/libcob
 COPY --from=0 /usr/share/gnucobol   /usr/share/gnucobol
 
-ENTRYPOINT ["cobc", "--version"]
+ENTRYPOINT ["/usr/bin/cobol"]
+
+CMD ["--version"]

--- a/langs/cobol/cobol.c
+++ b/langs/cobol/cobol.c
@@ -5,6 +5,12 @@
 #include <unistd.h>
 
 int main (int argc, char *argv[]) {
+    if (argc > 1 && strcmp(argv[1], "--version") == 0) {
+        execv("/usr/bin/cobc", argv);
+        perror("execv");
+        return 0;
+    }
+
     pid_t pid = fork();
     if (!pid) {
         execl("/usr/bin/cobc", "/usr/bin/cobc", "-CFxo", "/tmp/code.c", "-", NULL);

--- a/langs/crystal/Dockerfile
+++ b/langs/crystal/Dockerfile
@@ -7,6 +7,8 @@ RUN mkdir /empty /mydev             \
 
 FROM scratch
 
+ENV CRYSTAL_CACHE_DIR=/tmp PATH=/usr/bin:/bin
+
 COPY --from=0 /bin   /bin
 COPY --from=0 /mydev /dev
 COPY --from=0 /lib   /lib
@@ -14,4 +16,6 @@ COPY --from=0 /empty /proc
 COPY --from=0 /empty /tmp
 COPY --from=0 /usr   /usr
 
-ENTRYPOINT ["crystal", "-v"]
+ENTRYPOINT ["crystal"]
+
+CMD ["-v"]

--- a/langs/f-sharp/Dockerfile
+++ b/langs/f-sharp/Dockerfile
@@ -28,4 +28,6 @@ COPY --from=0 /empty                   /tmp
 COPY --from=0 /usr/lib                 /usr/lib/
 COPY --from=0 /compiler                /compiler/
 
-ENTRYPOINT ["/compiler/Compiler", "--version"]
+ENTRYPOINT ["/compiler/Compiler"]
+
+CMD ["--version"]

--- a/langs/fish/Dockerfile
+++ b/langs/fish/Dockerfile
@@ -21,3 +21,5 @@ FROM scratch
 COPY --from=0 /empty      /proc
 COPY --from=0 /empty      /tmp
 COPY --from=0 /fish-jit-c /usr/bin/fish
+
+ENTRYPOINT ["/usr/bin/fish", "--no-prng", "-u"]

--- a/langs/fortran/Dockerfile
+++ b/langs/fortran/Dockerfile
@@ -70,4 +70,6 @@ COPY --from=0 /empty                        /tmp
 
 COPY fortran /usr/bin/
 
-ENTRYPOINT ["gfortran", "--version"]
+ENTRYPOINT ["fortran"]
+
+CMD ["--version"]

--- a/langs/fortran/fortran
+++ b/langs/fortran/fortran
@@ -1,5 +1,10 @@
 #!/bin/sh -e
 
+if [ "$1" = "--version" ]; then
+    /usr/local/bin/gfortran --version
+    exit 0
+fi
+
 # Compile
 cat - > /tmp/code.f90
 /usr/local/bin/gfortran -fbackslash -o /tmp/code /tmp/code.f90

--- a/langs/go/Dockerfile
+++ b/langs/go/Dockerfile
@@ -15,4 +15,6 @@ COPY --from=0 /usr/local/go/pkg/tool/linux_amd64/compile \
 
 COPY go /usr/bin/go
 
-ENTRYPOINT ["/usr/local/go/bin/go", "version"]
+ENTRYPOINT ["/usr/bin/go"]
+
+CMD ["version"]

--- a/langs/go/go
+++ b/langs/go/go
@@ -1,5 +1,10 @@
 #!/bin/sh -e
 
+if [ "$1" = "version" ]; then
+    /usr/local/go/bin/go version
+    exit 0
+fi
+
 # Separate compile and link relies on environment variables less than "go run" does.
 # "go run" also doesn't support reading the file from stdin.
 shift

--- a/langs/haskell/Dockerfile
+++ b/langs/haskell/Dockerfile
@@ -43,4 +43,6 @@ COPY --from=0 /usr/lib                 /usr/lib
 
 COPY haskell /usr/bin/
 
-ENTRYPOINT ["ghc", "--version"]
+ENTRYPOINT ["/usr/bin/haskell"]
+
+CMD ["--version"]

--- a/langs/haskell/haskell
+++ b/langs/haskell/haskell
@@ -1,5 +1,10 @@
 #!/bin/sh -e
 
+if [ "$1" = "--version" ]; then
+    /usr/bin/ghc --version
+    exit 0
+fi
+
 cat - > /tmp/code.hs
 
 exec /usr/bin/runghc /tmp/code.hs "$@"

--- a/langs/j/Dockerfile
+++ b/langs/j/Dockerfile
@@ -30,4 +30,6 @@ COPY --from=0 /j                                \
               /jsource/bin/linux/j64/jconsole   \
               /jsource/bin/linux/j64/libj.so    /usr/bin/
 
-ENTRYPOINT ["j", "-v"]
+ENTRYPOINT ["j"]
+
+CMD ["-v"]

--- a/langs/java/Dockerfile
+++ b/langs/java/Dockerfile
@@ -30,4 +30,6 @@ COPY --from=1 /usr/lib/libncursesw.so.6 \
 
 COPY java /usr/bin/
 
-ENTRYPOINT ["/opt/jdk/bin/java", "--version"]
+ENTRYPOINT ["/usr/bin/java"]
+
+CMD ["--version"]

--- a/langs/java/java
+++ b/langs/java/java
@@ -1,5 +1,10 @@
 #!/bin/bash -e
 
+if [ "$1" = "--version" ]; then
+    /opt/jdk/bin/java --version
+    exit 0
+fi
+
 export LC_ALL=C.UTF-8
 
 cd /tmp

--- a/langs/javascript/Dockerfile
+++ b/langs/javascript/Dockerfile
@@ -37,4 +37,6 @@ COPY --from=0 /empty                                /proc
 COPY --from=0 /empty                                /tmp
 COPY --from=0 /v8/out/d8                            /usr/bin/
 
-ENTRYPOINT ["/usr/bin/d8", "-v"]
+ENTRYPOINT ["/usr/bin/d8"]
+
+CMD ["-v"]

--- a/langs/julia/Dockerfile
+++ b/langs/julia/Dockerfile
@@ -37,4 +37,6 @@ COPY --from=0 /usr/lib/libbrotlicommon.so.1 \
               /usr/lib/libssl.so.1.1        \
               /usr/lib/libstdc++.so.6       /usr/lib/
 
-ENTRYPOINT ["julia", "-e", "println(VERSION)"]
+ENTRYPOINT ["/usr/bin/run-julia"]
+
+CMD ["-e", "println(VERSION)"]

--- a/langs/julia/julia.c
+++ b/langs/julia/julia.c
@@ -3,6 +3,13 @@
 #include <unistd.h>
 
 int main (int argc, char *argv[]) {
+    if (argc > 1 && strcmp(argv[1], "-e") == 0) {
+        // Support printing the version number.
+        execv("/usr/bin/julia", argv);
+        perror("execv");
+        return 0;
+    }
+
     char buffer[4096];
     ssize_t nbytes;
     FILE *fp = fopen("/tmp/code.jl", "w");

--- a/langs/lisp/Dockerfile
+++ b/langs/lisp/Dockerfile
@@ -25,4 +25,6 @@ COPY --from=0 /empty                   /tmp
 COPY --from=0 /usr/bin/clisp           /usr/bin/lisp
 COPY --from=0 /usr/lib/clisp-2.49.92   /usr/lib/clisp-2.49.92
 
-ENTRYPOINT ["lisp", "--version"]
+ENTRYPOINT ["lisp"]
+
+CMD ["--version"]

--- a/langs/lua/Dockerfile
+++ b/langs/lua/Dockerfile
@@ -20,4 +20,6 @@ COPY --from=0 /empty             /proc
 COPY --from=0 /empty             /tmp
 COPY --from=0 /lua-5.4.3/src/lua /usr/bin/
 
-ENTRYPOINT ["lua", "-v"]
+ENTRYPOINT ["lua"]
+
+CMD ["-v"]

--- a/langs/nim/Dockerfile
+++ b/langs/nim/Dockerfile
@@ -34,4 +34,6 @@ COPY --from=0 /usr/lib/crt1.o          \
 COPY --from=0 /usr/lib/nim             /usr/lib/nim/
 COPY --from=0 /usr/lib/tcc             /usr/lib/tcc/
 
-ENTRYPOINT ["nim", "-v"]
+ENTRYPOINT ["nim"]
+
+CMD ["-v"]

--- a/langs/perl/Dockerfile
+++ b/langs/perl/Dockerfile
@@ -46,4 +46,6 @@ COPY --from=0 /perl/lib/File/Glob.pm   /usr/lib/perl/File/
 COPY --from=0 /perl/lib/auto/File/Glob/Glob.so \
           /usr/lib/perl/auto/File/Glob/
 
-ENTRYPOINT ["perl", "-e", "say substr $^V, 1"]
+ENTRYPOINT ["perl"]
+
+CMD ["-e", "say substr $^V, 1"]

--- a/langs/php/Dockerfile
+++ b/langs/php/Dockerfile
@@ -28,4 +28,6 @@ COPY --from=0 /empty           /tmp
 COPY --from=0 /usr/bin/php     /usr/bin/
 COPY --from=0 /usr/lib/php.ini /usr/lib/
 
-ENTRYPOINT ["php", "-r", "echo phpversion();"]
+ENTRYPOINT ["php"]
+
+CMD ["-r", "echo phpversion();"]

--- a/langs/powershell/Dockerfile
+++ b/langs/powershell/Dockerfile
@@ -29,4 +29,6 @@ COPY --from=0 /empty                   /tmp
 COPY --from=0 /usr/lib                 /usr/lib/
 COPY --from=0 /interpreter             /interpreter/
 
-ENTRYPOINT ["/interpreter/Interpreter", "--version"]
+ENTRYPOINT ["/interpreter/Interpreter"]
+
+CMD ["--version"]

--- a/langs/powershell/Interpreter.cs
+++ b/langs/powershell/Interpreter.cs
@@ -24,7 +24,7 @@ class Program
 			args = args[1..];
 		}
 
-		return Run(Console.In.ReadToEnd(), args, requireExplicitOutput);
+		return Run(Console.In.ReadToEnd(), args[1..], requireExplicitOutput);
 	}
 
 	static int Run(string code, string[] args, bool requireExplicitOutput)

--- a/langs/python/Dockerfile
+++ b/langs/python/Dockerfile
@@ -29,4 +29,6 @@ COPY --from=0 /empty                   /tmp
 COPY --from=0 /usr/bin/python3.9       /usr/bin/python
 COPY --from=0 /usr/lib/python3.9       /usr/lib/python3.9
 
-ENTRYPOINT ["python", "-c", "import platform;print(platform.python_version())"]
+ENTRYPOINT ["python"]
+
+CMD ["-c", "import platform;print(platform.python_version())"]

--- a/langs/raku/Dockerfile
+++ b/langs/raku/Dockerfile
@@ -29,4 +29,6 @@ COPY --from=0 /usr/share/nqp           /usr/share/nqp
 COPY --from=0 /usr/share/perl6/lib     /usr/share/perl6/lib
 COPY --from=0 /usr/share/perl6/runtime /usr/share/perl6/runtime
 
-ENTRYPOINT ["raku", "-v"]
+ENTRYPOINT ["raku"]
+
+CMD ["-v"]

--- a/langs/ruby/Dockerfile
+++ b/langs/ruby/Dockerfile
@@ -60,4 +60,6 @@ COPY --from=0 /empty                   /tmp
 COPY --from=0 /usr/bin/ruby            /usr/bin/
 COPY --from=0 /usr/lib/ruby/3.0.0      /usr/lib/ruby/3.0.0
 
-ENTRYPOINT ["ruby", "-e", "puts RUBY_VERSION"]
+ENTRYPOINT ["ruby"]
+
+CMD ["-e", "puts RUBY_VERSION"]

--- a/langs/rust/Dockerfile
+++ b/langs/rust/Dockerfile
@@ -39,4 +39,6 @@ COPY --from=0 /usr/x86_64-alpine-linux-musl /usr/x86_64-alpine-linux-musl
 
 COPY rust /usr/bin/
 
-ENTRYPOINT ["/usr/local/cargo/bin/rustc", "--version"]
+ENTRYPOINT ["/usr/bin/rust"]
+
+CMD ["--version"]

--- a/langs/rust/rust
+++ b/langs/rust/rust
@@ -1,5 +1,10 @@
 #!/bin/sh -e
 
+if [ "$1" = "--version" ]; then
+    /usr/local/cargo/bin/rustc --version
+    exit 0
+fi
+
 export CARGO_HOME=/usr/local/cargo
 export RUST_BACKTRACE=1
 export RUSTUP_HOME=/usr/local/rustup

--- a/langs/sql/Dockerfile
+++ b/langs/sql/Dockerfile
@@ -18,4 +18,6 @@ COPY --from=0 /empty /proc
 COPY --from=0 /empty /tmp
 COPY --from=0 /sql   /usr/bin/
 
-ENTRYPOINT ["sql", "-v"]
+ENTRYPOINT ["sql"]
+
+CMD ["-v"]

--- a/langs/swift/Dockerfile
+++ b/langs/swift/Dockerfile
@@ -24,4 +24,6 @@ COPY --from=0 /      /
 COPY --from=0 /empty /proc
 COPY --from=0 /empty /tmp
 
-ENTRYPOINT ["swift", "--version"]
+ENTRYPOINT ["swift"]
+
+CMD ["--version"]

--- a/langs/v/Dockerfile
+++ b/langs/v/Dockerfile
@@ -27,4 +27,6 @@ COPY --from=1 /usr   /usr
 
 COPY v /usr/bin/
 
-CMD ["/opt/v/v", "version"]
+ENTRYPOINT ["/usr/bin/v"]
+
+CMD ["version"]

--- a/langs/v/v
+++ b/langs/v/v
@@ -1,5 +1,10 @@
 #!/bin/sh -e
 
+if [ "$1" = "version" ]; then
+    /opt/v/v version
+    exit 0
+fi
+
 export VMODULES=/tmp
 
 # FIXME Setting VVV=/opt/v doesn't prevent the need to cd.

--- a/langs/zig/Dockerfile
+++ b/langs/zig/Dockerfile
@@ -23,4 +23,6 @@ COPY --from=0 /zig-linux-x86_64-0.8.0/lib /usr/local/lib/
 
 COPY zig /usr/bin/
 
-ENTRYPOINT ["/usr/local/bin/zig", "version"]
+ENTRYPOINT ["/usr/bin/zig"]
+
+CMD ["version"]

--- a/langs/zig/zig
+++ b/langs/zig/zig
@@ -1,5 +1,10 @@
 #!/bin/sh -e
 
+if [ "$1" = "version" ]; then
+    /usr/local/bin/zig version
+    exit 0
+fi
+
 cd /tmp
 
 # Compile


### PR DESCRIPTION
Split up the ENTRYPOINT, so that ENTRYPOINT is the program to run the code and CMD is the default parameters, to obtain the version number.
When you run with no arguments, it prints the version number.
When you provide arguments, they replace the default arguments to get the version number.
Users can now use the containers like this:
docker run --rm -i codegolf/lang-ruby - < golf1.rb

Instead of needing to override the entrypoint:
docker run --rm -i --entrypoint /usr/bin/ruby codegolf/lang-ruby - < golf1.rb

For PowerShell, I had to add an - argument to get it to suppress the default --version argument when running the container from the command line.