### PR TITLE
Time Distance: test cases for exactly two of each unit

### DIFF
--- a/hole/time-distance.go
+++ b/hole/time-distance.go
@@ -64,6 +64,8 @@ func timeDistance() ([]string, string) {
 		inputs = append(inputs, -randInt(secs, secs*2-1))       // past singular
 		inputs = append(inputs, randInt(2*secs, secsLarger-1))  // future plural
 		inputs = append(inputs, -randInt(2*secs, secsLarger-1)) // past plural
+		inputs = append(inputs, 2*secs)                         // future exactly 2
+		inputs = append(inputs, -2*secs)                        // past exactly 2
 		blimit := secs - 1
 		if blimit > 1000 {
 			blimit = 1000


### PR DESCRIPTION
My Haskell solution cheeses these and I don't like it: I shouldn't be allowed to turn `['s'|n>=2*u]` into `['s'|n>2*u]`.