### PR TITLE
rakings_holes: Show bytes and chars of solutions in tooltip. Fixes #416.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.vagrant/
 /code-golf
 /db/
 /dist/

--- a/db/a-schema.sql
+++ b/db/a-schema.sql
@@ -146,7 +146,8 @@ GROUP BY hole, lang, scoring
 
 CREATE MATERIALIZED VIEW rankings AS WITH strokes AS (
     select hole, lang, scoring, user_id, submitted,
-           case when scoring = 'bytes' then bytes else chars end strokes
+           case when scoring = 'bytes' then bytes else chars end strokes,
+           case when scoring = 'bytes' then chars else bytes end other_strokes
       from solutions
      where not failing
 ), min as (
@@ -163,7 +164,7 @@ CREATE MATERIALIZED VIEW rankings AS WITH strokes AS (
       from min
       join min_per_lang using(hole, scoring)
 ), points as (
-    select hole, lang, scoring, user_id, strokes, submitted,
+    select hole, lang, scoring, user_id, strokes, other_strokes, submitted,
            round(Sb / strokes * 1000) points,
            round(S  / strokes * 1000) points_for_lang
       from strokes

--- a/views/rankings/holes.html
+++ b/views/rankings/holes.html
@@ -110,7 +110,12 @@
             {{ if eq $.Data.HoleID "all" }}
                 {{ comma .Strokes }}
             {{ else }}
-                <a href="/golfers/{{ .Login }}/{{ $.Data.HoleID }}/{{ .Lang.ID }}/{{ $.Data.Scoring }}">{{ comma .Strokes }}</a>
+                <a href="/golfers/{{ .Login }}/{{ $.Data.HoleID }}/{{ .Lang.ID }}/{{ $.Data.Scoring }}"
+                {{ if .OtherStrokes }}
+                   data-tooltip="{{ title $.Data.Scoring }} solution is {{ comma .Strokes }} {{ $.Data.Scoring }}, {{ comma .OtherStrokes }} {{ $.Data.OtherScoring }}."
+                {{ end }}>
+                   {{ comma .Strokes }}
+                </a>
             {{ end }}
             <td class=right>{{ time (.Submitted.In $.Location) }}
     {{ end }}


### PR DESCRIPTION
This provides the same information that the user can see in the mini-scoreboard on the hole page.

<img width="882" alt="Screen Shot 2021-12-04 at 2 29 26 PM" src="https://user-images.githubusercontent.com/53135437/144722360-0fb44944-9690-4cd2-86e9-b323a3f1da04.png">

<img width="879" alt="Screen Shot 2021-12-04 at 2 29 38 PM" src="https://user-images.githubusercontent.com/53135437/144722368-dc60059f-a890-4098-ac0c-ad5a51cb5265.png">
