### PR TITLE
Revert a recent change to hole.js, because it was incorrect.

### DIFF
--- a/js/hole.js
+++ b/js/hole.js
@@ -100,10 +100,7 @@ onload = () => {
             startOpen: true,
             multiLineStrings: lang == 'c', // TCC supports multi-line strings
         });
-
-        // In some cases, setting the code to its current value can lead to auto-saved code being removed from localStorage.
-        if (cm.getValue() != code)
-            cm.setValue(code);
+        cm.setValue(code);
 
         refreshScores();
 
@@ -279,8 +276,10 @@ async function refreshScores() {
 
     // Only show the solution picker when both solutions are actually used.
     if (code0 && code1 && code0 != code1 || autoSave0 && autoSave1 && autoSave0 != autoSave1 ||
-        (code0 && autoSave1 && code0 != autoSave1) ||
-        (autoSave0 && code1 && autoSave0 != code1)) {
+        // If a logged in user has an auto-saved solution for the other metric, that they have not
+        // submitted since logging in, they must be allowed to switch to it, so they can submit it.
+        (solution == 0 && code0 && autoSave1 && code0 != autoSave1) ||
+        (solution == 1 && autoSave0 && code1 && autoSave0 != code1)) {
         for (let i = 0; i < scorings.length; i++) {
             let name = `Fewest ${scorings[i]}`;
 

--- a/t/hole-logged-in.t
+++ b/t/hole-logged-in.t
@@ -4,7 +4,7 @@
 use hole;
 use t;
 
-plan 12;
+plan 15;
 
 sub createUserAndSession {
     my $dbh = dbh;
@@ -14,7 +14,7 @@ sub createUserAndSession {
 }
 
 subtest 'Successful solutions are loaded from the database on reload.' => {
-    plan 3;
+    plan 5;
     my $wd = HoleWebDriver.create;
     LEAVE $wd.delete-session;
     $wd.loadFizzBuzz;
@@ -25,15 +25,17 @@ subtest 'Successful solutions are loaded from the database on reload.' => {
     $wd.isBytesAndChars: 57, 55;
     $wd.run;
     $wd.isPassing;
+    $wd.isSolutionPickerState: '';
     # Clear local storage just to prove that it's not required.
     $wd.clearLocalStorage;
     $wd.loadFizzBuzz;
     $wd.getLangLink('Raku').click;
     $wd.isBytesAndChars: 57, 55, 'The byte count should be the same after reloading the page.';
+    $wd.isSolutionPickerState: '', 'after clearing localStorage and reloading the page.';
 }
 
 subtest 'Untested solutions are loaded from localStorage on reload.' => {
-    plan 3;
+    plan 5;
     my $wd = HoleWebDriver.create;
     LEAVE $wd.delete-session;
     $wd.loadFizzBuzz;
@@ -44,13 +46,16 @@ subtest 'Untested solutions are loaded from localStorage on reload.' => {
     $wd.isBytesAndChars: 3, 3;
     $wd.loadFizzBuzz;
     $wd.isBytesAndChars: 3, 3, 'The byte count should be the same after reloading the page.';
+    $wd.isSolutionPickerState: '';
     $wd.clearLocalStorage;
     $wd.loadFizzBuzz;
+    $wd.getLangLink('Raku').click;
     $wd.isBytesAndChars: 0, 0, 'Untested solutions should not be preserved, after clearing localStorage.';
+    $wd.isSolutionPickerState: '', 'after clearing localStorage and reloading the page.';
 }
 
 subtest 'Failing solutions are loaded from localStorage on reload.' => {
-    plan 4;
+    plan 5;
     my $wd = HoleWebDriver.create;
     LEAVE $wd.delete-session;
     $wd.loadFizzBuzz;
@@ -65,7 +70,9 @@ subtest 'Failing solutions are loaded from localStorage on reload.' => {
     $wd.isBytesAndChars: 3, 3, 'The byte count should be the same after reloading the page.';
     $wd.clearLocalStorage;
     $wd.loadFizzBuzz;
+    $wd.getLangLink('Raku').click;
     $wd.isBytesAndChars: 0, 0, 'Failing solutions should not be preserved, after clearing localStorage.';
+    $wd.isSolutionPickerState: '', 'after clearing localStorage and reloading the page.';
 }
 
 subtest 'The solution picker appears automatically, switching to bytes, and is independent of the scoring.' => {
@@ -80,13 +87,13 @@ subtest 'The solution picker appears automatically, switching to bytes, and is i
     $wd.isBytesAndChars: 210, 88;
     $wd.run;
     $wd.isPassing;
-    is $wd.getSolutionPickerState, '', "The solution picker shouldn't be visible, because a single solution optimizes both metrics.";
+    $wd.isSolutionPickerState: '';
     is $wd.getScoringPickerState, 'bytes', "The scoring should be the default, bytes.";
     $wd.typeCode: BACKSPACE x 88 ~ $python121_121;
     $wd.isBytesAndChars: 121, 121;
     $wd.run;
     $wd.isPassing;
-    is $wd.getSolutionPickerState, 'bytes', 'The bytes solution should be active, because the submitted solution optimized that criteria.';
+    $wd.isSolutionPickerState: 'bytes';
     is $wd.getScoringPickerState, 'bytes', "The scoring should be the default, bytes.";
 }
 
@@ -102,13 +109,13 @@ subtest 'The solution picker appears automatically, switching to chars, and is i
     $wd.isBytesAndChars: 121, 121;
     $wd.run;
     $wd.isPassing;
-    is $wd.getSolutionPickerState, '', "The solution picker shouldn't be visible, because a single solution optimizes both metrics.";
+    $wd.isSolutionPickerState: '';
     is $wd.getScoringPickerState, 'bytes', "The scoring should be the default, bytes.";
     $wd.typeCode: BACKSPACE x 121 ~ $python210_88;
     $wd.isBytesAndChars: 210, 88;
     $wd.run;
     $wd.isPassing;
-    is $wd.getSolutionPickerState, 'chars', 'The chars solution should be active, because the submitted solution optimized that criteria.';
+    $wd.isSolutionPickerState: 'chars';
     is $wd.getScoringPickerState, 'bytes', "The scoring should be the default, bytes.";
 }
 
@@ -128,15 +135,15 @@ subtest 'The user can choose from bytes and chars solutions, independently of th
     $wd.isBytesAndChars: 210, 88;
     $wd.run;
     $wd.isPassing;
-    is $wd.getSolutionPickerState, 'chars', 'The chars solution should be active, because the submitted solution optimized that criteria.';
+    $wd.isSolutionPickerState: 'chars';
     is $wd.getScoringPickerState, 'bytes', "The scoring should be the default, bytes.";
     $wd.isBytesAndChars: 210, 88;
     $wd.setSolution: 'bytes';
-    is $wd.getSolutionPickerState, 'bytes', 'The bytes solution should still be active, after reloading the page.';
+    $wd.isSolutionPickerState: 'bytes', 'after reloading the page.';
     is $wd.getScoringPickerState, 'bytes', "The scoring should be the default, bytes.";
     $wd.isBytesAndChars: 121, 121;
     $wd.setSolution: 'chars';
-    is $wd.getSolutionPickerState, 'chars', 'The chars solution should be active, because the submitted solution optimized that criteria.';
+    $wd.isSolutionPickerState: 'chars', 'after switching solutions.';
     is $wd.getScoringPickerState, 'bytes', "The scoring should be the default, bytes.";
     $wd.isBytesAndChars: 210, 88;
 }
@@ -157,12 +164,12 @@ subtest 'The solution picker disappears automatically.' => {
     $wd.isBytesAndChars: 210, 88;
     $wd.run;
     $wd.isPassing;
-    is $wd.getSolutionPickerState, 'chars', 'The chars solution should be active, because the submitted solution optimized that criteria.';
+    $wd.isSolutionPickerState: 'chars';
     $wd.typeCode: BACKSPACE x 88 ~ $python62_62;
     $wd.isBytesAndChars: 62, 62;
     $wd.run;
     $wd.isPassing;
-    is $wd.getSolutionPickerState, '', "The solution picker shouldn't be visible, because a single solution once again optimizes both metrics.";
+    $wd.isSolutionPickerState: '';
 }
 
 subtest 'Different bytes and chars solutions, and the active solution, are loaded from the database on reload.' => {
@@ -182,32 +189,33 @@ subtest 'Different bytes and chars solutions, and the active solution, are loade
     $wd.isBytesAndChars: 210, 88;
     $wd.run;
     $wd.isPassing;
-    is $wd.getSolutionPickerState, 'chars', 'The chars solution should be active, because the submitted solution optimized that criteria.';
+    $wd.isSolutionPickerState: 'chars';
     $wd.loadFizzBuzz;
-    is $wd.getSolutionPickerState, 'chars', 'The chars solution should still be active, after reloading the page.';
+    $wd.isSolutionPickerState: 'chars', 'after reloading the page.';
     $wd.isBytesAndChars: 210, 88;
     $wd.setSolution: 'bytes';
-    is $wd.getSolutionPickerState, 'bytes', 'The bytes solution should be active, after selecting it.';
+    $wd.isSolutionPickerState: 'bytes', 'after switching solutions.';
     $wd.isBytesAndChars: 121, 121;
     $wd.loadFizzBuzz;
-    is $wd.getSolutionPickerState, 'bytes', 'The bytes solution should still be active, after reloading the page.';
+    $wd.isSolutionPickerState: 'bytes', 'after reloading the page.';
     $wd.isBytesAndChars: 121, 121;
     # Clear local storage just to prove that it's not required.
     $wd.clearLocalStorage;
     $wd.loadFizzBuzz;
     $wd.getLangLink('Python').click;
-    is $wd.getSolutionPickerState, 'bytes', 'The bytes solution should be active, by default, after clearing localStorage and reloading the page.';
+    $wd.isSolutionPickerState: 'bytes', 'after clearing localStorage and reloading the page.';
     $wd.isBytesAndChars: 121, 121;
     $wd.setSolution: 'chars';
-    is $wd.getSolutionPickerState, 'chars', 'The chars solution should be active, after selecting it.';
+    $wd.isSolutionPickerState: 'chars', 'after switching solutions.';
     $wd.isBytesAndChars: 210, 88;
 }
 
-subtest 'Different bytes and chars solutions, submitted while not logged in, can be resubmitted once logged in.' => {
+# TODO: Add a variant that submits the two solutions in the opposite order.
+subtest 'After submitting different bytes and chars solutions while not logged in, users can submit both once logged in.' => {
     plan 15;
     my $wd = HoleWebDriver.create;
     LEAVE $wd.delete-session;
-    $wd.loadFizzBuzz; 
+    $wd.loadFizzBuzz;
     $wd.getLangLink('Python').click;
     $wd.typeCode: $python121_121;
     $wd.isBytesAndChars: 121, 121;
@@ -222,7 +230,7 @@ subtest 'Different bytes and chars solutions, submitted while not logged in, can
     $wd.setSessionCookie: createUserAndSession;
     $wd.loadFizzBuzz;
     $wd.isBytesAndChars: 210, 88;
-    is $wd.getSolutionPickerState, 'chars', 'The chars solution should be active, because the submitted solution optimized that criteria.';
+    $wd.isSolutionPickerState: 'chars';
     # Submit the solution as a logged-in user.
     $wd.run;
     $wd.isPassing;
@@ -230,7 +238,7 @@ subtest 'Different bytes and chars solutions, submitted while not logged in, can
     is $wd.alert-text, 'Your local copy of the code is different than the remote one. Do you want to restore the local version?', 'Confirm alert text';
     $wd.accept-alert;
     $wd.isBytesAndChars: 121, 121;
-    is $wd.getSolutionPickerState, 'bytes', 'The bytes solution should be active, after selecting it.';
+    is $wd.getSolutionPickerState, '', 'after submitting the first solution after logging in.';
     # Submit the solution as a logged-in user.
     $wd.run;
     $wd.isPassing;
@@ -238,15 +246,49 @@ subtest 'Different bytes and chars solutions, submitted while not logged in, can
     $wd.clearLocalStorage;
     $wd.loadFizzBuzz;
     $wd.getLangLink('Python').click;
-    is $wd.getSolutionPickerState, 'bytes', 'The bytes solution should be active, by default, after clearing localStorage and reloading the page.';
+    $wd.isSolutionPickerState: 'bytes', 'after clearing localStorage and reloading the page.';
     $wd.isBytesAndChars: 121, 121;
     $wd.setSolution: 'chars';
-    is $wd.getSolutionPickerState, 'chars', 'The chars solution should be active, after selecting it.';
+    $wd.isSolutionPickerState: 'chars', 'after switching solutions.';
     $wd.isBytesAndChars: 210, 88;
 }
 
+subtest 'After submitting different bytes and chars solutions while not logged in, users can submit one and discard the other once logged in.' => {
+    plan 12;
+    my $wd = HoleWebDriver.create;
+    LEAVE $wd.delete-session;
+    $wd.loadFizzBuzz;
+    $wd.getLangLink('Python').click;
+    $wd.typeCode: $python121_121;
+    $wd.isBytesAndChars: 121, 121;
+    $wd.run;
+    $wd.isPassing;
+    $wd.find('textarea').send-keys: BACKSPACE x 121;
+    $wd.typeCode: $python210_88;
+    $wd.isBytesAndChars: 210, 88;
+    $wd.run;
+    $wd.isPassing;
+    # Log in and reload the page.
+    $wd.setSessionCookie: createUserAndSession;
+    $wd.loadFizzBuzz;
+    $wd.isBytesAndChars: 210, 88;
+    $wd.isSolutionPickerState: 'chars';
+    # Submit the solution as a logged-in user.
+    $wd.run;
+    $wd.isPassing;
+    $wd.setSolution: 'bytes';
+    is $wd.alert-text, 'Your local copy of the code is different than the remote one. Do you want to restore the local version?', 'Confirm alert text';
+    $wd.dismiss-alert;
+    $wd.isBytesAndChars: 210, 88;
+    is $wd.getSolutionPickerState, '', 'after discarding the other solution.';
+    # Reload the page to verify that users aren't prompted to restore the solution again.
+    $wd.loadFizzBuzz;
+    $wd.isBytesAndChars: 210, 88, 'The byte count should be the same, after reloading the page.';
+    is $wd.getSolutionPickerState, '', 'after reloading the page.';
+}
+
 subtest 'Users can choose not to restore autosaved solutions.' => {
-    plan 6;
+    plan 11;
     my $wd = HoleWebDriver.create;
     LEAVE $wd.delete-session;
     $wd.loadFizzBuzz;
@@ -257,18 +299,25 @@ subtest 'Users can choose not to restore autosaved solutions.' => {
     $wd.isBytesAndChars: 57, 55;
     $wd.run;
     $wd.isPassing;
+    $wd.isSolutionPickerState: '';
     $wd.typeCode: BACKSPACE x 55 ~ 'abc';
     $wd.isBytesAndChars: 3, 3;
     $wd.run;
     $wd.isFailing;
+    $wd.isSolutionPickerState: '', 'after submitting failing solution.';
     $wd.loadFizzBuzz;
     is $wd.alert-text, 'Your local copy of the code is different than the remote one. Do you want to restore the local version?', 'Confirm alert text';
     $wd.dismiss-alert;
     $wd.isBytesAndChars: 57, 55;
+    $wd.isSolutionPickerState: '', 'after reloading the page.';
+    # Reload the page to verify that users aren't prompted to restore the solution again.
+    $wd.loadFizzBuzz;
+    $wd.isBytesAndChars: 57, 55;
+    $wd.isSolutionPickerState: '', 'after reloading the page.';
 }
 
 subtest 'Users can restore autosaved solutions.' => {
-    plan 6;
+    plan 9;
     my $wd = HoleWebDriver.create;
     LEAVE $wd.delete-session;
     $wd.loadFizzBuzz;
@@ -279,18 +328,21 @@ subtest 'Users can restore autosaved solutions.' => {
     $wd.isBytesAndChars: 57, 55;
     $wd.run;
     $wd.isPassing;
+    $wd.isSolutionPickerState: '';
     $wd.typeCode: BACKSPACE x 55 ~ 'abc';
     $wd.isBytesAndChars: 3, 3;
     $wd.run;
     $wd.isFailing;
+    $wd.isSolutionPickerState: '', 'after submitting failing solution.';
     $wd.loadFizzBuzz;
     is $wd.alert-text, 'Your local copy of the code is different than the remote one. Do you want to restore the local version?', 'Confirm alert text';
     $wd.accept-alert;
     $wd.isBytesAndChars: 3, 3;
+    $wd.isSolutionPickerState: '', 'after reloading the page.';
 }
 
 subtest 'If the user improves their solution on another browser, they are not prompted to restore their old one.' => {
-    plan 4;
+    plan 6;
     my $wd = HoleWebDriver.create;
     LEAVE $wd.delete-session;
     $wd.loadFizzBuzz;
@@ -302,8 +354,59 @@ subtest 'If the user improves their solution on another browser, they are not pr
     $wd.isBytesAndChars: 121, 121;
     $wd.run;
     $wd.isPassing;
+    $wd.isSolutionPickerState: '';
     # Improve the solution outside of this browser session.
     ok post-solution(:code($python62_62), :hole<fizz-buzz>, :lang<python>, :$session)<Pass>, 'Passes';
     $wd.loadFizzBuzz;
     $wd.isBytesAndChars: 62, 62, 'The byte count should be lower, after reloading the page.';
+    $wd.isSolutionPickerState: '', 'after reloading the page.';
+}
+
+subtest 'Unsaved changes are auto-saved.' => {
+    plan 7;
+    my $wd = HoleWebDriver.create;
+    LEAVE $wd.delete-session;
+    $wd.loadFizzBuzz;
+    my $session = createUserAndSession;
+    $wd.setSessionCookie: $session;
+    $wd.loadFizzBuzz;
+    $wd.getLangLink('Python').click;
+    $wd.typeCode: $python121_121;
+    $wd.isBytesAndChars: 121, 121;
+    $wd.run;
+    $wd.isPassing;
+    $wd.isSolutionPickerState: '';
+    # Type some code, but don't run it.
+    $wd.typeCode: "a";
+    $wd.isBytesAndChars: 122, 122;
+    $wd.loadFizzBuzz;
+    is $wd.alert-text, 'Your local copy of the code is different than the remote one. Do you want to restore the local version?', 'Confirm alert text';
+    $wd.accept-alert;
+    $wd.isBytesAndChars: 122, 122, 'The byte count should be the same, after reloading the page.';
+    $wd.isSolutionPickerState: '', 'after reloading the page.';
+}
+
+subtest 'If unsaved changes are manually reverted, the user is not prompted to restore them.' => {
+    plan 7;
+    my $wd = HoleWebDriver.create;
+    LEAVE $wd.delete-session;
+    $wd.loadFizzBuzz;
+    my $session = createUserAndSession;
+    $wd.setSessionCookie: $session;
+    $wd.loadFizzBuzz;
+    $wd.getLangLink('Python').click;
+    $wd.typeCode: $python121_121;
+    $wd.isBytesAndChars: 121, 121;
+    $wd.run;
+    $wd.isPassing;
+    $wd.isSolutionPickerState: '';
+    # Type some code, but don't run it.
+    $wd.typeCode: "a";
+    $wd.isBytesAndChars: 122, 122;
+    # Manually undo the code change.
+    $wd.typeCode: BACKSPACE;
+    $wd.isBytesAndChars: 121, 121;
+    $wd.loadFizzBuzz;
+    $wd.isBytesAndChars: 121, 121, 'The byte count should be the same, after reloading the page.';
+    $wd.isSolutionPickerState: '', 'after reloading the page.';
 }

--- a/t/hole-logged-out.t
+++ b/t/hole-logged-out.t
@@ -7,7 +7,7 @@ use hole;
 plan 8;
 
 subtest 'Successful solutions are loaded from localStorage on reload.' => {
-    plan 3;
+    plan 5;
     my $wd = HoleWebDriver.create;
     LEAVE $wd.delete-session;
     $wd.loadFizzBuzz;
@@ -16,13 +16,16 @@ subtest 'Successful solutions are loaded from localStorage on reload.' => {
     $wd.isBytesAndChars: 57, 55;
     $wd.run;
     $wd.isPassing;
+    $wd.isSolutionPickerState: '';
     $wd.clearLocalStorage;
     $wd.loadFizzBuzz;
+    $wd.getLangLink('Raku').click;
     $wd.isBytesAndChars: 0, 0, 'Solutions should not be preserved, after clearing localStorage.';
+    $wd.isSolutionPickerState: '';
 }
 
 subtest 'Untested solutions are loaded from localStorage on reload.' => {
-    plan 3;
+    plan 5;
     my $wd = HoleWebDriver.create;
     LEAVE $wd.delete-session;
     $wd.loadFizzBuzz;
@@ -31,13 +34,16 @@ subtest 'Untested solutions are loaded from localStorage on reload.' => {
     $wd.isBytesAndChars: 3, 3;
     $wd.loadFizzBuzz;
     $wd.isBytesAndChars: 3, 3, 'The byte count should be the same after reloading the page.';
+    $wd.isSolutionPickerState: '';
     $wd.clearLocalStorage;
     $wd.loadFizzBuzz;
+    $wd.getLangLink('Raku').click;
     $wd.isBytesAndChars: 0, 0, 'Untested solutions should not be preserved, after clearing localStorage.';
+    $wd.isSolutionPickerState: '', 'after clearing localStorage and reloading the page.';
 }
 
 subtest 'Failing solutions are loaded from localStorage on reload.' => {
-    plan 4;
+    plan 5;
     my $wd = HoleWebDriver.create;
     LEAVE $wd.delete-session;
     $wd.loadFizzBuzz;
@@ -50,7 +56,9 @@ subtest 'Failing solutions are loaded from localStorage on reload.' => {
     $wd.isBytesAndChars: 3, 3, 'The byte count should be the same after reloading the page.';
     $wd.clearLocalStorage;
     $wd.loadFizzBuzz;
+    $wd.getLangLink('Raku').click;
     $wd.isBytesAndChars: 0, 0, 'Failing solutions should not be preserved, after clearing localStorage.';
+    $wd.isSolutionPickerState: '', 'after clearing localStorage and reloading the page.';
 }
 
 subtest 'The solution picker appears automatically, switching to bytes, and is independent of the scoring.' => {
@@ -63,13 +71,13 @@ subtest 'The solution picker appears automatically, switching to bytes, and is i
     $wd.isBytesAndChars: 210, 88;
     $wd.run;
     $wd.isPassing;
-    is $wd.getSolutionPickerState, '', "The solution picker shouldn't be visible, because a single solution optimizes both metrics.";
+    $wd.isSolutionPickerState: '';
     is $wd.getScoringPickerState, 'bytes', "The scoring should be the default, bytes.";
     $wd.typeCode: BACKSPACE x 88 ~ $python121_121;
     $wd.isBytesAndChars: 121, 121;
     $wd.run;
     $wd.isPassing;
-    is $wd.getSolutionPickerState, 'bytes', 'The bytes solution should be active, because the submitted solution optimized that criteria.';
+    $wd.isSolutionPickerState: 'bytes';
     is $wd.getScoringPickerState, 'bytes', "The scoring should be the default, bytes.";
 }
 
@@ -83,13 +91,13 @@ subtest 'The solution picker appears automatically, switching to chars, and is i
     $wd.isBytesAndChars: 121, 121;
     $wd.run;
     $wd.isPassing;
-    is $wd.getSolutionPickerState, '', "The solution picker shouldn't be visible, because a single solution optimizes both metrics.";
+    $wd.isSolutionPickerState: '';
     is $wd.getScoringPickerState, 'bytes', "The scoring should be the default, bytes.";
     $wd.typeCode: BACKSPACE x 121 ~ $python210_88;
     $wd.isBytesAndChars: 210, 88;
     $wd.run;
     $wd.isPassing;
-    is $wd.getSolutionPickerState, 'chars', 'The chars solution should be active, because the submitted solution optimized that criteria.';
+    $wd.isSolutionPickerState: 'chars';
     is $wd.getScoringPickerState, 'bytes', "The scoring should be the default, bytes.";
 }
 
@@ -107,15 +115,15 @@ subtest 'The user can choose from bytes and chars solutions, independently of th
     $wd.isBytesAndChars: 210, 88;
     $wd.run;
     $wd.isPassing;
-    is $wd.getSolutionPickerState, 'chars', 'The chars solution should be active, because the submitted solution optimized that criteria.';
+    $wd.isSolutionPickerState: 'chars';
     is $wd.getScoringPickerState, 'bytes', "The scoring should be the default, bytes.";
     $wd.isBytesAndChars: 210, 88;
     $wd.setSolution: 'bytes';
-    is $wd.getSolutionPickerState, 'bytes', 'The bytes solution should still be active, after reloading the page.';
+    $wd.isSolutionPickerState: 'bytes', 'after reloading the page.';
     is $wd.getScoringPickerState, 'bytes', "The scoring should be the default, bytes.";
     $wd.isBytesAndChars: 121, 121;
     $wd.setSolution: 'chars';
-    is $wd.getSolutionPickerState, 'chars', 'The chars solution should be active, because the submitted solution optimized that criteria.';
+    $wd.isSolutionPickerState: 'chars', 'after switching solutions.';
     is $wd.getScoringPickerState, 'bytes', "The scoring should be the default, bytes.";
     $wd.isBytesAndChars: 210, 88;
 }
@@ -134,12 +142,12 @@ subtest 'The solution picker disappears automatically.' => {
     $wd.isBytesAndChars: 210, 88;
     $wd.run;
     $wd.isPassing;
-    is $wd.getSolutionPickerState, 'chars', 'The chars solution should be active, because the submitted solution optimized that criteria.';
+    $wd.isSolutionPickerState: 'chars';
     $wd.typeCode: BACKSPACE x 88 ~ $python62_62;
     $wd.isBytesAndChars: 62, 62;
     $wd.run;
     $wd.isPassing;
-    is $wd.getSolutionPickerState, '', "The solution picker shouldn't be visible, because a single solution once again optimizes both metrics.";
+    $wd.isSolutionPickerState: '';
 }
 
 subtest 'Different bytes and chars solutions, and the active solution, are loaded from localStorage on reload.' => {
@@ -157,14 +165,14 @@ subtest 'Different bytes and chars solutions, and the active solution, are loade
     $wd.isBytesAndChars: 210, 88;
     $wd.run;
     $wd.isPassing;
-    is $wd.getSolutionPickerState, 'chars', 'The chars solution should be active, because the submitted solution optimized that criteria.';
+    $wd.isSolutionPickerState: 'chars';
     $wd.loadFizzBuzz;
-    is $wd.getSolutionPickerState, 'chars', 'The chars solution should still be active, after reloading the page.';
+    $wd.isSolutionPickerState: 'chars', 'after reloading the page.';
     $wd.isBytesAndChars: 210, 88;
     $wd.setSolution: 'bytes';
-    is $wd.getSolutionPickerState, 'bytes', 'The bytes solution should be active, after selecting it.';
+    $wd.isSolutionPickerState: 'bytes', 'after switching solutions.';
     $wd.isBytesAndChars: 121, 121;
     $wd.loadFizzBuzz;
-    is $wd.getSolutionPickerState, 'bytes', 'The bytes solution should still be active, after reloading the page.';
+    $wd.isSolutionPickerState: 'bytes', 'after reloading the page.';
     $wd.isBytesAndChars: 121, 121;
 }

--- a/t/hole.rakumod
+++ b/t/hole.rakumod
@@ -109,6 +109,15 @@ class HoleWebDriver is WebDriver is export {
         flunk "Failed to find run results. $desc";
     }
 
+    # Methods whose names begin with "is" do exactly one assertion.
+    method isSolutionPickerState(Str:D $expectedState, Str:D $context = '') {
+        my $desc = $expectedState ??
+            "The $expectedState solution should be active" !!
+            "The solution picker shouldn't be visible, because a single solution optimizes both metrics";
+        $desc ~= $context ?? ", $context" !! '.';
+        is $.getSolutionPickerState, $expectedState, $desc;
+    }
+
     method loadFibonacci {
         $.get: 'https://app:1443/fibonacci';
     }


### PR DESCRIPTION
The recent change made the solution picker appear sometimes when it shouldn't. I have modified the tests to detect this.

After careful consideration, I have decided that the behavior before that change was actually correct and have modified the tests to explicitly require that behavior.

I also made some other improvements to the tests. For example, in tests 2 and 3 in hole-logged-in.t and 1-3 in hole-logged-out.t, the results of checking the byte count were misleading, because I hadn't switched back to Raku after clearing localStorage.