### PR TITLE
Fix long diffs

### DIFF
--- a/css/hole-diff.css
+++ b/css/hole-diff.css
@@ -1,4 +1,4 @@
-#diff-content {
+.diff-content {
     display: grid;
     grid-template-columns:
         [arg] max-content

--- a/css/hole-ng.css
+++ b/css/hole-ng.css
@@ -88,7 +88,7 @@ select {
 }
 
 #arguments-tab:checked ~ #arguments { display: flex }
-     #diff-tab:checked ~ #diff,
+     #diff-tab:checked ~ #diff { display: grid }
    #errors-tab:checked ~ #errors,
  #expected-tab:checked ~ #expected,
    #output-tab:checked ~ #output { display: block }

--- a/js/_diff.js
+++ b/js/_diff.js
@@ -2,6 +2,13 @@ import * as Diff  from "diff";
 
 export function attachDiff(element, hole, exp, out, argv) {
     const header = getHeader();
+    // Limit `out` to 999 lines to avoid slow computation of the line diff
+    let outLines = lines(out)
+    if (outLines.length > 998) {
+        outLines = outLines.slice(0, 998);
+        outLines.push("[Truncated for performance]");
+        out = outLines.join("\n")
+    }
     const rows = diffHTMLRows(hole, exp, out, argv);
     updateDiff(element, rows, header);
     element.onscroll = () => {

--- a/js/hole-ng.js
+++ b/js/hole-ng.js
@@ -3,7 +3,7 @@ import LZString                                from 'lz-string';
 import { EditorState, EditorView, extensions } from './_codemirror.js';
 import pbm                                     from './_pbm.js';
 import strlen                                  from './_strlen.js';
-import diffHTML                                from './_diff';
+import { attachDiff }                          from './_diff';
 
 const all         = document.querySelector('#all');
 const hole        = decodeURI(location.pathname.slice(4));
@@ -16,7 +16,7 @@ const status      = document.querySelector('#status');
 const statusH2    = document.querySelector('#status h2');
 const strokes     = document.querySelector('#strokes');
 const thirdParty  = document.querySelector('#thirdParty');
-const diffContent = document.querySelector('#diff-content');
+const diffContent = document.querySelector('#diff');
 
 const darkMode = matchMedia(JSON.parse(document.querySelector(
     '#darkModeMediaQuery').innerText)).matches;
@@ -182,7 +182,7 @@ const runCode = document.querySelector('#run a').onclick = async () => {
         <span>{arg}</span>
     ));
 
-    diffContent.innerHTML = diffHTML(hole, data.Exp, data.Out, data.Argv);
+    attachDiff(diffContent, hole, data.Exp, data.Out, data.Argv);
 
     document.querySelector('#errors').innerHTML   = data.Err;
     document.querySelector('#expected').innerText = data.Exp;

--- a/js/hole.js
+++ b/js/hole.js
@@ -1,6 +1,6 @@
 import CodeMirror from './_codemirror-legacy';
 import strlen     from './_strlen';
-import diffHTML   from './_diff';
+import { attachDiff }   from './_diff';
 
 const chars              = document.querySelector('#chars');
 const darkModeMediaQuery = JSON.parse(document.querySelector('#darkModeMediaQuery').innerText);
@@ -254,8 +254,9 @@ onload = () => {
         document.querySelector('#exp div').innerText = data.Exp;
         document.querySelector('#out div').innerText = data.Out;
 
-        document.querySelector("#diff-content").innerHTML = diffHTML(hole, data.Exp, data.Out, data.Argv);
-        diff.style.display = data.Exp === data.Out ? 'none' : 'block'
+        const diffContent = document.querySelector("#diff-content");
+        attachDiff(diffContent, hole, data.Exp, data.Out, data.Argv);
+        diff.style.display = data.Exp === data.Out ? 'none' : 'block';
 
         status.className = data.Pass ? 'green' : 'red';
         status.style.display = 'block';

--- a/views/hole-ng.html
+++ b/views/hole-ng.html
@@ -156,7 +156,7 @@
         <div id=arguments></div>
         <div id=output   ></div>
         <div id=expected ></div>
-        <div id=diff     ><div id=diff-content></div></div>
+        <div id=diff class="diff-content"></div>
         <div id=errors   ></div>
     </div>
 </main>

--- a/views/hole.html
+++ b/views/hole.html
@@ -136,7 +136,7 @@
         <aside id=arg><h3 class='aside-title'>Arguments</h3><div></div></aside>
         <aside id=exp><h3 class='aside-title'>Expected</h3><div></div></aside>
         <aside id=out><h3 class='aside-title'>Output</h3><div></div></aside>
-        <aside id=diff><h3 class='aside-title'>Diff</h3><div id=diff-content></div></aside>
+        <aside id=diff><h3 class='aside-title'>Diff</h3><div id=diff-content class="diff-content"></div></aside>
     </div>
 </main>
 


### PR DESCRIPTION
This makes two changes:
- Allows the diff display to have more than 1000 rows by only including visible rows in the DOM, and updating on scroll. (Chrome limits grid to 1000 rows)
- Truncates the output shown in the diff, to avoid slow computation of the line diff.