### PR TITLE
Moved some OEIS links in Lucky Tickets to Hole Specific Tips in the wiki.

### DIFF
--- a/config/holes.toml
+++ b/config/holes.toml
@@ -1126,8 +1126,6 @@ Delete every 7th element and advance:
 category = 'Mathematics'
 links = [
     { name = 'OEIS A174061', url = '//oeis.org/A174061' },
-    { name = 'OEIS A163269', url = '//oeis.org/A163269' },
-    { name = 'OEIS A077042', url = '//oeis.org/A077042' },
 ]
 preamble = '''
 <p>


### PR DESCRIPTION
These links are better suited to the Hole Specific Tips page in the wiki, because they are kind of like spoilers and don't directly discuss the problem.

See also #674. These links were initially removed, then replaced upon a request on discord. A number of months ago I suggested, on discord, that the links be moved to the wiki instead and all agreed.