### PR TITLE
Make golfer/holes cells narrower

### DIFF
--- a/css/golfer/holes.css
+++ b/css/golfer/holes.css
@@ -11,7 +11,7 @@ main > a {
     border: 1px solid var(--color);
     color: var(--color);
     display: flex;
-    padding: .25rem;
+    padding: .25rem 0.0625rem;
     text-decoration: none;
 }
 
@@ -80,7 +80,7 @@ input:checked + label {
 
 label {
     cursor: pointer;
-    padding: .25rem;
+    padding: .25rem 0;
     text-align: center;
 }
 
@@ -96,7 +96,7 @@ main svg:nth-of-type(2) {
 
 @media (min-width: 95rem) {
     /* Increase this number when adding a language. */
-    main { grid-template-columns: 4fr repeat(40, 1fr) }
+    main { grid-template-columns: 6fr repeat(40, 1fr) }
 
     main a { height: 1.9rem }
 


### PR DESCRIPTION
Just a quick fix since the number of languages grows and redesign is probably not gonna be here any time soon. Hole names are now mostly visible on 1920px.
Old:
![image](https://user-images.githubusercontent.com/13916220/174092753-418c0502-bf60-42ea-8dc2-6026672410d1.png)

New:
![image](https://user-images.githubusercontent.com/13916220/174092420-2a570143-511b-41de-8618-b22af1052b10.png)
