### PR TITLE
Change dark mode coloring to highlight borders and text in colored boxes

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -1,3 +1,13 @@
+:root {
+    /* https://flatuicolors.com */
+    --red:        #FC5C65BB;
+    --orange:     #FD9644BB;
+    --yellow:     #FED330BB;
+    --green:      #26DE81BB;
+    --blue:       #45AAF2BB;
+    --purple:     #8C7AE6BB;
+}
+
 * {
     box-sizing: border-box;
     margin: 0;
@@ -245,8 +255,7 @@ thead th {
 .bold { font-weight: bold }
 
 .btn {
-    border: solid 1px var(--color);
-    color: var(--color);
+    border-width: 1px;
     display: flex;
     font-size: 1rem;
     font-weight: bold;
@@ -270,8 +279,6 @@ thead th {
 
 .card {
     align-items: end;
-    border: 2px solid var(--color);
-    color: var(--color);
     display: grid;
     gap: .5rem;
     grid-template: min-content / 1fr min-content;
@@ -297,19 +304,18 @@ thead th {
 }
 
 .card svg {
-    fill: var(--color);
     height: 1rem;
     width: 1rem;
 }
 
 .center { text-align: center }
 
-.color:nth-of-type(6n+1), .red    { background: var(--red)    }
-.color:nth-of-type(6n+2), .orange { background: var(--orange) }
-.color:nth-of-type(6n+3), .yellow { background: var(--yellow) }
-.color:nth-of-type(6n+4), .green  { background: var(--green)  }
-.color:nth-of-type(6n+5), .blue   { background: var(--blue)   }
-.color:nth-of-type(6n+6), .purple { background: var(--purple) }
+.color:nth-of-type(6n+1), .red    { --thisColor: var(--red)    }
+.color:nth-of-type(6n+2), .orange { --thisColor: var(--orange) }
+.color:nth-of-type(6n+3), .yellow { --thisColor: var(--yellow) }
+.color:nth-of-type(6n+4), .green  { --thisColor: var(--green)  }
+.color:nth-of-type(6n+5), .blue   { --thisColor: var(--blue)   }
+.color:nth-of-type(6n+6), .purple { --thisColor: var(--purple) }
 
 .flag {
     margin-left: .5rem;

--- a/css/dark.css
+++ b/css/dark.css
@@ -3,14 +3,6 @@
     --color:      #ebebeb;
     --grey:       #85888c; /* #85888c is 0.6 * #343a40 + 0.4 * #ffffff */
 
-    --red:        hsl(357, 70%, 30%);
-    --orange:     hsl( 27, 80%, 36%);
-    --yellow:     hsl( 60, 80%, 28%);
-
-    --green:      hsl(150, 80%, 25%);
-    --blue:       hsl(205, 80%, 36%);
-    --purple:     hsl(265, 60%, 36%);
-
     /* For dark mode, the light colors are darker than the typical ones. */
     --light-blue:   hsl(210, 50%, 15%);
     --light-green:  hsl(150, 80%, 15%);
@@ -32,6 +24,16 @@
 body > header {
     --background: #ddd;
     --color:      #343a40;
+}
+
+.card, .btn {
+    border: 2px solid var(--thisColor);
+    fill: var(--thisColor);
+}
+
+.color, .red, .orange, .yellow, .green, .blue, .purple {
+    background: var(--light-grey);
+    color: var(--thisColor);
 }
 
 select {

--- a/css/ideas.css
+++ b/css/ideas.css
@@ -4,18 +4,4 @@
     grid-template: min-content / min-content min-content 1fr min-content min-content;
 }
 
-.card h2 {
-    font-size: 1.25rem;
-    line-height: 1.25;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-.card svg {
-    fill: var(--color);
-    height: 1rem;
-    width: 1rem;
-}
-
 .card svg:last-of-type { grid-column: 4 }

--- a/css/light.css
+++ b/css/light.css
@@ -3,14 +3,6 @@
     --color:      #343a40;
     --grey:       #85888c; /* #85888c is 0.6 * #343a40 + 0.4 * #ffffff */
 
-    /* https://flatuicolors.com */
-    --red:        #FC5C65BB;
-    --orange:     #FD9644BB;
-    --yellow:     #FED330BB;
-    --green:      #26DE81BB;
-    --blue:       #45AAF2BB;
-    --purple:     #8C7AE6BB;
-
     --light-blue:   #def;
     --light-green:  #efd;
     --light-grey:   #eee;
@@ -25,6 +17,16 @@
     --red-text:           var(--red);
     --summary-background: #343a40;
     --summary-color:      #fdfdfd;
+}
+
+.card, .btn {
+    border: 2px solid var(--color);
+    fill: var(--color);
+}
+
+.color, .red, .orange, .yellow, .green, .blue, .purple {
+    background: var(--thisColor);
+    color: var(--color);
 }
 
 select {


### PR DESCRIPTION
Suggested by panorrrama.

Some examples of this change:
![image](https://user-images.githubusercontent.com/36775845/128032506-6772c9db-4567-411e-b51a-1f2fb9d3ac24.png)
![image](https://user-images.githubusercontent.com/36775845/128032558-d7b89474-35fd-40ce-bf7c-faaf87737861.png)
![image](https://user-images.githubusercontent.com/36775845/128032713-5e4c1f92-0264-4c2b-99d1-1e8669e5b905.png)
![image](https://user-images.githubusercontent.com/36775845/128032772-45742eaf-5811-4428-8bea-f7f520496a0f.png)
![image](https://user-images.githubusercontent.com/36775845/128032839-7a7faf91-55a7-41e1-9b70-72af29b48417.png)
![image](https://user-images.githubusercontent.com/36775845/128032916-63e04c4e-23fb-4f66-9b19-bec2ae8e863f.png)

