### PR TITLE
Prolog: Don't provide - as the first argument.

### DIFF
--- a/config/langs.toml
+++ b/config/langs.toml
@@ -554,7 +554,7 @@ example = '''
    maplist(writeln, List).
 
 % Accessing arguments
-:- current_prolog_flag(argv, [_| Args]),
+:- prolog_flag(argv, Args),
    maplist(writeln, Args).
 '''
 

--- a/langs/prolog/prolog
+++ b/langs/prolog/prolog
@@ -6,7 +6,9 @@ export LC_ALL=C.UTF-8
 
 # Put user-defined predicates in file
 cd /tmp
-cat - > code.pl
+cat $1 > code.pl
+# Discard the filename argument. swipl doesn't normally provide the filename as the first argument.
+shift
 
 # Ensure interpreter never shows its face in the output box.
 # Concatenate 'halt' as a goal to every program.

--- a/views/hole-ng.html
+++ b/views/hole-ng.html
@@ -118,7 +118,7 @@
     </div>
 {{ end }}
     <div class="info prolog">
-        Your code will be passed to <b>swipl</b> as an external file. <b>current_prolog_flag(argv, [_|Args])</b> to access the arguments.
+        Your code will be passed to <b>swipl</b> as an external file. <b>prolog_flag(argv, Args)</b> to access the arguments.
     </div>
     <div class="info sql">
         <b>SELECT arg FROM argv</b> to access the arguments, only the first

--- a/views/hole.html
+++ b/views/hole.html
@@ -117,7 +117,7 @@
     </div>
 {{ end }}
     <div class="info prolog">
-        Your code will be passed to <b>swipl</b> as an external file. <b>current_prolog_flag(argv, [_|Args])</b> to access the arguments.
+        Your code will be passed to <b>swipl</b> as an external file. <b>prolog_flag(argv, Args)</b> to access the arguments.
     </div>
     <div class="info sql">
         <b>SELECT arg FROM argv</b> to access the arguments, only the first


### PR DESCRIPTION
It's not normal for swipl to provide an argument that corresponds to the name of the code file.

This will invalidate existing solutions for holes with arguments, but there aren't too many at this point. It may be a good time to fix this.

@annaproxy 