### PR TITLE
Add newline to COBOL sample

### DIFF
--- a/config/langs.toml
+++ b/config/langs.toml
@@ -278,6 +278,7 @@ accept a from argument-value
 display a
 end-perform.
 end-program.
+
 '''
 
 [Crystal]


### PR DESCRIPTION
The COBOL sample won't run without an ending newline. The number of people this impacts can probably be counted on one hand, but it'd be nice for the odd newbie COBOL golfer to not get an error from the most basic of examples.