### PR TITLE
Enable tcl syntax highlighting

### DIFF
--- a/js/_codemirror.ts
+++ b/js/_codemirror.ts
@@ -46,6 +46,7 @@ import { rust }        from '@codemirror/lang-rust';
 import { shell }       from '@codemirror/legacy-modes/mode/shell';
 import { sql, SQLite } from '@codemirror/lang-sql';
 import { swift }       from '@codemirror/legacy-modes/mode/swift';
+import { tcl }         from '@codemirror/legacy-modes/mode/tcl';
 import { wren }        from '@exercism/codemirror-lang-wren';
 
 // For some reason, this doesn't fully work unless added to both themes.
@@ -134,6 +135,7 @@ export const extensions = {
     // TODO sed
     'sql':        sql({ dialect: SQLite }),
     'swift':      StreamLanguage.define(swift),
+    'tcl':        StreamLanguage.define(tcl),
     // TODO v
     // TODO viml
     'wren':       wren(),


### PR DESCRIPTION
Turns out Codemirror legacy modes already include a Tcl syntax highlighter