### PR TITLE
Separate ideas into languages/other

### DIFF
--- a/routes/ideas.go
+++ b/routes/ideas.go
@@ -16,9 +16,9 @@ func Ideas(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := struct {
-		Holes []*config.Hole
+		Holes     []*config.Hole
 		Languages []idea
-		Ideas []idea
+		Ideas     []idea
 	}{Holes: config.ExpHoleList}
 
 	rows, err := session.Database(r).Query(

--- a/routes/ideas.go
+++ b/routes/ideas.go
@@ -37,8 +37,7 @@ func Ideas(w http.ResponseWriter, r *http.Request) {
 		}
 		if strings.Contains(strings.ToLower(t.Title), "lang") {
 			data.Languages = append(data.Languages, i)
-		}
-		else{
+		} else {
 			data.Ideas = append(data.Ideas, i)
 		}
 	}

--- a/routes/ideas.go
+++ b/routes/ideas.go
@@ -2,6 +2,7 @@ package routes
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/code-golf/code-golf/config"
 	"github.com/code-golf/code-golf/session"
@@ -16,6 +17,7 @@ func Ideas(w http.ResponseWriter, r *http.Request) {
 
 	data := struct {
 		Holes []*config.Hole
+		Languages []idea
 		Ideas []idea
 	}{Holes: config.ExpHoleList}
 
@@ -33,8 +35,12 @@ func Ideas(w http.ResponseWriter, r *http.Request) {
 		if err := rows.Scan(&i.ID, &i.ThumbsDown, &i.ThumbsUp, &i.Title); err != nil {
 			panic(err)
 		}
-
-		data.Ideas = append(data.Ideas, i)
+		if strings.Contains(strings.ToLower(t.Title), "lang") {
+			data.Languages = append(data.Languages, i)
+		}
+		else{
+			data.Ideas = append(data.Ideas, i)
+		}
 	}
 
 	if err := rows.Err(); err != nil {

--- a/routes/ideas.go
+++ b/routes/ideas.go
@@ -35,7 +35,7 @@ func Ideas(w http.ResponseWriter, r *http.Request) {
 		if err := rows.Scan(&i.ID, &i.ThumbsDown, &i.ThumbsUp, &i.Title); err != nil {
 			panic(err)
 		}
-		if strings.Contains(strings.ToLower(t.Title), "lang") {
+		if strings.Contains(strings.ToLower(i.Title), "lang") {
 			data.Languages = append(data.Languages, i)
 		} else {
 			data.Ideas = append(data.Ideas, i)

--- a/routes/ideas.go
+++ b/routes/ideas.go
@@ -16,9 +16,8 @@ func Ideas(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := struct {
-		Holes     []*config.Hole
-		Languages []idea
-		Ideas     []idea
+		Holes            []*config.Hole
+		Ideas, Languages []idea
 	}{Holes: config.ExpHoleList}
 
 	rows, err := session.Database(r).Query(

--- a/views/ideas.html
+++ b/views/ideas.html
@@ -17,7 +17,7 @@
 {{ end }}
 {{ end }}
 
-{{define "IdeasTable"}}
+{{ define "IdeasTable" }}
     <a class="card color" href="//github.com/code-golf/code-golf/issues/{{ .ID }}" title="{{ .Title }}">
         <h2 class=span>{{ .Title }}</h2>
         <svg><use href="#thumbs-up"/></svg>
@@ -25,16 +25,16 @@
         <svg><use href="#thumbs-down"/></svg>
         {{ .ThumbsDown }}
     </a>
-{{end}}
+{{ end }}
 
     <h1 class=span>Ideas</h1>
 {{ range .Data.Ideas }}
-    {{template "IdeasTable"}}
+    {{ template "IdeasTable" }}
 {{ end }}
 
     <h1 class=span>Language Suggestions</h1>
 {{ range .Data.Languages }}
-    {{template "IdeasTable"}}
+    {{ template "IdeasTable" }}
 {{ end }}
 
     <p class="right span">

--- a/views/ideas.html
+++ b/views/ideas.html
@@ -27,13 +27,13 @@
     </a>
 {{end}}
 
-    <h1 class=span>Languages</h1>
-{{ range .Data.Languages }}
+    <h1 class=span>Ideas</h1>
+{{ range .Data.Ideas }}
     {{template "IdeasTable"}}
 {{ end }}
 
-    <h1 class=span>Other ideas</h1>
-{{ range .Data.Ideas }}
+    <h1 class=span>Language Suggestions</h1>
+{{ range .Data.Languages }}
     {{template "IdeasTable"}}
 {{ end }}
 

--- a/views/ideas.html
+++ b/views/ideas.html
@@ -17,7 +17,18 @@
 {{ end }}
 {{ end }}
 
-    <h1 class=span>Ideas</h1>
+    <h1 class=span>Languages</h1>
+
+{{ range .Data.Languages }}
+    <a class="card color" href="//github.com/code-golf/code-golf/issues/{{ .ID }}" title="{{ .Title }}">
+        <h2 class=span>{{ .Title }}</h2>
+        <svg><use href="#thumbs-up"/></svg>
+        {{ .ThumbsUp }}
+        <svg><use href="#thumbs-down"/></svg>
+        {{ .ThumbsDown }}
+    </a>
+{{ end }}
+    <h1 class=span>Other ideas</h1>
 
 {{ range .Data.Ideas }}
     <a class="card color" href="//github.com/code-golf/code-golf/issues/{{ .ID }}" title="{{ .Title }}">

--- a/views/ideas.html
+++ b/views/ideas.html
@@ -18,6 +18,7 @@
 {{ end }}
 
 {{ define "IdeasTable" }}
+  {{ range . }}
     <a class="card color" href="//github.com/code-golf/code-golf/issues/{{ .ID }}" title="{{ .Title }}">
         <h2 class=span>{{ .Title }}</h2>
         <svg><use href="#thumbs-up"/></svg>
@@ -25,17 +26,14 @@
         <svg><use href="#thumbs-down"/></svg>
         {{ .ThumbsDown }}
     </a>
+  {{ end }}
 {{ end }}
 
     <h1 class=span>Ideas</h1>
-{{ range .Data.Ideas }}
-    {{ template "IdeasTable" }}
-{{ end }}
+{{ template "IdeasTable" .Data.Ideas }}
 
     <h1 class=span>Language Suggestions</h1>
-{{ range .Data.Languages }}
-    {{ template "IdeasTable" }}
-{{ end }}
+{{ template "IdeasTable" .Data.Languages }}
 
     <p class="right span">
         <a href="//github.com/code-golf/code-golf/issues/new?labels=idea">

--- a/views/ideas.html
+++ b/views/ideas.html
@@ -17,27 +17,24 @@
 {{ end }}
 {{ end }}
 
+{{define "IdeasTable"}}
+    <a class="card color" href="//github.com/code-golf/code-golf/issues/{{ .ID }}" title="{{ .Title }}">
+        <h2 class=span>{{ .Title }}</h2>
+        <svg><use href="#thumbs-up"/></svg>
+        {{ .ThumbsUp }}
+        <svg><use href="#thumbs-down"/></svg>
+        {{ .ThumbsDown }}
+    </a>
+{{end}}
+
     <h1 class=span>Languages</h1>
-
 {{ range .Data.Languages }}
-    <a class="card color" href="//github.com/code-golf/code-golf/issues/{{ .ID }}" title="{{ .Title }}">
-        <h2 class=span>{{ .Title }}</h2>
-        <svg><use href="#thumbs-up"/></svg>
-        {{ .ThumbsUp }}
-        <svg><use href="#thumbs-down"/></svg>
-        {{ .ThumbsDown }}
-    </a>
+    {{template "IdeasTable"}}
 {{ end }}
-    <h1 class=span>Other ideas</h1>
 
+    <h1 class=span>Other ideas</h1>
 {{ range .Data.Ideas }}
-    <a class="card color" href="//github.com/code-golf/code-golf/issues/{{ .ID }}" title="{{ .Title }}">
-        <h2 class=span>{{ .Title }}</h2>
-        <svg><use href="#thumbs-up"/></svg>
-        {{ .ThumbsUp }}
-        <svg><use href="#thumbs-down"/></svg>
-        {{ .ThumbsDown }}
-    </a>
+    {{template "IdeasTable"}}
 {{ end }}
 
     <p class="right span">


### PR DESCRIPTION
Most of the ideas shown at `/ideas` are suggestions to add new languages. This means other ideas are harder to notice. This PR aims at solving this by separating the ideas into two groups: "Languages related" and "Other".

Please note that I have written no lines in Go before this.