### PR TITLE
Add experimental "QR Encoder" hole

### DIFF
--- a/config/holes.toml
+++ b/config/holes.toml
@@ -1506,7 +1506,7 @@ preamble = '''
       <span>^^</span> 10       <span>vv</span> ..
 </div>
 
-<p>To decode a bit off of a strip, read the value from the QR code bitmap ("#" = 1, space = 0) and invert it if <b>(x+y)%2 = 0</b>, where <b>(x, y)</b> are the coordinates of the bit in the bitmap with the origin (0, 0) at the top-left corner.
+<p>To decode a bit off of a strip, read the value from the QR code bitmap ("#" = 1, space = 0) and invert it if <b>(x+y)%2 = 0</b>, where <b>(x, y)</b> are the coordinates of the bit in the bitmap with the origin <b>(0, 0)</b> at the top-left corner.
 
 <p>This will yield a bitstream like:
 
@@ -1517,6 +1517,65 @@ preamble = '''
 </pre>
 
 <p>Print the 17 bytes of ASCII stored in the QR code.
+'''
+
+['QR Encoder']
+category = 'Transform'
+experiment = -1
+links = [
+    { name = 'Wikipedia', url = '//www.wikipedia.org/wiki/QR_code#Encoding' },
+]
+preamble = '''
+<div class=qr-span>
+<p>Encode ASCII string to a Version-1 QR code of this ASCII-art format, where all the <span>v</span> and <span>^</span> must be filled with "#" and spaces.
+</div>
+
+<div class=qr-span><pre>
+    #######  <span>vv^^</span> #######
+    #     #  <span>vv^^</span> #     #
+    # ### # #<span>vv^^</span> # ### #
+    # ### #  <span>vv^^</span> # ### #
+    # ### #  <span>vv^^</span> # ### #
+    #     #  <span>vv^^</span> #     #
+    ####### # # # #######
+            #<span>vv^^</span>
+    ### #####<span>vv^^</span>##   #
+    <span>vv^^vv</span> <span>^^vv^^vv^^vv^^</span>
+    <span>vv^^vv</span>#<span>^^vv^^vv^^vv^^</span>
+    <span>vv^^vv</span> <span>^^vv^^vv^^vv^^</span>
+    <span>vv^^vv</span>#<span>^^vv^^vv^^vv^^</span>
+            #<span>vv^^vv^^vv^^</span>
+    ####### #<span>vv^^vv^^vv^^</span>
+    #     # #<span>vv^^vv^^vv^^</span>
+    # ### # #<span>vv^^vv^^vv^^</span>
+    # ### #  <span>vv^^vv^^vv^^</span>
+    # ### # #<span>vv^^vv^^vv^^</span>
+    #     # #<span>vv^^vv^^vv^^</span>
+    ####### #<span>vv^^vv^^vv^^</span>
+</div>
+
+<div class=qr-span>
+<p>The 10 vertical "strips" of <span>^^</span> or <span>vv</span> must be written from right to left. The bits in a strip are written in a zig-zag order: <span>^^</span> zig-zags upwards, and <span>vv</span> zig-zags downwards. The bit on the right always precedes the one on its left.
+</div>
+
+<div class=qr-span><pre>
+      <span>^^</span> ..       <span>vv</span> 10
+      <span>^^</span> 98       <span>vv</span> 32
+      <span>^^</span> 76       <span>vv</span> 54
+      <span>^^</span> 54       <span>vv</span> 76
+      <span>^^</span> 32       <span>vv</span> 98
+      <span>^^</span> 10       <span>vv</span> ..
+</div>
+
+<p>The strips are filled with data from a bitstream:
+
+<pre>
+    0100  00010001  01001000  01100101  ...  01101111  0000  11000000  11111111  ...  11101110
+    Enc   Length    'H'       'e'                 'o'  End   c0        ff             ee
+    (4)   (17)      (17-byte ASCII message)            (0)   (7 error correction bytes)
+</pre>
+
+<p>To encode a bit from the bitstream to a strip, determine the coordinates <b>(x, y)</b> of the current position in the bitmap with the origin <b>(0, 0)</b> at the top-left corner, invert the bit if <b>(x+y)%2 = 0</b>, and write the value to this position ("#" = 1, space = 0).
 '''
 
 [Quine]

--- a/hole/play.go
+++ b/hole/play.go
@@ -65,8 +65,8 @@ func getAnswer(holeID, code string) (args []string, answer string) {
 		args, answer = pangramGrep()
 	case "poker":
 		args, answer = poker()
-	case "qr-decoder":
-		args, answer = qr()
+	case "qr-decoder", "qr-encoder":
+		args, answer = qr(holeID == "qr-decoder")
 	case "quine":
 		answer = code
 	case "rock-paper-scissors-spock-lizard":

--- a/hole/qr.go
+++ b/hole/qr.go
@@ -109,7 +109,7 @@ func qr(decoder bool) (args []string, out string) {
 		args = []string{qrString}
 		out = content
 	} else {
-		arg := fmt.Sprintf("%s %s", content, hex.EncodeToString(getErrorCorrectionBlocks(qr)))
+		arg := content + " " + hex.EncodeToString(getErrorCorrectionBlocks(qr))
 		args = []string{arg}
 		out = qrString
 	}

--- a/hole/qr.go
+++ b/hole/qr.go
@@ -38,8 +38,15 @@ func get8(qr matrix, i, j, dir int) byte {
 }
 
 func getErrorCorrectionBlocks(qr matrix) []byte {
-	return []byte{get8(qr, 9, 10, 1), get8(qr, 13, 10, 1), get8(qr, 17, 10, 1),
-		get8(qr, 12, 8, -1), get8(qr, 9, 5, 1), get8(qr, 12, 3, -1), get8(qr, 9, 1, 1)}
+	return []byte{
+		get8(qr, 9, 10, 1),
+		get8(qr, 13, 10, 1),
+		get8(qr, 17, 10, 1),
+		get8(qr, 12, 8, -1),
+		get8(qr, 9, 5, 1),
+		get8(qr, 12, 3, -1),
+		get8(qr, 9, 1, 1),
+	}
 }
 
 func genQr(content string) matrix {

--- a/hole/qr.go
+++ b/hole/qr.go
@@ -1,6 +1,7 @@
 package hole
 
 import (
+	"encoding/hex"
 	"math/rand"
 	"strings"
 
@@ -9,40 +10,85 @@ import (
 
 func randStr(len int) string {
 	buf := make([]byte, len)
-	for i := 0; i < len-1; i++ {
-		buf[i] = byte(32 + rand.Intn(95)) // randPrintableAscii: [32; 126]
+	for i := range buf {
+		buf[i] = byte(33 + rand.Intn(94)) // randPrintableAscii: [33; 126]
 	}
-	buf[len-1] = byte(33 + rand.Intn(94)) // [33; 126]: avoid trailing spaces because of trimming
 	return string(buf)
 }
 
-func genQr(content string) [][]bool {
+type matrix = [][]bool
+
+func get(qr matrix, i, j int) byte {
+	if qr[i][j] != (((i + j) & 1) == 0) {
+		return 1
+	}
+	return 0
+}
+
+func get2(qr matrix, i, j int) byte {
+	return 2*get(qr, i, j) + get(qr, i, j-1)
+}
+
+func get4(qr matrix, i, j, dir int) byte {
+	return 4*get2(qr, i, j) + get2(qr, i+dir, j)
+}
+
+func get8(qr matrix, i, j, dir int) byte {
+	return 16*get4(qr, i, j, dir) + get4(qr, i+2*dir, j, dir)
+}
+
+func getErrorCorrectionBlocks(qr matrix) []byte {
+	return []byte{get8(qr, 9, 10, 1), get8(qr, 13, 10, 1), get8(qr, 17, 10, 1),
+		get8(qr, 12, 8, -1), get8(qr, 9, 5, 1), get8(qr, 12, 3, -1), get8(qr, 9, 1, 1)}
+}
+
+func genQr(content string) matrix {
 	qr, _ := qrcode.New(content, qrcode.Low)
 	qr.DisableBorder = true
 	return qr.Bitmap()
 }
 
-func qrIsStandard(b [][]bool) bool {
-	if !(b[8][2] && !b[8][3] && b[8][4]) { // mask pattern: (i+j)%2 == 0
+func qrIsStandard(qr matrix) bool {
+	if !(qr[8][2] && !qr[8][3] && qr[8][4]) { // mask pattern: (i+j)%2 == 0
 		return false
 	}
 
-	if !(b[20][20] && b[20][19] && !b[19][20] && b[19][19]) { // mode indicator: byte encoding
+	if get4(qr, 20, 20, -1) != 4 { // mode indicator: byte encoding
 		return false
 	}
 
-	if !(!b[17][19] && !b[15][19]) { // message length: 17
+	if get8(qr, 18, 20, -1) != 17 { // message length: 17
 		return false
 	}
 
 	return true
 }
 
-func qrToString(qr [][]bool) string {
+func getStandardQr() (content string, qr matrix) {
+	for {
+		content = randStr(17)
+		qr = genQr(content)
+
+		if qrIsStandard(qr) {
+			return
+		}
+	}
+}
+
+func qrToString(qr matrix, trimRight bool) string {
 	var buf strings.Builder
 	for i, row := range qr {
 		if i > 0 {
 			buf.WriteByte('\n')
+		}
+		if trimRight {
+			lastTrue := -1
+			for j, bit := range row {
+				if bit {
+					lastTrue = j
+				}
+			}
+			row = row[:lastTrue+1]
 		}
 		for _, bit := range row {
 			if bit {
@@ -55,14 +101,18 @@ func qrToString(qr [][]bool) string {
 	return buf.String()
 }
 
-func qr() ([]string, string) {
-	for {
-		content := randStr(17)
-		qr := genQr(content)
+func qr(decoder bool) (args []string, out string) {
+	content, qr := getStandardQr()
+	qrString := qrToString(qr, !decoder)
 
-		if qrIsStandard(qr) {
-			qrString := qrToString(qr)
-			return []string{qrString}, content
-		}
+	if decoder {
+		args = []string{qrString}
+		out = content
+	} else {
+		arg := fmt.Sprintf("%s %s", content, hex.EncodeToString(getErrorCorrectionBlocks(qr)))
+		args = []string{arg}
+		out = qrString
 	}
+
+	return
 }


### PR DESCRIPTION
Convert
```
^-^(code.golf)^-^ c53ff5b3abc581
```
(17-bytes ASCII string and 7-bytes hex string of error correction)
to
```
#######  #    #######
#     #    #  #     #
# ### # ###   # ### #
# ### #     # # ### #
# ### #  # ## # ### #
#     #  ##   #     #
####### # # # #######
        ##           
### ##### #  ##   #  
  ##    # ###  ## ###
#   ### # # ####### #
 # #    #  ### #   ##
   # ##  ####  ##### 
        ## ## ### #  
####### ## ##  ##  ##
#     # # ##    ##   
# ### # ## #   #    #
# ### #   ###  ####  
# ### # ## ### ## # #
#     # #   #   #  # 
####### ####    #  ##
```

