### PR TITLE
Fix missing heading ids in wiki

### DIFF
--- a/github/wiki.go
+++ b/github/wiki.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
+	"github.com/yuin/goldmark/parser"
 	"github.com/yuin/goldmark/renderer/html"
 )
 
@@ -48,6 +49,7 @@ func Wiki(db *sql.DB) error {
 
 	markdown := goldmark.New(
 		goldmark.WithExtensions(extension.GFM),
+		goldmark.WithParserOptions(parser.WithAutoHeadingID()),
 		goldmark.WithRendererOptions(html.WithUnsafe()),
 	)
 


### PR DESCRIPTION
In Markdown, headings (`#`, `##`, ...) are automatically given an HTML id. This makes it possible to link a particular section of a page using an anchor in the URL.

However it turns out that the current implementation of the conversion from Markdown to HTML does not do that. For example on https://code.golf/wiki/langs/python we have the following internal link:

![image](https://user-images.githubusercontent.com/9027075/200167760-2c361bf8-7127-48ed-86eb-06ecc6b83f95.png)

But no id on `<h1 />`:

![image](https://user-images.githubusercontent.com/9027075/200167775-f392e343-108c-4df1-9ccc-441910aa03d1.png)

This tiny PR aims to address this problem by passing [an additional flag](https://github.com/yuin/goldmark#parser-options) to the configuration of `goldmark`, which enables the desired behavior.