### PR TITLE
Add Go caching to GitHub Actions

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -10,6 +10,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
+          cache: true
           go-version-file: go.mod
 
       - uses: actions/setup-node@v3


### PR DESCRIPTION
Cuts the `make test` stage from ~30s to <5s