### PR TITLE
Set bytes column to always appear in Discord records

### DIFF
--- a/discord/bot.go
+++ b/discord/bot.go
@@ -88,6 +88,15 @@ func recAnnounceToEmbed(announce *RecAnnouncement) *discordgo.MessageEmbed {
 	if fieldValues["bytes"] == fieldValues["chars"] {
 		fieldValues = map[string]string{"bytes/chars": fieldValues["bytes"]}
 	}
+
+	// Find the dominant scoring (only "chars" if there were no improvements on bytes)
+	if fieldValues["bytes"] == "" && fieldValues["bytes/chars"] == "" {
+		embed.URL += "chars"
+		fieldValues["bytes"] = "​" // Display the bytes column in any case, to avoid confusion
+	} else {
+		embed.URL += "bytes"
+	}
+
 	// We iterate over the scorings rather than the map itself so that the order will be guaranteed
 	for _, scoring := range []string{"bytes", "chars", "bytes/chars"} {
 		if fieldValues[scoring] != "" {
@@ -97,13 +106,6 @@ func recAnnounceToEmbed(announce *RecAnnouncement) *discordgo.MessageEmbed {
 				Inline: true,
 			})
 		}
-	}
-
-	// Find the dominant scoring (only "chars" if there were no improvements on bytes)
-	if fieldValues["bytes"] == "" && fieldValues["bytes/chars"] == "" {
-		embed.URL += "chars"
-	} else {
-		embed.URL += "bytes"
 	}
 
 	return embed


### PR DESCRIPTION
e.g.
![image](https://user-images.githubusercontent.com/36775845/149632269-9d4fe83c-be6e-42f0-a5cd-770c4349a1ca.png)
This is to avoid confusing a chars-only record with a bytes-only record, which happens often.
The empty bytes column contains a zero-width space (U+200B), because an empty string causes the column not to display at all.