### PR TITLE
Update Zig example code

### DIFF
--- a/config/langs.toml
+++ b/config/langs.toml
@@ -722,9 +722,8 @@ pub fn main() !void {
         try stdout.print("{}\n", .{i});
 
     // Accessing arguments
-    var args = std.process.args();
-    _ = args.skip();
-    while (args.next(std.testing.allocator)) |arg|
-        try stdout.print("{s}\n", .{arg});
+    for (std.os.argv) |arg, index|
+        if (index > 0)
+            try stdout.print("{s}\n", .{arg});
 }
 '''


### PR DESCRIPTION
IMO this is much more intuitive for accessing args. This method does yield args differently, as sentinel-terminated pointers rather than (error unioned) sentinel-terminated slices, but unless anyone has any major objections I feel this ought to be the default.