### PR TITLE
Fix bugs related to auto-saving code in localstorage.

### DIFF
--- a/views/hole.html
+++ b/views/hole.html
@@ -174,8 +174,9 @@
 
 {{ with .Data.Hole.Data }}<script id=data type=application/json>{{ . }}</script>{{ end }}
 
-<script id=darkModeMediaQuery type=application/json>{{ .DarkModeMediaQuery }}</script>
-<script id=langs              type=application/json>{{ .Langs              }}</script>
-<script id=solutions          type=application/json>{{ .Data.Solutions     }}</script>
+<script id=experimental       type=application/json>{{ ne .Data.Hole.Experiment 0 }}</script>
+<script id=darkModeMediaQuery type=application/json>{{ .DarkModeMediaQuery   }}</script>
+<script id=langs              type=application/json>{{ .Langs                }}</script>
+<script id=solutions          type=application/json>{{ .Data.Solutions       }}</script>
 
 {{ template "footer" }}


### PR DESCRIPTION
* Never store the example in code localstorage (Fixes #619).
* For experimental holes, treat logged-in users as effectively logged-out for auto-save purposes, because the server will not save their solutions. This fixes an issue where passing solutions were not stored in localstorage for logged-in users (reported by @canissimia).