### PR TITLE
Add two OEIS links to Lucky Tickets

### DIFF
--- a/holes.toml
+++ b/holes.toml
@@ -938,6 +938,10 @@ preamble = '''
 
 ['Lucky Tickets']
 category = 'Mathematics'
+links = [
+    { name = 'OEIS A163269', url = '//oeis.org/A163269' },
+    { name = 'OEIS A077042', url = '//oeis.org/A077042' },
+]
 preamble = '''
 <p>
     In Russia, bus ticket numbers consist of 6 decimal digits. It is considered lucky when the sum of the first three digits equals the sum of the last three digits. The concept of lucky tickets can be extended to ticket numbering systems with even numbers of digits and arbitrary bases.


### PR DESCRIPTION
The first http://oeis.org/A163269 notes "T(n,k) = number of ways the sums of all components of two 1..n k-vectors can be equal", so this is trivially equivalent to the Lucky Tickets formula.

I'm including http://oeis.org/A077042 because it generalizes the function to odd `n` instead of just even `n` (note that the even columns of A077042 are the same as A163269), and it gives a free formula (~150 bytes in Python. Still no idea how the <100 byte solutions work).