### PR TITLE
Fix alert pool for "info" banners

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -201,8 +201,10 @@ main {
     padding: 1rem;
 }
 
-nav #alert-pool,
-nav > :empty { flex: 1 }
+nav #alert-pool {
+    flex: 1;
+    margin-right: 0.5em;
+}
 
 select {
     -webkit-appearance: none;

--- a/css/hole-tabs.css
+++ b/css/hole-tabs.css
@@ -198,7 +198,7 @@ main {
     position: relative;
 }
 
-.alert .main_close {
+.main_close {
     position: absolute;
     top: 0;
     right: 0;

--- a/js/hole-tabs.tsx
+++ b/js/hole-tabs.tsx
@@ -42,10 +42,9 @@ let editor: EditorView | null = null;
 init(true, setSolution, setCodeForLangAndSolution, updateReadonlyPanels, () => editor);
 
 // Handle showing/hiding alerts
-for (const alert of $$('.alert')) {
-    const closeBtn = alert.querySelector('.main_close');
-    if (!closeBtn) continue;
-    closeBtn.addEventListener('click', () => {
+for (const alertCloseBtn of $$('.main_close')) {
+    const alert = alertCloseBtn.parentNode as HTMLDivElement;
+    alertCloseBtn.addEventListener('click', () => {
         const child = (alert.querySelector('svg') as any).cloneNode(true);
         $('#alert-pool').appendChild(child);
         alert.classList.add('hide');

--- a/views/header.html
+++ b/views/header.html
@@ -94,5 +94,6 @@
         {{ svg "info-circle" }}
     {{ end }}
         <p>{{ .Body }}
+        <div class=main_close></div>
     </div>
 {{ end }}

--- a/views/header.html
+++ b/views/header.html
@@ -67,7 +67,6 @@
             {{ svg "journals" }}
         </a>
         <div id=alert-pool></div>
-        <div></div>
     {{ with .Golfer }}
         {{ $slug := (print "/golfers/" .Name) }}
 


### PR DESCRIPTION
In the big tab layout PR, I included the ability to close alert banners, moving them to an alert pool at the top-right (this was grouped with the tab layout PR because vertical space is a premium on tab layout, and the PR also added X button SVGs).

This new PR fixes the button to appear and work for "info" banners, not just "alert" banners.
![image](https://user-images.githubusercontent.com/20214911/190980342-d530ea6a-54ae-4cd5-9f61-9a131f26fb86.png)

This is related to issue #709, asking for the ability to close banners. Now all banners can be closed in tab layout, but it only lasts until page reload or navigation. Local persistence like #738 would work, but it might be better to store ignored banners server-side as alluded to in afd220473fc95b5c181808576f10b0f6bdbb47dd.
