### PR TITLE
Display solution results on hole-ng correctly

### DIFF
--- a/css/hole-ng.css
+++ b/css/hole-ng.css
@@ -1,3 +1,7 @@
+.term-fg31 { color: #c00 }
+.term-fg32 { color: #490 }
+.term-fg33 { color: #ca0 }
+
 canvas {
     border: 1px solid var(--color);
     image-rendering: crisp-edges;
@@ -65,7 +69,22 @@ select {
 .cm-editor { height: 100% }
 .cm-gutter { min-width: 1.75rem }
 
-#arguments-tab:checked ~ #arguments,
+#arguments {
+    align-content: flex-start;
+    column-gap: .5rem;
+    flex-flow: wrap;
+}
+
+#arguments > span {
+    background: var(--arg-background);
+    border-radius: .5rem;
+    display: inline-block;
+    margin-bottom: .5rem;
+    padding: 3px 7px;
+    white-space: pre;
+}
+
+#arguments-tab:checked ~ #arguments { display: flex }
      #diff-tab:checked ~ #diff,
    #errors-tab:checked ~ #errors,
  #expected-tab:checked ~ #expected,
@@ -118,8 +137,16 @@ select {
     border: 1px solid var(--color);
     border-top-width: 2px;
     display: none;
+    font-family: emoji, 'SFMono-Regular', Menlo, Consolas, 'Liberation Mono', Courier, monospace;
     grid-column: span 7;
     height: 14rem;
+    overflow: auto;
+    white-space: pre;
+}
+
+#status > div:not(#diff) {
+    padding: 4px;
+    line-height: 22.4px;
 }
 
 #status h2 {

--- a/js/_codemirror.js
+++ b/js/_codemirror.js
@@ -79,6 +79,7 @@ export const extensions = {
         oneDarkTheme,
         oneDarkHighlightStyle,
     ],
+    defaultHighlightStyle,
 
     // Languages.
     'assembly':   assembly(),

--- a/js/hole-ng.js
+++ b/js/hole-ng.js
@@ -11,7 +11,6 @@ const scoringTabs = document.querySelectorAll('#scoringTabs a');
 const select      = document.querySelector('select');
 const solutions   = JSON.parse(document.querySelector('#solutions').innerText);
 const status      = document.querySelector('#status');
-const statusDivs  = document.querySelectorAll('#status > div');
 const statusH2    = document.querySelector('#status h2');
 const strokes     = document.querySelector('#strokes');
 const thirdParty  = document.querySelector('#thirdParty');
@@ -22,7 +21,7 @@ const darkMode = matchMedia(JSON.parse(document.querySelector(
 const baseExtensions =
     darkMode ? [...extensions.dark, ...extensions.base] : extensions.base;
 
-let lang, result = {}, scoring = 'bytes';
+let lang, scoring = 'bytes';
 
 const editor = new EditorView({
     dispatch: tr => {
@@ -176,25 +175,23 @@ const runCode = document.querySelector('#run a').onclick = async () => {
     status.style.background = data.Pass ? 'var(--green)' : 'var(--red)';
     statusH2.innerText      = data.Pass ? 'Pass 😀'      : 'Fail ☹️';
 
-    result = {
-        arguments: data.Argv.join('\n'),
-        diff:      data.Diff,
-        errors:    data.Err,
-        expected:  data.Exp,
-        output:    data.Out,
-    };
+    document.querySelector('#arguments').replaceChildren(...data.Argv.map(arg =>
+        <span>{arg}</span>
+    ));
 
-    for (const div of statusDivs)
-        div.replaceChildren(new EditorView({
-            state: EditorState.create({
-                doc: result[div.id],
-                extensions: [
-                    ...baseExtensions,
-                    EditorView.editable.of(false),
-                    EditorView.lineWrapping,
-                    div.id == 'diff' ? extensions.diff : [],
-                ] }),
-        }).dom);
+    document.querySelector('#diff').replaceChildren(new EditorView({
+        state: EditorState.create({
+            doc: data.Diff,
+            extensions: [
+                darkMode ? extensions.dark : extensions.defaultHighlightStyle,
+                EditorView.editable.of(false),
+                extensions.diff,
+            ] }),
+    }).dom);
+
+    document.querySelector('#errors').innerHTML   = data.Err;
+    document.querySelector('#expected').innerText = data.Exp;
+    document.querySelector('#output').innerText   = data.Out;
 
     // 3rd party integrations.
     thirdParty.replaceChildren( lang == 'hexagony' ? <a target="_blank" href={


### PR DESCRIPTION
("Correctly" meaning closer to the way they're displayed on the main editor)
This includes:
- No line wrapping on any tabs (except for Arguments)
- No line numbers on any tabs (CodeMirror is only used for the Diff tab, though it may also be dropped there if we implement the highlighting ourselves (shouldn't be too difficult))
- Wrapping arguments in grey bubbles
- Correctly displaying HTML elements in the Errors tab