### PR TITLE
Move language notes from the blue info boxes to sample code.

### DIFF
--- a/config/langs.toml
+++ b/config/langs.toml
@@ -15,6 +15,10 @@ v               ~<
         o       o
         ~
 ^       <       <
+
+Arguments are available via STDIN,
+each argument is NULL terminated.
+x is a no-op.
 '''
 
 [Assembly]
@@ -144,6 +148,10 @@ example = '''
     ++++++++++.
     [-],
 ]
+
+Arguments are available via STDIN; each argument is NULL terminated;
+Taking input after EOF leaves the cell unchanged; the tape is circular
+with 65536 cells; and cells are 8-bit with wrapping;
 '''
 
 [C]
@@ -184,6 +192,9 @@ for (int i = 0; i < 10; i++)
 // Accessing arguments
 foreach (String arg in args)
     Console.WriteLine(arg);
+
+// Implicit using directives for console applications are enabled.
+// See: https://docs.microsoft.com/en-us/dotnet/core/tutorials/top-level-templates#implicit-using-directives
 '''
 
 ['C++']
@@ -207,6 +218,9 @@ int main(int argc, char* argv[]) {
 
     return 0;
 }
+
+// Code is compiled with clang with -std=c++2b
+// See: https://clang.llvm.org/cxx_status.html
 '''
 
 [COBOL]
@@ -428,9 +442,9 @@ example = '''
      . . . . . . > \ . @ . . . . .
       . > $ > , < \ ) < . . . . .
        . . \ . ; / $ 0 / . . . .
-        . . . . . . . . . . . .
-         . . . . . . . . . . .
-          . . . . . . . . . .
+        . A r g u m e n t s . .
+         . a r e . N U L L . .
+          t e r m i n a t e d
 '''
 
 [J]
@@ -484,6 +498,8 @@ for (let i = 0; i < 10; i++)
 // Accessing arguments
 for (let arg of arguments)
     print(arg);
+
+// write() outputs without a newline.
 '''
 
 [Julia]
@@ -611,6 +627,8 @@ say for 0..9;
 
 # Accessing arguments
 say for @ARGV;
+
+# Code is run under -E, all current features are enabled.
 '''
 
 [PHP]
@@ -761,6 +779,11 @@ G
 
 # Accessing arguments
 # (... automatic, one per line ...)
+
+# Arguments are available via STDIN,
+# each argument is seperated with a null byte.
+# The code is run with -E and -z options.
+# Output replaces null bytes with newlines.
 '''
 
 [SQL]
@@ -782,6 +805,9 @@ SELECT i FROM loop;
 
 -- Accessing arguments
 SELECT arg FROM argv;
+
+-- Only the first column of the first result set will be printed,
+-- NULL values will be skipped, and the dialect is SQLite.
 '''
 
 [Swift]

--- a/views/hole-tabs.html
+++ b/views/hole-tabs.html
@@ -68,69 +68,25 @@
     </header>
     <nav class=tabs id=picker></nav>
     <div id=info-container>
-        <div class="info assembly">
+        <div class="hide info assembly">
             Compiled from
             <a href=//www.wikibooks.org/wiki/X86_Assembly/GAS_Syntax>
                 AT&T syntax</a> to x86-64 Linux. Use
             <a href=//blog.rchapman.org/posts/Linux_System_Call_Table_for_x86_64>
                 syscalls</a> to write output.
         </div>
-        <div class="info c-sharp">
-            <a href=//devblogs.microsoft.com/dotnet/welcome-to-c-9-0/#top-level-programs>
-                Top-level programs</a> are supported.
-            <a href=//docs.microsoft.com/en-us/dotnet/core/tutorials/top-level-templates#implicit-using-directives>
-                Implicit using directives</a> for console applications are enabled.
-        </div>
-        <div class="hide info brainfuck">
-            Arguments are available via STDIN, each argument is NULL terminated.
-            Taking input after EOF leaves the cell unchanged, the tape is circular
-            with 65536 cells, and cells are 8-bit with wrapping.
-        </div>
-        <div class="hide info cpp">
-            Code is compiled with clang with <a href=//clang.llvm.org/cxx_status.html>-std=c++2b</a>.
-        </div>
-        <div class="hide info d">
-            Code is compiled with <a href=//wiki.dlang.org/LDC>LDC2</a>.
-        </div>
-        <div class="hide info fish">
-            Arguments are available via STDIN, each argument is NULL terminated.
-            <b>x</b> is a no-op.
-        </div>
-        <div class="hide info hexagony">
-            Arguments are available via STDIN, each argument is NULL terminated.
-        </div>
-        <div class="hide info javascript">
-            <b>arguments</b> holds ARGV, <b>print()</b> to output with a newline,
-            <b>write()</b> to output without a newline.
-        </div>
     {{ if eq .Data.Hole.ID "quine" }}
+        <div class="hide info golfscript">
+            Implicit output is disabled for this hole.
+        </div>
         <div class="hide info k">
             Implicit output is disabled for this hole. Code must end with a newline.
         </div>
-    {{ end }}
-        <div class="hide info perl">
-            <b>say()</b> is available without any import.
-        </div>
-    {{ if eq .Data.Hole.ID "quine" }}
         <div class="hide info powershell">
             Implicit output is disabled for this hole. Use <b>Out-Host</b> or
             <b>Write-Host</b> for output.
         </div>
     {{ end }}
-        <div class="hide info sed">
-            Arguments are available via STDIN, each argument is seperated with a null byte.
-            The code is run with <b>-E</b> and <b>-z</b>.
-            Output replaces null bytes with newlines.
-        </div>
-        <div class="hide info sql">
-            <b>SELECT arg FROM argv</b> to access the arguments, only the first
-            column of the first result set will be printed, NULL values will be
-            skipped, and the dialect is <a href=//sqlite.org/index.html>SQLite</a>.
-        </div>
-        <div class="hide info viml">
-            Arguments are available via <b>args</b> list variable. To terminate
-            script execution, write and quit the current buffer.
-        </div>
     </div>
     <div id="picker-status-row">
         <nav class="tabs hide" id=solutionPicker></nav>

--- a/views/hole.html
+++ b/views/hole.html
@@ -95,79 +95,25 @@
             </a>
         </nav>
     </section>
-    <div class="info assembly">
+    <div class="hide info assembly">
         Compiled from
         <a href=//www.wikibooks.org/wiki/X86_Assembly/GAS_Syntax>
             AT&T syntax</a> to x86-64 Linux. Use
         <a href=//blog.rchapman.org/posts/Linux_System_Call_Table_for_x86_64>
             syscalls</a> to write output.
     </div>
-    <div class="info c-sharp">
-        <a href=//devblogs.microsoft.com/dotnet/welcome-to-c-9-0/#top-level-programs>
-            Top-level programs</a> are supported.
-        <a href=//docs.microsoft.com/en-us/dotnet/core/tutorials/top-level-templates#implicit-using-directives>
-            Implicit using directives</a> for console applications are enabled.
-    </div>
-    <div class="hide info brainfuck">
-        Arguments are available via STDIN, each argument is NULL terminated.
-        Taking input after EOF leaves the cell unchanged, the tape is circular
-        with 65536 cells, and cells are 8-bit with wrapping.
-    </div>
-    <div class="hide info cpp">
-        Code is compiled with clang with <a href=//clang.llvm.org/cxx_status.html>-std=c++2b</a>.
-    </div>
-    <div class="hide info d">
-        Code is compiled with <a href=//wiki.dlang.org/LDC>LDC2</a>.
-    </div>
-    <div class="hide info fish">
-        Arguments are available via STDIN, each argument is NULL terminated.
-        <b>x</b> is a no-op.
-    </div>
 {{ if eq .Data.Hole.ID "quine" }}
     <div class="hide info golfscript">
         Implicit output is disabled for this hole.
     </div>
-{{ else }}
-    <div class="hide info golfscript">
-        The stack is initialized with an array containing arguments, rather
-        than the contents of STDIN.
-    </div>
-{{ end }}
-    <div class="hide info hexagony">
-        Arguments are available via STDIN, each argument is NULL terminated.
-    </div>
-    <div class="hide info javascript">
-        <b>arguments</b> holds ARGV, <b>print()</b> to output with a newline,
-        <b>write()</b> to output without a newline.
-    </div>
-{{ if eq .Data.Hole.ID "quine" }}
     <div class="hide info k">
         Implicit output is disabled for this hole. Code must end with a newline.
     </div>
-{{ end }}
-    <div class="hide info perl">
-        Code is run under <b>-E</b>, all current features are enabled.
-    </div>
-{{ if eq .Data.Hole.ID "quine" }}
     <div class="hide info powershell">
         Implicit output is disabled for this hole. Use <b>Out-Host</b> or
         <b>Write-Host</b> for output.
     </div>
 {{ end }}
-    <div class="hide info sed">
-        Arguments are available via STDIN, each argument is seperated with a null byte.
-        The code is run with <b>-E</b> and <b>-z</b>.
-        Output replaces null bytes with newlines.
-    </div>
-    <div class="hide info sql">
-        <b>SELECT arg FROM argv</b> to access the arguments, only the first
-        column of the first result set will be printed, NULL values will be
-        skipped, and the dialect is <a href=//sqlite.org/index.html>SQLite</a>.
-    </div>
-    <div class="hide info viml">
-        Arguments are available via <b>args</b> list variable. To terminate
-        script execution, write and quit the current buffer.
-    </div>
     <div id=run>
     {{ if .Golfer }}
         <button class="btn hide red" id=deleteBtn>


### PR DESCRIPTION
Also removed info box content that was covered by the compiler version numbers and links on the about page.

For Assembly, I left the content in the info box, because moving the URLs to the sample code greatly increased the width of the sample code and affected where the position of the machine language annotations. I fixed a bug where the assembly language info content might be rendered briefly right after the page loads.