### PR TITLE
Clarify Jacobi symbol description a bit more

### DIFF
--- a/config/holes.toml
+++ b/config/holes.toml
@@ -839,16 +839,18 @@ links = [
     { name = 'Wikipedia',    url = '//en.wikipedia.org/wiki/Jacobi_symbol' },
 ]
 preamble = '''
-<p>For each input pair (a,n) print the Jacobi symbol (a/n).
+<p>For each input pair <b>(a, n)</b> print the Jacobi symbol <b>J(a, n)</b>.
 
 <p>
-    For odd prime n, (a/n) defined as 0 for a=0 mod n, as 1 if a is a square
-    mod n and -1 otherwise.
+    Both inputs are non-negative integers, and <b>n</b> is odd.
     <br>
-    For odd n=m*p, (a/n) is defined as (a/m)*(a/p).
+    If <b>n</b> is prime, then <b>J(a, n)</b> is defined as <b>0</b> if <b>a=0 (mod n)</b>, as <b>1</b> if <b>a</b> is a square
+    modulo <b>n</b>, and <b>−1</b> otherwise.
+    <br>
+    If <b>n = x*y</b>, then <b>J(a, n)</b> is defined as <b>J(a, x)*J(a, y)</b>.
     <br>
     Note that calculating the symbol from the definition is not very efficient
-    as it requires factorisation of n.
+    as it requires factorisation of <b>n</b>.
 '''
 
 ['Kolakoski Constant']

--- a/config/holes.toml
+++ b/config/holes.toml
@@ -839,7 +839,7 @@ links = [
     { name = 'Wikipedia',    url = '//en.wikipedia.org/wiki/Jacobi_symbol' },
 ]
 preamble = '''
-<p>For each input pair <b>(a, n)</b> print the Jacobi symbol <b>J(a, n)</b>.
+<p>For each argument <code>a n</code>, print the value of the Jacobi symbol <b>J(a, n)</b>.
 
 <p>
     Both inputs are non-negative integers, and <b>n</b> is odd.


### PR DESCRIPTION
Use bold for inline math as in some other hole descriptions, specify the domain of the inputs, and use the notation **J(a, b)** instead of **(a/b)**.