### PR TITLE
Pangram Grep anti-cheese for new test cases

### DIFF
--- a/hole/pangram-grep.go
+++ b/hole/pangram-grep.go
@@ -90,6 +90,14 @@ func pangramGrep() (args []string, out string) {
 		for c := 'a'; c <= 'z'; c++ {
 			if c != del {
 				str = append(str, byte(c))
+				// Uppercase random letters
+				if rand.Intn(2) == 0 {
+					str[len(str)-1] -= 32
+				}
+				// Add random symbols
+				if rand.Intn(5) == 0 {
+					str = append(str, '!'+byte(rand.Intn(14)))
+				}
 			}
 		}
 		pangrams = append(pangrams, str)


### PR DESCRIPTION
Uppercase random letters and insert symbols to prevent a testcase from being used as a list of alphabet characters.