### PR TITLE
Prompt the user to restore their local solution at most once per language.

### DIFF
--- a/t/hole-logged-out.t
+++ b/t/hole-logged-out.t
@@ -20,8 +20,8 @@ subtest 'Successful solutions are loaded from localStorage on reload.' => {
     $wd.clearLocalStorage;
     $wd.loadFizzBuzz;
     $wd.getLangLink('Raku').click;
-    $wd.isBytesAndChars: 0, 0, 'Solutions should not be preserved, after clearing localStorage.';
-    $wd.isSolutionPickerState: '';
+    $wd.isBytesAndChars: 0, 0, 'after clearing localStorage and reloading the page.';
+    $wd.isSolutionPickerState: '', 'after clearing localStorage and reloading the page.';
 }
 
 subtest 'Untested solutions are loaded from localStorage on reload.' => {
@@ -33,12 +33,12 @@ subtest 'Untested solutions are loaded from localStorage on reload.' => {
     $wd.typeCode: 'abc';
     $wd.isBytesAndChars: 3, 3;
     $wd.loadFizzBuzz;
-    $wd.isBytesAndChars: 3, 3, 'The byte count should be the same after reloading the page.';
+    $wd.isBytesAndChars: 3, 3, 'after reloading the page.';
     $wd.isSolutionPickerState: '';
     $wd.clearLocalStorage;
     $wd.loadFizzBuzz;
     $wd.getLangLink('Raku').click;
-    $wd.isBytesAndChars: 0, 0, 'Untested solutions should not be preserved, after clearing localStorage.';
+    $wd.isBytesAndChars: 0, 0, 'after clearing localStorage and reloading the page.';
     $wd.isSolutionPickerState: '', 'after clearing localStorage and reloading the page.';
 }
 
@@ -53,11 +53,11 @@ subtest 'Failing solutions are loaded from localStorage on reload.' => {
     $wd.run;
     $wd.isFailing;
     $wd.loadFizzBuzz;
-    $wd.isBytesAndChars: 3, 3, 'The byte count should be the same after reloading the page.';
+    $wd.isBytesAndChars: 3, 3, 'after reloading the page.';
     $wd.clearLocalStorage;
     $wd.loadFizzBuzz;
     $wd.getLangLink('Raku').click;
-    $wd.isBytesAndChars: 0, 0, 'Failing solutions should not be preserved, after clearing localStorage.';
+    $wd.isBytesAndChars: 0, 0, 'after clearing localStorage and reloading the page.';
     $wd.isSolutionPickerState: '', 'after clearing localStorage and reloading the page.';
 }
 

--- a/t/hole.rakumod
+++ b/t/hole.rakumod
@@ -81,7 +81,9 @@ class HoleWebDriver is WebDriver is export {
     }
 
     # Methods whose names begin with "is" do exactly one assertion.
-    method isBytesAndChars($bytes, $chars, $desc = 'Confirm byte and char counts') {
+    method isBytesAndChars(Int:D $bytes, Int:D $chars, Str:D $context = '') {
+        my $desc = 'Confirm byte and char counts';
+        $desc ~= $context ?? ", $context" !! '.';
         is $.find('#chars').text, "$bytes bytes, $chars chars", $desc;
     }
 


### PR DESCRIPTION
Once a user is prompted for a language, they will not be prompted again until they reload the page (assuming they still have autosaved changes).
The prompt now applies to both the chars and bytes solutions. If the user accepts, they will both be restored. If they decline, they will both be removed.
Using the solution picker to switch between the chars and bytes solutions never triggers a prompt to restore local solutions.
Users can reload the server solutions by reloading the page and declining the prompt to restore local solutions.

Add test coverage for the new behavior.
hole.rakumod: Make the interface for isBytesAndChars more similar to isSolutionPickerState.

Fixes #306