### PR TITLE
Add language medal glows for dark mode only.

### DIFF
--- a/css/dark.css
+++ b/css/dark.css
@@ -35,8 +35,10 @@
 
     --gl-border: hsl(214, 8%, 30%);
 
-    --diamond-weight: normal;
-    --diamond-outglow: gold;
+    --rank-1-glow: 0 0 10px 2px gold;
+    --rank-2-glow: 0 0 10px 2px silver;
+    --rank-3-glow: 0 0 10px 2px burlywood;
+
     --play-color: #444;
 }
 

--- a/css/golfer/profile.css
+++ b/css/golfer/profile.css
@@ -54,9 +54,9 @@ section > a, section > div {
     width: 2rem;
 }
 
-.rank-1:not(:hover) { color: #343a40; background: gold }
-.rank-2:not(:hover) { color: #343a40; background: silver }
-.rank-3:not(:hover) { color: #343a40; background: burlywood }
+.rank-1:not(:hover) { color: #343a40; background: gold; box-shadow: var(--rank-1-glow); }
+.rank-2:not(:hover) { color: #343a40; background: silver; box-shadow: var(--rank-2-glow); }
+.rank-3:not(:hover) { color: #343a40; background: burlywood; box-shadow: var(--rank-3-glow); }
 
 #connections {
     display: grid;

--- a/css/light.css
+++ b/css/light.css
@@ -31,8 +31,10 @@
 
     --gl-border: #ccc;
     
-    --diamond-weight: bold;
-    --diamond-outglow: #917f20;
+    --rank-1-glow: none;
+    --rank-2-glow: none;
+    --rank-3-glow: none;
+
     --play-color: silver;
 }
 


### PR DESCRIPTION
This helps to mitigate an issue with low contrast between silver and the white color used for language icons.

<img width="462" alt="langs" src="https://user-images.githubusercontent.com/53135437/204108549-3f68e58d-d0e2-4cec-bbd9-474612d00a27.png">
