### PR TITLE
Add Lucky Tickets cases

### DIFF
--- a/hole/lucky-tickets.go
+++ b/hole/lucky-tickets.go
@@ -13,11 +13,14 @@ type ticket struct {
 
 var data = []ticket{
 	{8, 2, 70},
+	{6, 6, 4332},
 	{4, 8, 344},
+	{4, 9, 489},
 	{2, 10, 10},
 	{4, 10, 670},
 	{6, 10, 55252},
 	{14, 12, 39222848622984},
+	{4, 15, 2255},
 }
 
 func iPow(a, b int64) int64 {
@@ -50,7 +53,7 @@ func luckyTickets() ([]string, string) {
 	copy(tickets, data)
 
 	// Randomly generate additional test cases.
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 8; i++ {
 		digits := 2 + 2*rand.Intn(5)
 		base := 2 + rand.Intn(15)
 

--- a/hole/lucky-tickets.go
+++ b/hole/lucky-tickets.go
@@ -13,14 +13,24 @@ type ticket struct {
 
 var data = []ticket{
 	{8, 2, 70},
+	{14, 5, 454805755},
 	{6, 6, 4332},
+	{12, 7, 786588243},
 	{4, 8, 344},
 	{4, 9, 489},
+	{8, 9, 2306025},
 	{2, 10, 10},
 	{4, 10, 670},
 	{6, 10, 55252},
-	{14, 12, 39222848622984},
+	{8, 10, 4816030},
+	{12, 9, 12434998005},
+	{12, 10, 39581170420},
+	{12, 11, 112835748609},
+	{6, 13, 204763},
 	{4, 15, 2255},
+	{6, 15, 418503},
+	{8, 15, 82073295},
+	{10, 15, 16581420835},
 }
 
 func iPow(a, b int64) int64 {
@@ -49,11 +59,18 @@ func sumDigits(number int64, base int64) int64 {
 }
 
 func luckyTickets() ([]string, string) {
+	// make a random selection of 4 from the fixed cases
+	rand.Shuffle(len(data), func(i, j int) {
+		data[i], data[j] = data[j], data[i]
+	})
+	data = data[0:3]
 	tickets := make([]ticket, len(data))
+	// always add case 14 12
+	tickets = append(tickets, ticket{14, 12, 39222848622984})
 	copy(tickets, data)
 
 	// Randomly generate additional test cases.
-	for i := 0; i < 8; i++ {
+	for i := 0; i < 15; i++ {
 		digits := 2 + 2*rand.Intn(5)
 		base := 2 + rand.Intn(15)
 

--- a/hole/lucky-tickets.go
+++ b/hole/lucky-tickets.go
@@ -63,7 +63,7 @@ func luckyTickets() ([]string, string) {
 	rand.Shuffle(len(data), func(i, j int) {
 		data[i], data[j] = data[j], data[i]
 	})
-	data = data[0:3]
+	data = data[0:4]
 	tickets := make([]ticket, len(data))
 	// always add case 14 12
 	tickets = append(tickets, ticket{14, 12, 39222848622984})

--- a/hole/lucky-tickets.go
+++ b/hole/lucky-tickets.go
@@ -59,15 +59,13 @@ func sumDigits(number int64, base int64) int64 {
 }
 
 func luckyTickets() ([]string, string) {
-	// make a random selection of 4 from the fixed cases
-	rand.Shuffle(len(data), func(i, j int) {
-		data[i], data[j] = data[j], data[i]
-	})
-	data = data[0:4]
-	tickets := make([]ticket, len(data))
+	var tickets []ticket
 	// always add case 14 12
 	tickets = append(tickets, ticket{14, 12, 39222848622984})
-	copy(tickets, data)
+	// add random sample of fixed cases
+	for _, test_case := range rand.Perm(len(data))[:4] {
+		tickets = append(tickets, data[test_case])
+	}
 
 	// Randomly generate additional test cases.
 	for i := 0; i < 15; i++ {


### PR DESCRIPTION
Currently, with enough persistence, you can pass in Lucky Tickets by hard coding fixed test cases and making some guesses about the random tests. This passes very rarely, but is potentially competitive. To fix this, I have largely followed the description in #179 

Random test cases have been increased from 5 to 15. Rather than picking a selection of 5 from 20 fixed cases, we pick a selection of 4 from 19, and add "14 12" as a fixed test case.