### PR TITLE
hexdump: add more testcases

### DIFF
--- a/hole/hexdump.go
+++ b/hole/hexdump.go
@@ -24,6 +24,8 @@ hexadecimal digit represents four bits (binary digits), also known as a nibble
 (or nybble). For example, an 8-bit byte can have values ranging from 00000000 to
 11111111 in binary form, which can be conveniently represented as 00 to FF in
 hexadecimal.`,
+		"0123456789abcdef",
+		"Lorem ipsum dolor sit amet,\n\n consectetur adipiscing elit\n",
 	}
 
 	outs := []string{


### PR DESCRIPTION
Mitigates some potential cheese discovered during testing.

Two testcases are added:

- exactly 16 bytes
- containing multiple consecutive newlines and trailing newline