### PR TITLE
Use gold linker for asm

### DIFF
--- a/hole/play.go
+++ b/hole/play.go
@@ -123,7 +123,7 @@ func Play(ctx context.Context, holeID, langID, code string) (score Scorecard) {
 			panic(err)
 		}
 
-		cmd.Args = []string{"/usr/bin/defasm", "--ldflags=-N", "--size-out=3", "-r"}
+		cmd.Args = []string{"/usr/bin/defasm", "-l", "ld.gold", "--ldflags=-N -u _start -T /usr/lib/defaultEntry.ld", "--size-out=3", "-r"}
 		cmd.ExtraFiles = []*os.File{asmBytesWrite}
 	case "bash":
 		cmd.Args = []string{"/usr/bin/bash", "-s", "-"}

--- a/langs/assembly/Dockerfile
+++ b/langs/assembly/Dockerfile
@@ -4,7 +4,7 @@ ENV VERSION=2.1.3
 
 RUN mkdir /empty
 
-RUN apk add --no-cache g++ make python3
+RUN apk add --no-cache binutils-gold g++ make python3
 
 RUN npm install -g @defasm/cli@1.0.5 @defasm/core@$VERSION
 
@@ -18,18 +18,22 @@ RUN sed -i '1c#!/usr/bin/node' /usr/local/lib/node_modules/@defasm/cli/main.js
 RUN mkdir /symlink \
  && ln -s /usr/lib/node_modules/@defasm/cli/main.js /symlink/defasm
 
+# Linker script that ensures ld.gold sets the entry point properly if _start is missing
+RUN echo 'PROVIDE_HIDDEN(_start = ADDR(.text));ENTRY (_start)' > /usr/lib/defaultEntry.ld
+
 FROM scratch
 
-COPY --from=0 /lib/ld-musl-x86_64.so.1            \
-              /lib/libz.so.1                      /lib/
-COPY --from=0 /empty                              /proc
-COPY --from=0 /empty                              /tmp
-COPY --from=0 /symlink                            /usr/bin
-COPY --from=0 /usr/bin/ld /usr/local/bin/node     /usr/bin/
-COPY --from=0 /usr/lib/libbfd-2.35.2.so           \
-              /usr/lib/libctf.so.0                \
-              /usr/lib/libgcc_s.so.1              \
-              /usr/lib/libstdc++.so.6             /usr/lib/
-COPY --from=0 /usr/local/lib/node_modules/@defasm /usr/lib/node_modules/@defasm
+COPY --from=0 /lib/ld-musl-x86_64.so.1             \
+              /lib/libz.so.1                       /lib/
+COPY --from=0 /empty                               /proc
+COPY --from=0 /empty                               /tmp
+COPY --from=0 /symlink                             /usr/bin
+COPY --from=0 /usr/bin/ld.gold /usr/local/bin/node /usr/bin/
+COPY --from=0 /usr/lib/defaultEntry.ld             \
+              /usr/lib/libbfd-2.35.2.so            \
+              /usr/lib/libctf.so.0                 \
+              /usr/lib/libgcc_s.so.1               \
+              /usr/lib/libstdc++.so.6              /usr/lib/
+COPY --from=0 /usr/local/lib/node_modules/@defasm  /usr/lib/node_modules/@defasm
 
 ENTRYPOINT ["/usr/bin/defasm"]


### PR DESCRIPTION
The GNU gold linker is faster than ld since it's specific to ELF files.  It also supports truncating relocations (e.g. `mov $., %al`), which ld forbids for some reason.