### PR TITLE
Quieter errors for TeX

### DIFF
--- a/config/langs.toml
+++ b/config/langs.toml
@@ -935,11 +935,11 @@ foreach arg $argv {
 '''
 
 [TeX]
-size    = '9.57 MiB'
 experiment = 877
-version = '3.141592653'
-website = 'https://tug.org'
-example = '''
+size       = '9.57 MiB'
+version    = '3.141592653'
+website    = 'https://tug.org'
+example    = '''
 % Printing
 Hello, World!
 

--- a/langs/tex/tex
+++ b/langs/tex/tex
@@ -53,15 +53,16 @@ set +e
 
 # The randoms might not actually prevent reading the file, but they do
 # certainly help avoid grepping out the wrong line
-FILENAME="solution_$RANDOM_$RANDOM_$RANDOM_$RANDOM"
+FILENAME="solution_${RANDOM}_${RANDOM}_${RANDOM}_${RANDOM}"
 
 echo "$code_to_run" > "$FILENAME.tex"
 
 /usr/local/bin/tex "$FILENAME.tex" >/dev/null
 
 cat "$FILENAME.log" \
-  | grep -v "$FILENAME." \
-  | grep -v "This is TeX, Version 3.141592653" \
+  | grep -Fv "$FILENAME." \
+  | grep -Fv "This is TeX, Version 3.141592653" \
+  | grep -Fv " [1] )" \
   >&2
 
 if [[ -f "$FILENAME.dvi" ]]; then

--- a/langs/tex/tex
+++ b/langs/tex/tex
@@ -51,10 +51,19 @@ $code
 # don't stop the bash script if /usr/local/bin/tex errors
 set +e
 
-echo "$code_to_run" | /usr/local/bin/tex >/dev/null
+# The randoms might not actually prevent reading the file, but they do
+# certainly help avoid grepping out the wrong line
+FILENAME="solution_$RANDOM_$RANDOM_$RANDOM_$RANDOM"
 
-cat texput.log >&2
+echo "$code_to_run" > "$FILENAME.tex"
 
-if [[ -f texput.dvi ]]; then
-  dvi-to-text texput.dvi
+/usr/local/bin/tex "$FILENAME.tex" >/dev/null
+
+cat "$FILENAME.log" \
+  | grep -v "$FILENAME." \
+  | grep -v "This is TeX, Version 3.141592653" \
+  >&2
+
+if [[ -f "$FILENAME.dvi" ]]; then
+  dvi-to-text "$FILENAME.dvi"
 fi


### PR DESCRIPTION
Reduces the messy error output for TeX. The PR does this by writing the TeX code to a file instead of piping in the code through stdin. (My original motivation for piping the code in through stdin was to avoid cheating quines; the random file names might help with this)

I also put in some greps to filter out some header and footer text.

However, the example code still stderrs
```
\i=\count26
\j=\count27
```
which could in theory be useful for debugging, so I have not filtered those out, so the special case remains in examples.t.