### PR TITLE
Fixed COBOL syntax highlighter. Restored old Raku syntax highlighter.

### DIFF
--- a/js/_codemirror.ts
+++ b/js/_codemirror.ts
@@ -20,7 +20,7 @@ import { vim }                                   from '@replit/codemirror-vim';
 import { assembly }    from '@defasm/codemirror';
 // import { brainfuck }   from '@codemirror/legacy-modes/mode/brainfuck';
 import { c, csharp }   from '@codemirror/legacy-modes/mode/clike';
-import { cobol }       from '@codemirror/legacy-modes/mode/cobol';
+import { cobol }       from './vendor/codemirror-cobol';
 import { commonLisp }  from '@codemirror/legacy-modes/mode/commonlisp';
 import { cpp }         from '@codemirror/lang-cpp';
 import { crystal }     from '@codemirror/legacy-modes/mode/crystal';
@@ -41,6 +41,7 @@ import { perl }        from '@codemirror/legacy-modes/mode/perl';
 import { php }         from '@codemirror/lang-php';
 import { powerShell }  from '@codemirror/legacy-modes/mode/powershell';
 import { python }      from '@codemirror/lang-python';
+import { raku }        from './vendor/codemirror-raku';
 import { ruby }        from '@codemirror/legacy-modes/mode/ruby';
 import { rust }        from '@codemirror/lang-rust';
 import { shell }       from '@codemirror/legacy-modes/mode/shell';
@@ -131,7 +132,7 @@ export const extensions = {
     'powershell': StreamLanguage.define(powerShell),
     // TODO prolog
     'python':     python(),
-    'raku':       StreamLanguage.define(perl),  // TODO raku
+    'raku':       StreamLanguage.define(raku),
     'ruby':       StreamLanguage.define(ruby),
     'rust':       rust(),
     // TODO sed

--- a/js/vendor/codemirror-cobol.d.ts
+++ b/js/vendor/codemirror-cobol.d.ts
@@ -1,0 +1,2 @@
+import {StreamParser} from '@codemirror/language';
+export declare const cobol: StreamParser<unknown>;

--- a/js/vendor/codemirror-cobol.js
+++ b/js/vendor/codemirror-cobol.js
@@ -1,0 +1,223 @@
+const BUILTIN = 'builtin', COMMENT = 'comment', STRING = 'string',
+    ATOM = 'atom', NUMBER = 'number', KEYWORD = 'keyword';
+function makeKeywords(str) {
+    const obj = {}, words = str.split(' ');
+    for (let i = 0; i < words.length; ++i) obj[words[i]] = true;
+    return obj;
+}
+const atoms = makeKeywords('TRUE FALSE ZEROES ZEROS ZERO SPACES SPACE LOW-VALUE LOW-VALUES ');
+const keywords = makeKeywords(
+    'ACCEPT ACCESS ACQUIRE ADD ADDRESS ' +
+    'ADVANCING AFTER ALIAS ALL ALPHABET ' +
+    'ALPHABETIC ALPHABETIC-LOWER ALPHABETIC-UPPER ALPHANUMERIC ALPHANUMERIC-EDITED ' +
+    'ALSO ALTER ALTERNATE AND ANY ' +
+    'ARE AREA AREAS ARITHMETIC ASCENDING ' +
+    'ASSIGN AT ATTRIBUTE AUTHOR AUTO ' +
+    'AUTO-SKIP AUTOMATIC B-AND B-EXOR B-LESS ' +
+    'B-NOT B-OR BACKGROUND-COLOR BACKGROUND-COLOUR BEEP ' +
+    'BEFORE BELL BINARY BIT BITS ' +
+    'BLANK BLINK BLOCK BOOLEAN BOTTOM ' +
+    'BY CALL CANCEL CD CF ' +
+    'CH CHARACTER CHARACTERS CLASS CLOCK-UNITS ' +
+    'CLOSE COBOL CODE CODE-SET COL ' +
+    'COLLATING COLUMN COMMA COMMIT COMMITMENT ' +
+    'COMMON COMMUNICATION COMP COMP-0 COMP-1 ' +
+    'COMP-2 COMP-3 COMP-4 COMP-5 COMP-6 ' +
+    'COMP-7 COMP-8 COMP-9 COMPUTATIONAL COMPUTATIONAL-0 ' +
+    'COMPUTATIONAL-1 COMPUTATIONAL-2 COMPUTATIONAL-3 COMPUTATIONAL-4 COMPUTATIONAL-5 ' +
+    'COMPUTATIONAL-6 COMPUTATIONAL-7 COMPUTATIONAL-8 COMPUTATIONAL-9 COMPUTE ' +
+    'CONFIGURATION CONNECT CONSOLE CONTAINED CONTAINS ' +
+    'CONTENT CONTINUE CONTROL CONTROL-AREA CONTROLS ' +
+    'CONVERTING COPY CORR CORRESPONDING COUNT ' +
+    'CRT CRT-UNDER CURRENCY CURRENT CURSOR ' +
+    'DATA DATE DATE-COMPILED DATE-WRITTEN DAY ' +
+    'DAY-OF-WEEK DB DB-ACCESS-CONTROL-KEY DB-DATA-NAME DB-EXCEPTION ' +
+    'DB-FORMAT-NAME DB-RECORD-NAME DB-SET-NAME DB-STATUS DBCS ' +
+    'DBCS-EDITED DE DEBUG-CONTENTS DEBUG-ITEM DEBUG-LINE ' +
+    'DEBUG-NAME DEBUG-SUB-1 DEBUG-SUB-2 DEBUG-SUB-3 DEBUGGING ' +
+    'DECIMAL-POINT DECLARATIVES DEFAULT DELETE DELIMITED ' +
+    'DELIMITER DEPENDING DESCENDING DESCRIBED DESTINATION ' +
+    'DETAIL DISABLE DISCONNECT DISPLAY DISPLAY-1 ' +
+    'DISPLAY-2 DISPLAY-3 DISPLAY-4 DISPLAY-5 DISPLAY-6 ' +
+    'DISPLAY-7 DISPLAY-8 DISPLAY-9 DIVIDE DIVISION ' +
+    'DOWN DROP DUPLICATE DUPLICATES DYNAMIC ' +
+    'EBCDIC EGI EJECT ELSE EMI ' +
+    'EMPTY EMPTY-CHECK ENABLE END END. END-ACCEPT END-ACCEPT. ' +
+    'END-ADD END-CALL END-COMPUTE END-DELETE END-DISPLAY ' +
+    'END-DIVIDE END-EVALUATE END-IF END-INVOKE END-MULTIPLY ' +
+    'END-OF-PAGE END-PERFORM END-READ END-RECEIVE END-RETURN ' +
+    'END-REWRITE END-SEARCH END-START END-STRING END-SUBTRACT ' +
+    'END-UNSTRING END-WRITE END-XML ENTER ENTRY ' +
+    'ENVIRONMENT EOP EQUAL EQUALS ERASE ' +
+    'ERROR ESI EVALUATE EVERY EXCEEDS ' +
+    'EXCEPTION EXCLUSIVE EXIT EXTEND EXTERNAL ' +
+    'EXTERNALLY-DESCRIBED-KEY FD FETCH FILE FILE-CONTROL ' +
+    'FILE-STREAM FILES FILLER FINAL FIND ' +
+    'FINISH FIRST FOOTING FOR FOREGROUND-COLOR ' +
+    'FOREGROUND-COLOUR FORMAT FREE FROM FULL ' +
+    'FUNCTION GENERATE GET GIVING GLOBAL ' +
+    'GO GOBACK GREATER GROUP HEADING ' +
+    'HIGH-VALUE HIGH-VALUES HIGHLIGHT I-O I-O-CONTROL ' +
+    'ID IDENTIFICATION IF IN INDEX ' +
+    'INDEX-1 INDEX-2 INDEX-3 INDEX-4 INDEX-5 ' +
+    'INDEX-6 INDEX-7 INDEX-8 INDEX-9 INDEXED ' +
+    'INDIC INDICATE INDICATOR INDICATORS INITIAL ' +
+    'INITIALIZE INITIATE INPUT INPUT-OUTPUT INSPECT ' +
+    'INSTALLATION INTO INVALID INVOKE IS ' +
+    'JUST JUSTIFIED KANJI KEEP KEY ' +
+    'LABEL LAST LD LEADING LEFT ' +
+    'LEFT-JUSTIFY LENGTH LENGTH-CHECK LESS LIBRARY ' +
+    'LIKE LIMIT LIMITS LINAGE LINAGE-COUNTER ' +
+    'LINE LINE-COUNTER LINES LINKAGE LOCAL-STORAGE ' +
+    'LOCALE LOCALLY LOCK ' +
+    'MEMBER MEMORY MERGE MESSAGE METACLASS ' +
+    'MODE MODIFIED MODIFY MODULES MOVE ' +
+    'MULTIPLE MULTIPLY NATIONAL NATIVE NEGATIVE ' +
+    'NEXT NO NO-ECHO NONE NOT ' +
+    'NULL NULL-KEY-MAP NULL-MAP NULLS NUMBER ' +
+    'NUMERIC NUMERIC-EDITED OBJECT OBJECT-COMPUTER OCCURS ' +
+    'OF OFF OMITTED ON ONLY ' +
+    'OPEN OPTIONAL OR ORDER ORGANIZATION ' +
+    'OTHER OUTPUT OVERFLOW OWNER PACKED-DECIMAL ' +
+    'PADDING PAGE PAGE-COUNTER PARSE PERFORM ' +
+    'PF PH PIC PICTURE PLUS ' +
+    'POINTER POSITION POSITIVE PREFIX PRESENT ' +
+    'PRINTING PRIOR PROCEDURE PROCEDURE-POINTER PROCEDURES ' +
+    'PROCEED PROCESS PROCESSING PROGRAM PROGRAM-ID ' +
+    'PROMPT PROTECTED PURGE QUEUE QUOTE ' +
+    'QUOTES RANDOM RD READ READY ' +
+    'REALM RECEIVE RECONNECT RECORD RECORD-NAME ' +
+    'RECORDS RECURSIVE REDEFINES REEL REFERENCE ' +
+    'REFERENCE-MONITOR REFERENCES RELATION RELATIVE RELEASE ' +
+    'REMAINDER REMOVAL RENAMES REPEATED REPLACE ' +
+    'REPLACING REPORT REPORTING REPORTS REPOSITORY ' +
+    'REQUIRED RERUN RESERVE RESET RETAINING ' +
+    'RETRIEVAL RETURN RETURN-CODE RETURNING REVERSE-VIDEO ' +
+    'REVERSED REWIND REWRITE RF RH ' +
+    'RIGHT RIGHT-JUSTIFY ROLLBACK ROLLING ROUNDED ' +
+    'RUN SAME SCREEN SD SEARCH ' +
+    'SECTION SECURE SECURITY SEGMENT SEGMENT-LIMIT ' +
+    'SELECT SEND SENTENCE SEPARATE SEQUENCE ' +
+    'SEQUENTIAL SET SHARED SIGN SIZE ' +
+    'SKIP1 SKIP2 SKIP3 SORT SORT-MERGE ' +
+    'SORT-RETURN SOURCE SOURCE-COMPUTER SPACE-FILL ' +
+    'SPECIAL-NAMES STANDARD STANDARD-1 STANDARD-2 ' +
+    'START STARTING STATUS STOP STORE ' +
+    'STRING SUB-QUEUE-1 SUB-QUEUE-2 SUB-QUEUE-3 SUB-SCHEMA ' +
+    'SUBFILE SUBSTITUTE SUBTRACT SUM SUPPRESS ' +
+    'SYMBOLIC SYNC SYNCHRONIZED SYSIN SYSOUT ' +
+    'TABLE TALLYING TAPE TENANT TERMINAL ' +
+    'TERMINATE TEST TEXT THAN THEN ' +
+    'THROUGH THRU TIME TIMES TITLE ' +
+    'TO TOP TRAILING TRAILING-SIGN TRANSACTION ' +
+    'TYPE TYPEDEF UNDERLINE UNEQUAL UNIT ' +
+    'UNSTRING UNTIL UP UPDATE UPON ' +
+    'USAGE USAGE-MODE USE USING VALID ' +
+    'VALIDATE VALUE VALUES VARYING VLR ' +
+    'WAIT WHEN WHEN-COMPILED WITH WITHIN ' +
+    'WORDS WORKING-STORAGE WRITE XML XML-CODE ' +
+    'XML-EVENT XML-NTEXT XML-TEXT ZERO ZERO-FILL ' );
+
+const builtins = makeKeywords('- * ** / + < <= = > >= . ');
+const tests = {
+    digit: /\d/,
+    digitOrColon: /[\d:]/,
+    hex: /[0-9a-f]/i,
+    sign: /[+-]/,
+    exponent: /e/i,
+    symbol: /[\w*+\-]/,
+};
+function isNumber(ch, stream){
+    // hex
+    if ( ch === '0' && stream.eat(/x/i) ) {
+        stream.eatWhile(tests.hex);
+        return true;
+    }
+    // leading sign
+    if ( ( ch == '+' || ch == '-' ) && ( tests.digit.test(stream.peek()) ) ) {
+        stream.eat(tests.sign);
+        ch = stream.next();
+    }
+    if ( tests.digit.test(ch) ) {
+        stream.eat(ch);
+        stream.eatWhile(tests.digit);
+        if ( '.' == stream.peek()) {
+            stream.eat('.');
+            stream.eatWhile(tests.digit);
+        }
+        if ( stream.eat(tests.exponent) ) {
+            stream.eat(tests.sign);
+            stream.eatWhile(tests.digit);
+        }
+        return true;
+    }
+    return false;
+}
+export const cobol = {
+    startState: function () {
+        return {
+            indentStack: null,
+            indentation: 0,
+            mode: false,
+        };
+    },
+    token: function (stream, state) {
+        if (state.indentStack == null && stream.sol()) {
+            // update indentation, but only if indentStack is empty
+            state.indentation = 6 ; //stream.indentation();
+        }
+        // skip spaces
+        if (stream.eatSpace()) {
+            return null;
+        }
+        let returnType = null;
+        switch (state.mode){
+        case 'string': // multi-line string parsing mode
+            let next = false;
+            while ((next = stream.next()) != null) {
+                if ((next == '"' || next == "\'") && !stream.match(/['"]/, false)) {
+                    state.mode = false;
+                    break;
+                }
+            }
+            returnType = STRING; // continue on in string mode
+            break;
+        default: // default parsing mode
+            const ch = stream.next();
+            if (ch == '*' && stream.eat('>')) { // comment
+                stream.skipToEnd(); // rest of the line is a comment
+                returnType = COMMENT;
+            }
+            else if (ch == '"' || ch == "\'") {
+                state.mode = 'string';
+                returnType = STRING;
+            }
+            else if (ch == "'" && !( tests.digitOrColon.test(stream.peek()) )) {
+                returnType = ATOM;
+            }
+            else if (isNumber(ch,stream)){
+                returnType = NUMBER;
+            }
+            else {
+                if (stream.current().match(tests.symbol)) {
+                    while (stream.eat(tests.symbol) !== undefined) {}
+                }
+                if (keywords && keywords.propertyIsEnumerable(stream.current().toUpperCase())) {
+                    returnType = KEYWORD;
+                }
+                else if (builtins && builtins.propertyIsEnumerable(stream.current().toUpperCase())) {
+                    returnType = BUILTIN;
+                }
+                else if (atoms && atoms.propertyIsEnumerable(stream.current().toUpperCase())) {
+                    returnType = ATOM;
+                }
+                else returnType = null;
+            }
+        }
+        return returnType;
+    },
+    indent: function (state) {
+        if (state.indentStack == null) return state.indentation;
+        return state.indentStack.indent;
+    },
+};

--- a/js/vendor/codemirror-raku.d.ts
+++ b/js/vendor/codemirror-raku.d.ts
@@ -1,0 +1,2 @@
+import {StreamParser} from '@codemirror/language';
+export declare const raku: StreamParser<unknown>;

--- a/js/vendor/codemirror-raku.js
+++ b/js/vendor/codemirror-raku.js
@@ -1,0 +1,782 @@
+// CodeMirror2 mode/perl/perl6.js (text/x-perl6)
+// This is a part of CodeMirror from https://github.com/azawawi/farabi6 (ahmad.zawawi@gmail.com)
+// This work is based on the perl.js mode by (TODO give credit)
+// and perl6.vim (TODO give credit)
+
+// it's like "peek", but need for look-ahead or look-behind if index < 0
+function look(stream, c){
+    return stream.string.charAt(stream.pos+(c||0));
+};
+
+// return a part of prefix of current stream from current position
+function prefix(stream, c){
+    if (c){
+        const x=stream.pos-c;
+        return stream.string.substr((x>=0?x:0),c);
+    }
+    else {
+        return stream.string.substr(0,stream.pos-1);
+    }
+};
+
+// return a part of suffix of current stream from current position
+function suffix(stream, c){
+    const y=stream.string.length;
+    const x=y-stream.pos+1;
+    return stream.string.substr(stream.pos,(c&&c<y?c:x));
+};
+
+// eating and vomiting a part of stream from current position
+function eatSuffix(stream, c){
+    const x=stream.pos+c;
+    let y;
+    if (x<=0) {
+        stream.pos=0;
+    }
+    else if (x>=(y=stream.string.length-1)) {
+        stream.pos=y;
+    }
+    else {
+        stream.pos=x;
+    }
+};
+
+const PERL = {
+    // null - magic touch
+    //   1 - keyword
+    //   2 - def
+    //   3 - atom
+    //   4 - operator
+    //   5 - variable-2 (predefined)
+    //   [x,y] - x=1,2,3; y=must be defined if x{...}
+    '->'				:   4,
+    '++'				:   4,
+    '--'				:   4,
+    '**'				:   4,
+    //   ! ~ \ and unary + and -
+    '=~'				:   4,
+    '!~'				:   4,
+    '*'				:   4,
+    '/'				:   4,
+    '%'				:   4,
+    'x'				:   4,
+    '+'				:   4,
+    '-'				:   4,
+    '.'				:   4,
+    '<<'				:   4,
+    '>>'				:   4,
+    //   named unary operators
+    '<'				:   4,
+    '>'				:   4,
+    '<='				:   4,
+    '>='				:   4,
+    '=='				:   4,
+    '!='				:   4,
+    '<=>'				:   4,
+    '~~'				:   4,
+    '&'				:   4,
+    '|'				:   4,
+    '^'				:   4,
+    '&&'				:   4,
+    '||'				:   4,
+    '//'				:   4,
+    '..'				:   4,
+    '...'				:   4,
+    '?'				:   4,
+    ':'				:   4,
+    '='				:   4,
+    '+='				:   4,
+    '-='				:   4,
+    '*='				:   4,	//   etc. ???
+    ','				:   4,
+    '=>'				:   4,
+    '::'				:   4,
+
+    // PERL predefined variables (I know, what this is a paranoid idea,
+    // but may be needed for people, who learn PERL, and for me as well,
+    // ...and may be for you?;)
+    'BEGIN'				:   [5,1],
+    'END'				:   [5,1],
+    'GETC'				:   [5,1],
+    'READ'				:   [5,1],
+    'READLINE'			:   [5,1],
+    'DESTROY'			:   [5,1],
+    'TIE'				:   [5,1],
+    'TIEHANDLE'			:   [5,1],
+    'UNTIE'				:   [5,1],
+    '$ARG'				:    5,
+    '$_'				:    5,
+    '@ARG'				:    5,
+    '@_'				:    5,
+    '$"'				:    5,
+    '$$'				:    5,
+    '$('				:    5,
+    '$EGID'				:    5,
+    '$)'				:    5,
+    '$0'				:    5,
+    '$SUBSEP'			:    5,
+    '$;'				:    5,
+    '$UID'				:    5,
+    '$<'				:    5,
+    '$EUID'				:    5,
+    '$>'				:    5,
+    '$a'				:    5,
+    '$b'				:    5,
+    '$^C'				:    5,
+    '$^D'				:    5,
+    '$ENV'				:    5,
+    '%ENV'				:    5,
+    '$^F'				:    5,
+    '@F'				:    5,
+    '$^H'				:    5,
+    '%^H'				:    5,
+    '$INPLACE_EDIT'			:    5,
+    '$^I'				:    5,
+    '$^M'				:    5,
+    '$OSNAME'			:    5,
+    '$^O'				:    5,
+    '${^OPEN}'			:    5,
+    '$PERLDB'			:    5,
+    '$^P'				:    5,
+    '$SIG'				:    5,
+    '%SIG'				:    5,
+    '$BASETIME'			:    5,
+    '$^T'				:    5,
+    '${^TAINT}'			:    5,
+    '${^UNICODE}'			:    5,
+    '${^UTF8CACHE}'			:    5,
+    '${^UTF8LOCALE}'		:    5,
+    '$PERL_VERSION'			:    5,
+    '$^V'				:    5,
+    '${^WIN32_SLOPPY_STAT}'		:    5,
+    '$EXECUTABLE_NAME'		:    5,
+    '$^X'				:    5,
+    '$1'				:    5,	// - regexp $1, $2...
+    '$MATCH'			:    5,
+    '$&'				:    5,
+    '${^MATCH}'			:    5,
+    '$PREMATCH'			:    5,
+    '$`'				:    5,
+    '${^PREMATCH}'			:    5,
+    '$POSTMATCH'			:    5,
+    "$'"				:    5,
+    '${^POSTMATCH}'			:    5,
+    '$LAST_PAREN_MATCH'		:    5,
+    '$+'				:    5,
+    '$LAST_SUBMATCH_RESULT'		:    5,
+    '$^N'				:    5,
+    '@LAST_MATCH_END'		:    5,
+    '@+'				:    5,
+    '%LAST_PAREN_MATCH'		:    5,
+    '%+'				:    5,
+    '@LAST_MATCH_START'		:    5,
+    '@-'				:    5,
+    '%LAST_MATCH_START'		:    5,
+    '%-'				:    5,
+    '$LAST_REGEXP_CODE_RESULT'	:    5,
+    '$^R'				:    5,
+    '${^RE_DEBUG_FLAGS}'		:    5,
+    '${^RE_TRIE_MAXBUF}'		:    5,
+    '$ARGV'				:    5,
+    '@ARGV'				:    5,
+    'ARGV'				:    5,
+    'ARGVOUT'			:    5,
+    '$OUTPUT_FIELD_SEPARATOR'	:    5,
+    '$OFS'				:    5,
+    '$,'				:    5,
+    '$INPUT_LINE_NUMBER'		:    5,
+    '$NR'				:    5,
+    '$.'				:    5,
+    '$INPUT_RECORD_SEPARATOR'	:    5,
+    '$RS'				:    5,
+    '$/'				:    5,
+    '$OUTPUT_RECORD_SEPARATOR'	:    5,
+    '$ORS'				:    5,
+    '$\\'				:    5,
+    '$OUTPUT_AUTOFLUSH'		:    5,
+    '$|'				:    5,
+    '$ACCUMULATOR'			:    5,
+    '$^A'				:    5,
+    '$FORMAT_FORMFEED'		:    5,
+    '$^L'				:    5,
+    '$FORMAT_PAGE_NUMBER'		:    5,
+    '$%'				:    5,
+    '$FORMAT_LINES_LEFT'		:    5,
+    '$-'				:    5,
+    '$FORMAT_LINE_BREAK_CHARACTERS'	:    5,
+    '$:'				:    5,
+    '$FORMAT_LINES_PER_PAGE'	:    5,
+    '$='				:    5,
+    '$FORMAT_TOP_NAME'		:    5,
+    '$^'				:    5,
+    '$FORMAT_NAME'			:    5,
+    '$~'				:    5,
+    '${^CHILD_ERROR_NATIVE}'	:    5,
+    '$EXTENDED_OS_ERROR'		:    5,
+    '$^E'				:    5,
+    '$EXCEPTIONS_BEING_CAUGHT'	:    5,
+    '$^S'				:    5,
+    '$WARNING'			:    5,
+    '$^W'				:    5,
+    '${^WARNING_BITS}'		:    5,
+    '$OS_ERROR'			:    5,
+    '$ERRNO'			:    5,
+    '$!'				:    5,
+    '%OS_ERROR'			:    5,
+    '%ERRNO'			:    5,
+    '%!'				:    5,
+    '$CHILD_ERROR'			:    5,
+    '$?'				:    5,
+    '$EVAL_ERROR'			:    5,
+    '$@'				:    5,
+    '$OFMT'				:    5,
+    '$#'				:    5,
+    '$*'				:    5,
+    '$ARRAY_BASE'			:    5,
+    '$['				:    5,
+    '$OLD_PERL_VERSION'		:    5,
+    '$]'				:    5,
+    //	PERL blocks
+    'if'				:[1,1],
+    'elsif'				:[1,1],
+    'else'				:[1,1],
+    'while'				:[1,1],
+    'unless'				:[1,1],
+    'for'				:[1,1],
+    'foreach'				:[1,1],
+    'q'				:null,	// - singly quote a string
+    'qq'				:null,	// - doubly quote a string
+    'qr'				:null,	// - Compile pattern
+    'quotemeta'			:null,	// - quote regular expression magic characters
+    'qw'				:null,	// - quote a list of words
+    'qx'				:null,	// - backquote quote a string
+    'y'				:null};	// - transliterate a string
+
+
+const p6DeclareRoutine = [
+    'macro sub submethod method multi proto only rule token regex category',
+];
+const p6Module = [
+    'module class role package enum grammar slang subset',
+];
+const p6Variable = [
+    'self',
+];
+const p6Include = [
+    'use require',
+];
+const p6Conditional = [
+    'if else elsif unless',
+];
+const p6VarStorage = [
+    'let my our state temp has constant',
+];
+const p6Repeat = [
+    'for loop repeat while until gather given',
+];
+const p6FlowControl = [
+    'take do when next last redo return contend maybe defer',
+    'default exit make continue break goto leave async lift',
+];
+const p6TypeConstraint = [
+    'is as but trusts of returns handles where augment supersede',
+];
+const p6ClosureTrait = [
+    'BEGIN CHECK INIT START FIRST ENTER LEAVE KEEP',
+    'UNDO NEXT LAST PRE POST END CATCH CONTROL TEMP',
+];
+const p6Exception = [
+    'die fail try warn',
+];
+const p6Property = [
+    'prec irs ofs ors export deep binary unary reparsed rw parsed cached',
+    'readonly defequiv will ref copy inline tighter looser equiv assoc',
+    'required',
+];
+const p6Number = [
+    'NaN Inf',
+];
+const p6Pragma = [
+    'oo fatal',
+];
+
+const p6Type = [
+    'Object Any Junction Whatever Capture Match',
+    'Signature Proxy Matcher Package Module Class',
+    'Grammar Scalar Array Hash KeyHash KeySet KeyBag',
+    'Pair List Seq Range Set Bag Mapping Void Undef',
+    'Failure Exception Code Block Routine Sub Macro',
+    'Method Submethod Regex Str Blob Char Byte',
+    'Codepoint Grapheme StrPos StrLen Version Num',
+    'Complex num complex Bit bit bool True False',
+    'Increasing Decreasing Ordered Callable AnyChar',
+    'Positional Associative Ordering KeyExtractor',
+    'Comparator OrderingPair IO KitchenSink Role',
+    'Int int int1 int2 int4 int8 int16 int32 int64',
+    'Rat rat rat1 rat2 rat4 rat8 rat16 rat32 rat64',
+    'Buf buf buf1 buf2 buf4 buf8 buf16 buf32 buf64',
+    'UInt uint uint1 uint2 uint4 uint8 uint16 uint32',
+    'uint64 Abstraction utf8 utf16 utf32',
+];
+const p6Routines = [
+    'eager hyper substr index rindex grep map sort join lines hints chmod',
+    'split reduce min max reverse truncate zip cat roundrobin classify',
+    'first sum keys values pairs defined delete exists elems end kv any',
+    'all one wrap shape key value name pop push shift splice unshift floor',
+    'ceiling abs exp log log10 rand sign sqrt sin cos tan round strand',
+    'roots cis unpolar polar atan2 pick chop p5chop chomp p5chomp lc',
+    'lcfirst uc ucfirst capitalize normalize pack unpack quotemeta comb',
+    'samecase sameaccent chars nfd nfc nfkd nfkc printf sprintf caller',
+    'evalfile run runinstead nothing want bless chr ord gmtime time eof',
+    'localtime gethost getpw chroot getlogin getpeername kill fork wait',
+    'perl graphs codes bytes clone print open read write readline say seek',
+    'close opendir readdir slurp pos fmt vec link unlink symlink uniq pair',
+    'asin atan sec cosec cotan asec acosec acotan sinh cosh tanh asinh',
+    'acos acosh atanh sech cosech cotanh sech acosech acotanh asech ok',
+    'plan_ok dies_ok lives_ok skip todo pass flunk force_todo use_ok isa_ok',
+    'diag is_deeply isnt like skip_rest unlike cmp_ok eval_dies_ok nok_error',
+    'eval_lives_ok approx is_approx throws_ok version_lt plan eval succ pred',
+    'times nonce once signature new connect operator undef undefine sleep',
+    'from to infix postfix prefix circumfix postcircumfix minmax lazy count',
+    'unwrap getc pi e context void quasi body each contains rewinddir subst',
+    'can isa flush arity assuming rewind callwith callsame nextwith nextsame',
+    'attr eval_elsewhere none srand trim trim_start trim_end lastcall WHAT',
+    'WHERE HOW WHICH VAR WHO WHENCE ACCEPTS REJECTS does not true iterator by',
+    're im invert flip',
+];
+const p6Operator = [
+    'div x xx mod also leg cmp before after eq ne le lt',
+    'gt ge eqv ff fff and andthen Z X or xor',
+    'orelse extra m mm rx s tr',
+    '%% +^ ~^ +| +^ ~| ~^ ?| ?^ ÷ %% +& +< +> ~& ~< ~>',
+];
+
+const addWords = function (p6Words, category) {
+    let i, j, words;
+    for (i = 0; i < p6Words.length; i++) {
+        words = p6Words[i].split(' ');
+        for (j = 0; j < words.length; j++) {
+            PERL[words[j]] = category;
+        }
+    }
+};
+
+addWords(p6DeclareRoutine, 1);
+addWords(p6Module,         1);
+addWords(p6Variable,       1);
+addWords(p6Include,        1);
+addWords(p6Conditional,    1);
+addWords(p6VarStorage,     2);
+addWords(p6Repeat,         1);
+addWords(p6FlowControl,    1);
+addWords(p6TypeConstraint, 1);
+addWords(p6ClosureTrait,   1);
+addWords(p6Exception,      1);
+addWords(p6Property,       1);
+addWords(p6Number,         1);
+addWords(p6Pragma,         1);
+addWords(p6Type,           2);
+addWords(p6Routines,       3);
+addWords(p6Operator,       4);
+
+const RXstyle='string-2';
+const RXmodifiers=/[goseximacplud]/;		// NOTE: "m", "s", "y" and "tr" need to correct real modifiers for each regexp type
+
+function tokenChain(stream,state,chain,style,tail){	// NOTE: chain.length > 2 is not working now (it's for s[...][...]geos;)
+    state.chain=null;                               //                                                          12   3tail
+    state.style=null;
+    state.tail=null;
+    state.tokenize=function (stream,state){
+        let e=false,c,i=0;
+        while (c=stream.next()){
+            if (c===chain[i]&&!e){
+                if (chain[++i]!==undefined){
+                    state.chain=chain[i];
+                    state.style=style;
+                    state.tail=tail;
+                }
+                else if (tail)
+                    stream.eatWhile(tail);
+                state.tokenize=tokenPerl;
+                return style;
+            }
+            e=!e&&c=='\\';
+        }
+        return style;
+    };
+    return state.tokenize(stream,state);
+}
+
+function tokenSOMETHING(stream,state,string){
+    state.tokenize=function (stream,state){
+        if (stream.string==string)
+            state.tokenize=tokenPerl;
+        stream.skipToEnd();
+        return 'string';
+    };
+    return state.tokenize(stream,state);
+}
+
+function tokenPerl(stream,state){
+    if (stream.eatSpace())
+        return null;
+    if (state.chain)
+        return tokenChain(stream,state,state.chain,state.style,state.tail);
+    if (stream.match(/^\-?[\d\.]/,false))
+        if (stream.match(/^(\-?(\d*\.\d+(e[+-]?\d+)?|\d+\.\d*)|0x[\da-fA-F]+|0b[01]+|\d+(e[+-]?\d+)?)/))
+            return 'number';
+    if (stream.match(/^<<(?=\w)/)){			// NOTE: <<SOMETHING\n...\nSOMETHING\n
+        stream.eatWhile(/\w/);
+        return tokenSOMETHING(stream,state,stream.current().substr(2));
+    }
+    if (stream.sol()&&stream.match(/^\=item(?!\w)/)){// NOTE: \n=item...\n=cut\n
+        return tokenSOMETHING(stream,state,'=cut');
+    }
+    const ch=stream.next();
+    if (ch=='"'||ch=="'"){				// NOTE: ' or " or <<'SOMETHING'\n...\nSOMETHING\n or <<"SOMETHING"\n...\nSOMETHING\n
+        if (prefix(stream, 3)=='<<'+ch){
+            const p=stream.pos;
+            stream.eatWhile(/\w/);
+            const n=stream.current().substr(1);
+            if (n&&stream.eat(ch))
+                return tokenSOMETHING(stream,state,n);
+            stream.pos=p;
+        }
+        return tokenChain(stream,state,[ch],'string');
+    }
+    if (ch=='q'){
+        let c=look(stream, -2);
+        if (!(c&&/\w/.test(c))){
+            c=look(stream, 0);
+            if (c=='x'){
+                c=look(stream, 1);
+                if (c=='('){
+                    eatSuffix(stream, 2);
+                    return tokenChain(stream,state,[')'],RXstyle,RXmodifiers);
+                }
+                if (c=='['){
+                    eatSuffix(stream, 2);
+                    return tokenChain(stream,state,[']'],RXstyle,RXmodifiers);
+                }
+                if (c=='{'){
+                    eatSuffix(stream, 2);
+                    return tokenChain(stream,state,['}'],RXstyle,RXmodifiers);
+                }
+                if (c=='<'){
+                    eatSuffix(stream, 2);
+                    return tokenChain(stream,state,['>'],RXstyle,RXmodifiers);
+                }
+                if (/[\^'"!~\/]/.test(c)){
+                    eatSuffix(stream, 1);
+                    return tokenChain(stream,state,[stream.eat(c)],RXstyle,RXmodifiers);
+                }
+            }
+            else if (c=='q'){
+                c=look(stream, 1);
+                if (c=='('){
+                    eatSuffix(stream, 2);
+                    return tokenChain(stream,state,[')'],'string');
+                }
+                if (c=='['){
+                    eatSuffix(stream, 2);
+                    return tokenChain(stream,state,[']'],'string');
+                }
+                if (c=='{'){
+                    eatSuffix(stream, 2);
+                    return tokenChain(stream,state,['}'],'string');
+                }
+                if (c=='<'){
+                    eatSuffix(stream, 2);
+                    return tokenChain(stream,state,['>'],'string');
+                }
+                if (/[\^'"!~\/]/.test(c)){
+                    eatSuffix(stream, 1);
+                    return tokenChain(stream,state,[stream.eat(c)],'string');
+                }
+            }
+            else if (c=='w'){
+                c=look(stream, 1);
+                if (c=='('){
+                    eatSuffix(stream, 2);
+                    return tokenChain(stream,state,[')'],'bracket');
+                }
+                if (c=='['){
+                    eatSuffix(stream, 2);
+                    return tokenChain(stream,state,[']'],'bracket');
+                }
+                if (c=='{'){
+                    eatSuffix(stream, 2);
+                    return tokenChain(stream,state,['}'],'bracket');
+                }
+                if (c=='<'){
+                    eatSuffix(stream, 2);
+                    return tokenChain(stream,state,['>'],'bracket');
+                }
+                if (/[\^'"!~\/]/.test(c)){
+                    eatSuffix(stream, 1);
+                    return tokenChain(stream,state,[stream.eat(c)],'bracket');
+                }
+            }
+            else if (c=='r'){
+                c=look(stream, 1);
+                if (c=='('){
+                    eatSuffix(stream, 2);
+                    return tokenChain(stream,state,[')'],RXstyle,RXmodifiers);
+                }
+                if (c=='['){
+                    eatSuffix(stream, 2);
+                    return tokenChain(stream,state,[']'],RXstyle,RXmodifiers);
+                }
+                if (c=='{'){
+                    eatSuffix(stream, 2);
+                    return tokenChain(stream,state,['}'],RXstyle,RXmodifiers);
+                }
+                if (c=='<'){
+                    eatSuffix(stream, 2);
+                    return tokenChain(stream,state,['>'],RXstyle,RXmodifiers);
+                }
+                if (/[\^'"!~\/]/.test(c)){
+                    eatSuffix(stream, 1);
+                    return tokenChain(stream,state,[stream.eat(c)],RXstyle,RXmodifiers);
+                }
+            }
+            else if (/[\^'"!~\/(\[{<]/.test(c)){
+                if (c=='('){
+                    eatSuffix(stream, 1);
+                    return tokenChain(stream,state,[')'],'string');
+                }
+                if (c=='['){
+                    eatSuffix(stream, 1);
+                    return tokenChain(stream,state,[']'],'string');
+                }
+                if (c=='{'){
+                    eatSuffix(stream, 1);
+                    return tokenChain(stream,state,['}'],'string');
+                }
+                if (c=='<'){
+                    eatSuffix(stream, 1);
+                    return tokenChain(stream,state,['>'],'string');
+                }
+                if (/[\^'"!~\/]/.test(c)){
+                    return tokenChain(stream,state,[stream.eat(c)],'string');
+                }
+            }
+        }
+    }
+    if (ch=='m'){
+        let c=look(stream, -2);
+        if (!(c&&/\w/.test(c))){
+            c=stream.eat(/[(\[{<\^'"!~\/]/);
+            if (c){
+                if (/[\^'"!~\/]/.test(c)){
+                    return tokenChain(stream,state,[c],RXstyle,RXmodifiers);
+                }
+                if (c=='('){
+                    return tokenChain(stream,state,[')'],RXstyle,RXmodifiers);
+                }
+                if (c=='['){
+                    return tokenChain(stream,state,[']'],RXstyle,RXmodifiers);
+                }
+                if (c=='{'){
+                    return tokenChain(stream,state,['}'],RXstyle,RXmodifiers);
+                }
+                if (c=='<'){
+                    return tokenChain(stream,state,['>'],RXstyle,RXmodifiers);
+                }
+            }
+        }
+    }
+    if (ch=='s'){
+        let c=/[\/>\]})\w]/.test(look(stream, -2));
+        if (!c){
+            c=stream.eat(/[(\[{<\^'"!~\/]/);
+            if (c){
+                if (c=='[')
+                    return tokenChain(stream,state,[']',']'],RXstyle,RXmodifiers);
+                if (c=='{')
+                    return tokenChain(stream,state,['}','}'],RXstyle,RXmodifiers);
+                if (c=='<')
+                    return tokenChain(stream,state,['>','>'],RXstyle,RXmodifiers);
+                if (c=='(')
+                    return tokenChain(stream,state,[')',')'],RXstyle,RXmodifiers);
+                return tokenChain(stream,state,[c,c],RXstyle,RXmodifiers);
+            }
+        }
+    }
+    if (ch=='y'){
+        let c=/[\/>\]})\w]/.test(look(stream, -2));
+        if (!c){
+            c=stream.eat(/[(\[{<\^'"!~\/]/);
+            if (c){
+                if (c=='[')
+                    return tokenChain(stream,state,[']',']'],RXstyle,RXmodifiers);
+                if (c=='{')
+                    return tokenChain(stream,state,['}','}'],RXstyle,RXmodifiers);
+                if (c=='<')
+                    return tokenChain(stream,state,['>','>'],RXstyle,RXmodifiers);
+                if (c=='(')
+                    return tokenChain(stream,state,[')',')'],RXstyle,RXmodifiers);
+                return tokenChain(stream,state,[c,c],RXstyle,RXmodifiers);
+            }
+        }
+    }
+    if (ch=='t'){
+        let c=/[\/>\]})\w]/.test(look(stream, -2));
+        if (!c){
+            c=stream.eat('r');if (c){
+                c=stream.eat(/[(\[{<\^'"!~\/]/);
+                if (c){
+                    if (c=='[')
+                        return tokenChain(stream,state,[']',']'],RXstyle,RXmodifiers);
+                    if (c=='{')
+                        return tokenChain(stream,state,['}','}'],RXstyle,RXmodifiers);
+                    if (c=='<')
+                        return tokenChain(stream,state,['>','>'],RXstyle,RXmodifiers);
+                    if (c=='(')
+                        return tokenChain(stream,state,[')',')'],RXstyle,RXmodifiers);
+                    return tokenChain(stream,state,[c,c],RXstyle,RXmodifiers);
+                }
+            }
+        }
+    }
+    if (ch=='`'){
+        return tokenChain(stream,state,[ch],'variable-2');
+    }
+    if (ch=='/'){
+        if (!/~\s*$/.test(prefix(stream.prefix)))
+            return 'operator';
+        else
+            return tokenChain(stream,state,[ch],RXstyle,RXmodifiers);
+    }
+    if (ch=='$'){
+        const p=stream.pos;
+        if (stream.eatWhile(/\d/)||stream.eat('{')&&stream.eatWhile(/\d/)&&stream.eat('}'))
+            return 'variable-2';
+        else
+            stream.pos=p;
+    }
+    if (/[$@%]/.test(ch)){
+        const p=stream.pos;
+        if (stream.eat('^')&&stream.eat(/[A-Z]/)||!/[@$%&]/.test(look(stream, -2))&&stream.eat(/[=|\\\-#?@;:&`~\^!\[\]*'"$+.,\/<>()]/)){
+            const c=stream.current();
+            if (PERL[c])
+                return 'variable-2';
+        }
+        stream.pos=p;
+    }
+    if (/[$@%&]/.test(ch)){
+        if (stream.eatWhile(/[\w$\[\]]/)||stream.eat('{')&&stream.eatWhile(/[\w$\[\]]/)&&stream.eat('}')){
+            const c=stream.current();
+            if (PERL[c])
+                return 'variable-2';
+            else
+                return 'variable';
+        }
+    }
+    if (ch=='#'){
+        if (look(stream, -2)!='$'){
+            stream.skipToEnd();
+            return 'comment';
+        }
+    }
+    if (/[:+\-\^*$&%@=<>!?|\/~\.]/.test(ch)){
+        const p=stream.pos;
+        stream.eatWhile(/[:+\-\^*$&%@=<>!?|\/~\.]/);
+        if (PERL[stream.current()])
+            return 'operator';
+        else
+            stream.pos=p;
+    }
+    if (ch=='_'){
+        if (stream.pos==1){
+            if (suffix(stream, 6)=='_END__'){
+                return tokenChain(stream,state,['\0'],'comment');
+            }
+            else if (suffix(stream, 7)=='_DATA__'){
+                return tokenChain(stream,state,['\0'],'variable-2');
+            }
+            else if (suffix(stream, 7)=='_C__'){
+                return tokenChain(stream,state,['\0'],'string');
+            }
+        }
+    }
+    if (/\w/.test(ch)){
+        const p=stream.pos;
+        if (look(stream, -2)=='{'&&(look(stream, 0)=='}'||stream.eatWhile(/\w/)&&look(stream, 0)=='}'))
+            return 'string';
+        else
+            stream.pos=p;
+    }
+    if (/[A-Z]/.test(ch)){
+        const l=look(stream, -2);
+        const p=stream.pos;
+        stream.eatWhile(/[A-Z_]/);
+        if (/[\da-z]/.test(look(stream, 0))){
+            stream.pos=p;
+        }
+        else {
+            let c=PERL[stream.current()];
+            if (!c)
+                return 'meta';
+            if (c[1])
+                c=c[0];
+            if (l!=':'){
+                if (c==1)
+                    return 'keyword';
+                else if (c==2)
+                    return 'def';
+                else if (c==3)
+                    return 'atom';
+                else if (c==4)
+                    return 'operator';
+                else if (c==5)
+                    return 'variable-2';
+                else
+                    return 'meta';
+            }
+            else
+                return 'meta';
+        }
+    }
+    if (/[a-zA-Z_]/.test(ch)){
+        const l=look(stream, -2);
+        stream.eatWhile(/\w/);
+        let c=PERL[stream.current()];
+        if (!c)
+            return 'meta';
+        if (c[1])
+            c=c[0];
+        if (l!=':'){
+            if (c==1)
+                return 'keyword';
+            else if (c==2)
+                return 'def';
+            else if (c==3)
+                return 'atom';
+            else if (c==4)
+                return 'operator';
+            else if (c==5)
+                return 'variable-2';
+            else
+                return 'meta';
+        }
+        else
+            return 'meta';
+    }
+    return null;
+}
+
+export const raku = {
+    startState: function () {
+        return {
+            tokenize:tokenPerl,
+            chain:null,
+            style:null,
+            tail:null,
+        };
+    },
+    token: function (stream, state) {
+        return (state.tokenize||tokenPerl)(stream,state);
+    },
+    electricChars:'{}',
+};


### PR DESCRIPTION
For COBOL, we use the free source format, instead of the fixed source format.
I merged our old highlighters with the new style for legacy CM modes.
Also added a couple of Raku operators that weren't listed: `%% +^ ~^ +| +^ ~| ~^ ?| ?^ ÷ %% +& +< +> ~& ~< ~>`
Fixes #691.