### PR TITLE
Use a brighter color for the CodeMirror cursor in dark mode.

### DIFF
--- a/js/_codemirror.ts
+++ b/js/_codemirror.ts
@@ -83,9 +83,11 @@ export const extensions = {
     'dark': [
         EditorView.theme({
             '&': { background: 'var(--background)', color: 'var(--color)' },
-            '.cm-asm-dump':          { color: 'var(--asm-dump)' },
-            '.cm-asm-error-tooltip': asmErrorTooltip,
-            '.cm-gutters':           { background: 'var(--light-grey)' },
+            '.cm-asm-dump':               { color: 'var(--asm-dump)' },
+            '.cm-asm-error-tooltip':      asmErrorTooltip,
+            '.cm-gutters':                { background: 'var(--light-grey)' },
+            '.cm-content':                { caretColor: 'var(--color)' },
+            '.cm-cursor, .cm-dropCursor': { borderLeftColor: 'var(--color)' },
         }, { dark: true }),
         syntaxHighlighting(HighlightStyle.define([
             { color: '#98c379', tag: tags.literal },


### PR DESCRIPTION
Example of cursor at the end of the word "Printing". It's easier to see the cursor with this change.

Before:
<img width="314" alt="b" src="https://user-images.githubusercontent.com/53135437/194217300-5a3af262-bd6d-4d86-8343-6085187458ad.png">

After:
<img width="292" alt="a" src="https://user-images.githubusercontent.com/53135437/194217320-badbfe44-9541-4e56-aee2-3fada05e3954.png">
