### PR TITLE
Fix "additional tabs" dropdown css in tab layout

### DIFF
--- a/css/vendor/goldenlayout-base.css
+++ b/css/vendor/goldenlayout-base.css
@@ -242,7 +242,6 @@
   border-top: 5px dashed;
   border-right: 5px solid transparent;
   border-left: 5px solid transparent;
-  color: white;
 }
 .lm_header .lm_tabdropdown_list {
   position: absolute;

--- a/css/vendor/goldenlayout-theme.css
+++ b/css/vendor/goldenlayout-theme.css
@@ -36,7 +36,6 @@
   color: var(--grey);
   margin-right: 2px;
   border: 1px solid var(--gl-border);
-  border-bottom: none;
 }
 .lm_header .lm_tab .lm_title {
   padding-top: 1px;
@@ -94,7 +93,7 @@
   opacity: 1;
 }
 .lm_controls .lm_maximise {
-  background: var(--color); 
+  background: var(--color);
   -webkit-mask: url(./img/lm_maximize.svg) center / 12px 12px no-repeat;
   mask: url(./img/lm_maximize.svg) center / 12px 12px no-repeat;
 }


### PR DESCRIPTION
Minor CSS changes to make this dropdown properly visible when toggled with the arrow. Checked on dark theme too.

![image](https://user-images.githubusercontent.com/20214911/190974882-e1fca036-4175-4a05-b25c-d3acb6980867.png)
