### PR TITLE
Enable 2021 edition of rust

### DIFF
--- a/langs/rust/rust
+++ b/langs/rust/rust
@@ -8,7 +8,7 @@ export RUST_BACKTRACE=1
 [ "$1" = "--version" ] && exec rustc --version
 
 # Compile
-rustc -C linker=ld -o /tmp/code --color always -
+rustc --edition 2021 -C linker=ld -o /tmp/code --color always -
 
 # Execute
 shift


### PR DESCRIPTION
If `--edition 2021` is not supplied, the default edition is 2015, which is... old.

(not tested)