### PR TITLE
Fix a typo in the Raku syntax highlighter.

### DIFF
--- a/js/vendor/codemirror-raku.js
+++ b/js/vendor/codemirror-raku.js
@@ -643,7 +643,7 @@ function tokenPerl(stream,state){
         return tokenChain(stream,state,[ch],'variable-2');
     }
     if (ch=='/'){
-        if (!/~\s*$/.test(prefix(stream.prefix)))
+        if (!/~\s*$/.test(prefix(stream)))
             return 'operator';
         else
             return tokenChain(stream,state,[ch],RXstyle,RXmodifiers);


### PR DESCRIPTION
I made a mistake when merging the older file with updated code in the legacy Perl syntax highlighter.