### PR TITLE
Disable implicit output for R on Quine

### DIFF
--- a/hole/play.go
+++ b/hole/play.go
@@ -255,6 +255,11 @@ func play(ctx context.Context, holeID, langID, code string, score *Scorecard) {
 		cmd.Args = []string{"/usr/bin/python", "-u", "-"}
 	case "r":
 		cmd.Args = []string{"/usr/bin/Rscript", "-"}
+
+		// Disable implicit output for Quine to prevent trivial solutions.
+		if holeID == "quine" {
+			cmd.Args = []string{"/usr/bin/Rscript", "-e", "source('stdin')"}
+		}
 	case "sed":
 		cmd.Args = []string{"/usr/bin/sed", "-E", "-z", "--sandbox", "-u", "--", code}
 	case "swift":

--- a/views/hole-tabs.html
+++ b/views/hole-tabs.html
@@ -76,7 +76,7 @@
                 syscalls</a> to write output.
         </div>
     {{ if eq .Data.Hole.ID "quine" }}
-        <div class="hide info golfscript">
+        <div class="hide info golfscript r">
             Implicit output is disabled for this hole.
         </div>
         <div class="hide info k">

--- a/views/hole.html
+++ b/views/hole.html
@@ -103,7 +103,7 @@
             syscalls</a> to write output.
     </div>
 {{ if eq .Data.Hole.ID "quine" }}
-    <div class="hide info golfscript">
+    <div class="hide info golfscript r">
         Implicit output is disabled for this hole.
     </div>
     <div class="hide info k">


### PR DESCRIPTION
Fixes #839.

I think it's nice to keep implicit output for other holes, because it's nice for debugging.