### PR TITLE
Add 26 extra cases to Pangram Grep

### DIFF
--- a/hole/pangram-grep.go
+++ b/hole/pangram-grep.go
@@ -84,6 +84,17 @@ func pangramGrep() (args []string, out string) {
 		}
 	}
 
+	// Add alphabet with one letter missing
+	for del := 'a'; del <= 'z'; del++ {
+		str := []byte{}
+		for c := 'a'; c <= 'z'; c++ {
+			if c != del {
+				str = append(str, byte(c))
+			}
+		}
+		pangrams = append(pangrams, str)
+	}
+
 outer:
 	for _, pangram := range shuffle(pangrams) {
 		str := string(pangram)


### PR DESCRIPTION
This will break solutions that try to hardcode the alphabet, but not all 26 letters. 