### PR TITLE
[CSS] Add `white-space: pre;` to `aside > div`

### DIFF
--- a/css/hole.css
+++ b/css/hole.css
@@ -36,6 +36,7 @@ aside > div {
     line-height: 1;
     overflow: auto;
     padding: 5px;
+    white-space: pre;
 }
 
 h3 {


### PR DESCRIPTION
How it currently is (compiler error indications are misaligned):
<img width="425" alt="2021-09-13_23-00-15" src="https://user-images.githubusercontent.com/1719996/133182721-98939bf5-3de5-4e8f-88e6-3685b43d00a2.png">

With `white-space: pre`:
<img width="409" alt="2021-09-13_23-00-49" src="https://user-images.githubusercontent.com/1719996/133182723-afaaff1d-d13d-4a81-9a27-6e3928967f50.png">

Tried to censor the code, not sure what's the policy on leaking solutions hehe

This should be a harmless change, but I'm not familiar with every compiler output there is, so I'll understand if this breaks an edge case.