### PR TITLE
use expected output in preamble, add copy output button

### DIFF
--- a/config/holes.go
+++ b/config/holes.go
@@ -24,6 +24,7 @@ type (
 	Hole struct {
 		Category, CategoryColor, CategoryIcon string
 		Data                                  template.JS
+		Output                                string
 		Experiment                            int
 		ID, Name, Prev, Next                  string
 		Preamble                              template.HTML
@@ -79,17 +80,31 @@ func init() {
 	for name, hole := range holes {
 		hole.ID = id(name)
 		hole.Name = name
+		holeID := hole.ID
+		hole.Output = ""
+		if holeID == "√2" {
+			holeID = "root-2"
+		}
 
-		// Process the templated preamble with the data.
-		if hole.Data != "" {
+		if b, err := answers.ReadFile("answers/" + holeID + ".txt"); err == nil {
+			hole.Output = string(bytes.TrimSuffix(b, []byte{'\n'}))
+		}
+
+		if hole.Data != "" or hole.Output != "" {
 			t, err := template.New("").Parse(string(hole.Preamble))
 			if err != nil {
 				panic(err)
 			}
 
-			var data ordered.Map
-			if err := json.Unmarshal([]byte(hole.Data), &data); err != nil {
-				panic(err)
+			var data struct {
+				Data ordered.Map
+				Output string
+			}
+			data.Output = hole.Output
+			if hole.Data != "" {
+				if err := json.Unmarshal([]byte(hole.Data), &data.Data); err != nil {
+					panic(err)
+				}
 			}
 
 			var b bytes.Buffer

--- a/config/holes.toml
+++ b/config/holes.toml
@@ -30,26 +30,10 @@ links = [
 preamble = '''
 <p>Print the lyrics to the song <b>The 12 Days of Christmas</b>:</p>
 
-<blockquote>On the First day of Christmas
-My true love sent to me
-A Partridge in a Pear Tree.
-<br><br>
+<blockquote>
+{{ lines 5 .Output }}
 …
-<br><br>
-On the Twelfth day of Christmas
-My true love sent to me
-Twelve Drummers Drumming,
-Eleven Pipers Piping,
-Ten Lords-a-Leaping,
-Nine Ladies Dancing,
-Eight Maids-a-Milking,
-Seven Swans-a-Swimming,
-Six Geese-a-Laying,
-Five Gold Rings,
-Four Calling Birds,
-Three French Hens,
-Two Turtle Doves, and
-A Partridge in a Pear Tree.
+{{ lines -16 .Output }}
 </blockquote>
 '''
 
@@ -62,19 +46,10 @@ links = [
 preamble = '''
 <p>Print the lyrics to the song <b>99 Bottles of Beer</b>:</p>
 
-<blockquote>99 bottles of beer on the wall, 99 bottles of beer.
-Take one down and pass it around, 98 bottles of beer on the wall.
-<br><br>
-98 bottles of beer on the wall, 98 bottles of beer.
-Take one down and pass it around, 97 bottles of beer on the wall.
-<br><br>
+<blockquote>
+{{ lines 6 .Output }}
 …
-<br><br>
-1 bottle of beer on the wall, 1 bottle of beer.
-Take one down and pass it around, no more bottles of beer on the wall.
-<br><br>
-No more bottles of beer on the wall, no more bottles of beer.
-Go to the store and buy some more, 99 bottles of beer on the wall.
+{{ lines -6 .Output }}
 </blockquote>
 '''
 
@@ -219,26 +194,7 @@ links = [
 preamble = '''
 <p>Print the following ASCII table, taken from <code>man 7 ascii</code>
 
-<pre>
-   2 3 4 5 6 7
- -------------
-0:   0 @ P ` p
-1: ! 1 A Q a q
-2: " 2 B R b r
-3: # 3 C S c s
-4: $ 4 D T d t
-5: % 5 E U e u
-6: & 6 F V f v
-7: ' 7 G W g w
-8: ( 8 H X h x
-9: ) 9 I Y i y
-A: * : J Z j z
-B: + ; K [ k {
-C: , < L \ l |
-D: - = M ] m }
-E: . > N ^ n ~
-F: / ? O _ o DEL
-</pre>
+<pre>{{ .Output }}</pre>
 '''
 
 [brainfuck]
@@ -332,25 +288,12 @@ preamble = '''
     A size <b>3</b> tree should look like this, with a single centered
     asterisk for the trunk:
 
-<pre>   *
-  ***
- *****
-   *
+<pre>{{ lines 4 .Output }}
 </pre>
 
 <p>With the largest size <b>9</b> tree looking like this:
 
-<pre>         *
-        ***
-       *****
-      *******
-     *********
-    ***********
-   *************
-  ***************
- *****************
-         *
-</pre>
+<pre>{{ lines -10 .Output }}</pre>
 '''
 
 [Collatz]
@@ -471,7 +414,7 @@ Given each CSS color keyword print the corresponding hex value. The output
 will be checked case-insensitively. The full mapping is as follows:
 
 <div id=colors>
-{{ range . }}
+{{ range .Data }}
     {{ if or (eq .Key "IndianRed") (eq .Key "Magenta")
              (eq .Key "Cyan"     ) (eq .Key "Sienna" ) }}
         <table><thead><tr><th>Keyword<th>Hex<tbody>
@@ -498,41 +441,11 @@ preamble = '''
     range from size <b>1</b> to size <b>7</b> with a blank line between each
     cube. A size <b>1</b> cube should look like:
 
-<pre>  █────█
- ╱    ╱│
-█────█ │
-│    │ █
-│    │╱
-█────█
-</pre>
+<pre>{{ lines 6 .Output }}</pre>
 
 <p>And a size <b>7</b> cube should look like:
 
-<pre>        █────────────────────────────█
-       ╱                            ╱│
-      ╱                            ╱ │
-     ╱                            ╱  │
-    ╱                            ╱   │
-   ╱                            ╱    │
-  ╱                            ╱     │
- ╱                            ╱      │
-█────────────────────────────█       │
-│                            │       │
-│                            │       │
-│                            │       │
-│                            │       │
-│                            │       │
-│                            │       │
-│                            │       █
-│                            │      ╱
-│                            │     ╱
-│                            │    ╱
-│                            │   ╱
-│                            │  ╱
-│                            │ ╱
-│                            │╱
-█────────────────────────────█
-</pre>
+<pre>{{ lines -24 .Output }}</pre>
 '''
 
 [Diamonds]
@@ -544,28 +457,11 @@ preamble = '''
     separated by a blank line.<p>A size <b>1</b> diamond should look like
     this, a single centered <b>1</b>:
 
-<pre>         1</pre>
+<pre>{{ lines 1 .Output }}</pre>
 
 <p>With the largest size <b>9</b> diamond looking like this:
 
-<pre>         1
-        121
-       12321
-      1234321
-     123454321
-    12345654321
-   1234567654321
-  123456787654321
- 12345678987654321
-  123456787654321
-   1234567654321
-    12345654321
-     123454321
-      1234321
-       12321
-        121
-         1
-</pre>
+<pre>{{ lines -17 .Output }}</pre>
 '''
 
 [Divisors]
@@ -631,7 +527,7 @@ preamble = '''
 <p>Note despite how they appear below, there are no spaces in the emoticons.
 
 <div id=emojify>
-{{ range . }}
+{{ range .Data }}
     <div>{{ .Value }}<pre>{{ .Key }}{{ if eq .Key ":-" }} {{ end }}</pre></div>
 {{ end }}
 </div>
@@ -1360,16 +1256,7 @@ preamble = '''
 
 <p>The full grid should look like this:
 
-<pre> 0  1  2  3  4  5  6  7  8  9
-35 36 37 38 39 40 41 42 43 10
-34 63 64 65 66 67 68 69 44 11
-33 62 83 84 85 86 87 70 45 12
-32 61 82 95 96 97 88 71 46 13
-31 60 81 94 99 98 89 72 47 14
-30 59 80 93 92 91 90 73 48 15
-29 58 79 78 77 76 75 74 49 16
-28 57 56 55 54 53 52 51 50 17
-27 26 25 24 23 22 21 20 19 18</pre>
+<pre>{{ .Output }}</pre>
 '''
 
 ['Odd Polyomino Tiling']
@@ -1797,17 +1684,7 @@ preamble = '''
 where 1 is alive, 0 is dead, and the middle digit represents the previous state of the current cell.
 <p>
     The first 10 rows are shown here:
-<pre>         █
-        ██
-       ███
-      ██ █
-     █████
-    ██   █
-   ███  ██
-  ██ █ ███
- ███████ █
-██     ███
-</pre>
+<pre>{{ lines 10 .Output }}</pre>
 
 '''
 
@@ -1845,23 +1722,7 @@ preamble = '''
     A Sierpiński triangle of order 4 should look like this, print such an
     output:
 
-<pre>               ▲
-              ▲ ▲
-             ▲   ▲
-            ▲ ▲ ▲ ▲
-           ▲       ▲
-          ▲ ▲     ▲ ▲
-         ▲   ▲   ▲   ▲
-        ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲
-       ▲               ▲
-      ▲ ▲             ▲ ▲
-     ▲   ▲           ▲   ▲
-    ▲ ▲ ▲ ▲         ▲ ▲ ▲ ▲
-   ▲       ▲       ▲       ▲
-  ▲ ▲     ▲ ▲     ▲ ▲     ▲ ▲
- ▲   ▲   ▲   ▲   ▲   ▲   ▲   ▲
-▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲
-</pre>
+<pre>{{ .Output }}</pre>
 '''
 
 ['Smith Numbers']
@@ -2125,22 +1986,7 @@ links = [
 preamble = '''
 <p>Output the following tongue twisters with a blank line between each one:
 
-<blockquote>
-How much wood would a woodchuck chuck,
-If a woodchuck could chuck wood?
-A woodchuck would chuck all the wood he could chuck
-If a woodchuck would chuck wood.
-<br><br>
-Peter Piper picked a peck of pickled peppers.
-A peck of pickled peppers Peter Piper picked.
-If Peter Piper picked a peck of pickled peppers,
-Where's the peck of pickled peppers Peter Piper picked?
-<br><br>
-She sells seashells by the seashore,
-The shells she sells are seashells, I'm sure.
-So if she sells seashells on the seashore,
-Then I'm sure she sells seashore shells.
-</blockquote>
+<blockquote>{{ .Output }}</blockquote>
 '''
 
 [Turtle]
@@ -2219,7 +2065,7 @@ preamble = '''
 <p>The full mapping is as follows:
 
 <div id=states>
-{{ range . }}
+{{ range .Data }}
     {{ if or (eq .Value "AL") (eq .Value "IL")
              (eq .Value "MT") (eq .Value "RI") }}
         <table><thead><tr><th>State<th>Abbr.<tbody>

--- a/css/hole-ng.css
+++ b/css/hole-ng.css
@@ -123,18 +123,18 @@ section header {
     line-height: 2rem;
 }
 
-#copy + span {
+.btn.copy + span {
     opacity: 0;
     transition: all 2s;
 }
 
-#copy:active + span {
+.btn.copy:active + span {
     opacity: 1;
     padding-left: 1rem;
     transition: all 0s;
 }
 
-#copy { display: inline }
+.btn.copy { display: inline }
 
 #editor {
     border: 1px solid var(--color);

--- a/css/hole.css
+++ b/css/hole.css
@@ -118,18 +118,18 @@ section header {
     line-height: 2rem;
 }
 
-#copy + span {
+.btn.copy + span {
     opacity: 0;
     transition: all 2s;
 }
 
-#copy:active + span {
+.btn.copy:active + span {
     opacity: 1;
     padding-left: 1rem;
     transition: all 0s;
 }
 
-#copy { display: inline }
+.btn.copy { display: inline }
 
 #editor {
     border: 1px solid var(--color);

--- a/js/_copy-as-json.ts
+++ b/js/_copy-as-json.ts
@@ -1,4 +1,6 @@
 import { $ } from './_util';
 
-$('#copy')?.addEventListener('click', () =>
-    navigator.clipboard.writeText($('#data').innerText));
+$('#copyJson')?.addEventListener('click', () =>
+    navigator.clipboard.writeText($('#dataJson').innerText));
+$('#copyOutput')?.addEventListener('click', () =>
+    navigator.clipboard.writeText($('#dataOutput').innerText));

--- a/routes/render.go
+++ b/routes/render.go
@@ -38,6 +38,14 @@ func colour(i int) string {
 	return "green"
 }
 
+func getLines(i int, text string) string {
+    lines := strings.Split(text, "\n")
+	if i >= 0{
+        return strings.Join(lines[:i], "\n")
+    }
+    return strings.Join(lines[len(lines)+i:], "\n")
+}
+
 var (
 	assets = map[string]string{}
 	css    = map[string]template.CSS{}
@@ -49,6 +57,7 @@ var (
 var tmpl = template.New("").Funcs(template.FuncMap{
 	"bytes":     pretty.Bytes,
 	"colour":    colour,
+    "lines":     getLines,
 	"comma":     pretty.Comma,
 	"dec":       func(i int) int { return i - 1 },
 	"hasPrefix": strings.HasPrefix,

--- a/views/hole-ng.html
+++ b/views/hole-ng.html
@@ -66,7 +66,10 @@
         <div class=grid>
             {{ .Data.Hole.Preamble }}
         {{ if .Data.Hole.Data }}
-            <div><button class="btn orange" id=copy>Copy as JSON</button><span>Copied</span></div>
+            <div><button class="btn copy orange" id=copyJson>Copy as JSON</button><span>Copied</span></div>
+        {{ end }}
+        {{ if .Data.Hole.Output }}
+            <div><button class="btn copy orange" id=copyOutput>Copy output</button><span>Copied</span></div>
         {{ end }}
         </div>
     </details>
@@ -209,7 +212,8 @@
 
 <div id=popups></div>
 
-{{ with .Data.Hole.Data }}<script id=data type=application/json>{{ . }}</script>{{ end }}
+{{ with .Data.Hole.Output }}<data id=dataOutput style="display: none">{{ . }}</data>{{ end }}
+{{ with .Data.Hole.Data }}<script id=dataJson type=application/json>{{ . }}</script>{{ end }}
 
 <script id=experimental       type=application/json>{{ ne .Data.Hole.Experiment 0 }}</script>
 <script id=darkModeMediaQuery type=application/json>{{ .DarkModeMediaQuery   }}</script>

--- a/views/hole.html
+++ b/views/hole.html
@@ -66,7 +66,10 @@
         <div class=grid>
             {{ .Data.Hole.Preamble }}
         {{ if .Data.Hole.Data }}
-            <div><button class="btn orange" id=copy>Copy as JSON</button><span>Copied</span></div>
+            <div><button class="btn copy orange" id=copyJson>Copy as JSON</button><span>Copied</span></div>
+        {{ end }}
+        {{ if .Data.Hole.Output }}
+            <div><button class="btn copy orange" id=copyOutput>Copy output</button><span>Copied</span></div>
         {{ end }}
         </div>
     </details>
@@ -211,11 +214,13 @@
 
 <div id=popups></div>
 
+{{ with .Data.Hole.Output }}<data id=dataOutput style="display: none">{{ . }}</data>{{ end }}
+
 <script id=keymap type=application/json>
     {{ with .Golfer }}{{ .Keymap }}{{ else }}"default"{{ end }}
 </script>
 
-{{ with .Data.Hole.Data }}<script id=data type=application/json>{{ . }}</script>{{ end }}
+{{ with .Data.Hole.Data }}<script id=dataJson type=application/json>{{ . }}</script>{{ end }}
 
 <script id=experimental       type=application/json>{{ ne .Data.Hole.Experiment 0 }}</script>
 <script id=darkModeMediaQuery type=application/json>{{ .DarkModeMediaQuery   }}</script>


### PR DESCRIPTION
In this draft PR, I attempted to do two things related to the fixed output holes.
1. Avoid duplicating the output data in the hole description.
2. Add Copy button, similar to the existing one for json.

However, I don't know how to load the outputs, since the answer files are in another folder.
Can you help me finish this?