### PR TITLE
Update Pascal Example code

### DIFF
--- a/config/langs.toml
+++ b/config/langs.toml
@@ -544,7 +544,7 @@ begin
         writeLn(i);
 
     { Accessing arguments }
-    for i := 1 to argc do
+    for i := 1 to argc - 1 do
         writeLn(argv[i]);
 end.
 '''


### PR DESCRIPTION
looping to argc reaches 1 beyond the length of argv. in this example code, an extra line will be written with a blank argument in it:

```Pascal
var
    i: integer;
begin
 	for i := 1 to argc do
 		writeLn(argv[i], ' <- arg[', i, ']');
end.```