### PR TITLE
QR Encoder should force the calculation of error correction

### DIFF
--- a/config/holes.toml
+++ b/config/holes.toml
@@ -1769,6 +1769,8 @@ preamble = '''
     (4)   (17)      (17-byte ASCII message)            (0)   (7 error correction bytes)
 </pre>
 
+<p>The 7 error correction bytes must be calculated using a form of <b>Reed-Solomon error correction</b>. 
+
 <p>To encode a bit from the bitstream to a strip, determine the coordinates <b>(x, y)</b> of the current position in the bitmap with the origin <b>(0, 0)</b> at the top-left corner, invert the bit if <b>(x+y)%2 = 0</b>, and write the value to this position ("#" = 1, space = 0).
 '''
 

--- a/config/holes.toml
+++ b/config/holes.toml
@@ -1653,6 +1653,8 @@ preamble = '''
 category = 'Transform'
 links = [
     { name = 'Wikipedia', url = '//en.wikipedia.org/wiki/QR_code#Encoding' },
+    { name = 'Nayuki', url = '//www.nayuki.io/page/creating-a-qr-code-step-by-step' },
+    { name = 'Thonky', url = '//www.thonky.com/qr-code-tutorial/' },
 ]
 preamble = '''
 <div class=qr-span>
@@ -1714,6 +1716,8 @@ category = 'Transform'
 experiment = -1
 links = [
     { name = 'Wikipedia', url = '//en.wikipedia.org/wiki/QR_code#Encoding' },
+    { name = 'Nayuki', url = '//www.nayuki.io/page/creating-a-qr-code-step-by-step' },
+    { name = 'Thonky', url = '//www.thonky.com/qr-code-tutorial/' },
 ]
 preamble = '''
 <div class=qr-span>

--- a/hole/qr.go
+++ b/hole/qr.go
@@ -116,8 +116,5 @@ func qr(decoder bool) []Scorecard {
 		return []Scorecard{{Args: []string{qrString}, Answer: content}}
 	}
 
-	return []Scorecard{{
-		Args:   []string{content + " " + hex.EncodeToString(getErrorCorrectionBlocks(qr))},
-		Answer: qrString,
-	}}
+	return []Scorecard{{Args: []string{content}, Answer: qrString}}
 }


### PR DESCRIPTION
Rationale: 
- When dealing with a fixed size, encoding and error correction level, (V1, byte, L) ECC is not too challenging.
- QR code encoding is unique style of algorithm compared to the rest of the challenges.
- the QR Decoder and Encoder challenges might be too similar
- Decoder is still in a 'beta' stage
Cons:
- Error correction coding might not have "more than one ways to do it" that allow other challenges to have creative codegolfs.
- Decoder has been in a 'beta' stage for almost a year; solutions may have 'settled in'

---

I have not seen any discussion about this topic - but please let me know what you think.
