### PR TITLE
fix typo in hole description

### DIFF
--- a/config/holes.toml
+++ b/config/holes.toml
@@ -1211,7 +1211,7 @@ preamble = '''
                 	<td><b>G♭</b>
             	<tr>
                 	<td>10
-                	<td><b>F</b>
+                	<td><b>G</b>
                 	<td>
             	<tr>
                 	<td>11


### PR DESCRIPTION
Fixed a mistake in the pitch classes table of the musical chords hole.