### PR TITLE
Add unprintable character extensions to ng

### DIFF
--- a/js/_codemirror.js
+++ b/js/_codemirror.js
@@ -4,14 +4,15 @@ import { EditorView, keymap } from '@codemirror/view';
 export { EditorState, EditorView };
 
 // Extensions.
-import { defaultTabBinding, standardKeymap }           from '@codemirror/commands';
-import { lineNumbers }                                 from '@codemirror/gutter';
-import { defaultHighlightStyle, HighlightStyle, tags } from '@codemirror/highlight';
-import { history, historyKeymap }                      from '@codemirror/history';
-import { indentOnInput }                               from '@codemirror/language';
-import { bracketMatching }                             from '@codemirror/matchbrackets';
-import { StreamLanguage }                              from '@codemirror/stream-parser';
-import { oneDarkTheme, oneDarkHighlightStyle }         from '@codemirror/theme-one-dark';
+import { carriageReturn, insertChar, showUnprintables } from './_codemirror_unprintable.js';
+import { defaultTabBinding, standardKeymap }            from '@codemirror/commands';
+import { lineNumbers }                                  from '@codemirror/gutter';
+import { defaultHighlightStyle, HighlightStyle, tags }  from '@codemirror/highlight';
+import { history, historyKeymap }                       from '@codemirror/history';
+import { indentOnInput }                                from '@codemirror/language';
+import { bracketMatching }                              from '@codemirror/matchbrackets';
+import { StreamLanguage }                               from '@codemirror/stream-parser';
+import { oneDarkTheme, oneDarkHighlightStyle }          from '@codemirror/theme-one-dark';
 
 // Languages.
 import { assembly }    from '@defasm/codemirror';
@@ -53,7 +54,8 @@ const fontFamily =
 export const extensions = {
     // Extensions.
     base: [
-        defaultHighlightStyle, history(), indentOnInput(), lineNumbers(),
+        carriageReturn, defaultHighlightStyle, history(),
+        indentOnInput(), insertChar, lineNumbers(), showUnprintables,
         keymap.of([ defaultTabBinding, ...historyKeymap, ...standardKeymap ]),
         EditorView.theme({
             '.cm-asm-error': { textDecoration: 'underline var(--asm-error)' },

--- a/js/_codemirror_unprintable.js
+++ b/js/_codemirror_unprintable.js
@@ -1,0 +1,66 @@
+// CodeMirror unprintable character extensions
+import { Decoration, EditorView, keymap, MatchDecorator, ViewPlugin, WidgetType } from "@codemirror/view";
+import { EditorState }                                                            from "@codemirror/state";
+
+export const carriageReturn = [
+    EditorState.lineSeparator.of('\n'), // Prevent CM from treating carriage return as newline
+    keymap.of({
+        key: 'Shift-Enter',
+        run: ({ state, dispatch }) => {
+            dispatch(state.replaceSelection('\r'));
+            return true;
+        }
+    })
+];
+
+let inputSequence = '';
+export const insertChar = EditorView.domEventHandlers({
+    'keydown': event => {
+        if(event.altKey && event.key.match(/^[0-9a-f]$/i)) {
+            inputSequence += event.key;
+            event.preventDefault();
+        }
+    },
+    'keyup': (event, view) => {
+        if(event.key == 'Alt' && inputSequence) {
+            try {
+                const codepoint = parseInt(inputSequence, 16);
+                if(codepoint != 0)
+                    view.dispatch(view.state.replaceSelection(
+                        String.fromCodePoint(codepoint)
+                    ));
+            }
+            catch(e) {}
+            inputSequence = '';
+        }
+    }
+});
+
+class UnprintableWidget extends WidgetType {
+    constructor(value) {
+        super();
+        this.value = value;
+    }
+    toDOM() {
+        return <span title={'\\u' + this.value.toString(16)}>•</span>
+    }
+}
+
+const unprintableDecorator = new MatchDecorator({
+    regexp: /[\x01-\x08\x0B-\x1F]/g,
+    decoration: match => Decoration.replace({
+        widget: new UnprintableWidget(match[0].charCodeAt(0))
+    })
+});
+
+export const showUnprintables = ViewPlugin.fromClass(
+    class {
+        constructor(view) {
+            this.decorations = unprintableDecorator.createDeco(view);
+        }
+        update(update) {
+            this.decorations = unprintableDecorator.updateDeco(update, this.decorations);
+        }
+    },
+    { decorations: plugin => plugin.decorations }
+);


### PR DESCRIPTION
These are:
- `carriageReturn`: Allows carriage returns to be inserted in the editor either by copy-paste or using shift+enter.
- `insertChar`: Holding down alt and writing a Unicode codepoint in hexadecimal will insert that codepoint into the editor. Non-hexadecimal characters are ignored; entering 0 or an invalid codepoint won't do anything.
- `showUnprintables`: Causes unprintable characters to be rendered as •, with a tooltip that shows their codepoint in hex, à la CodeMirror 5.