### PR TITLE
Fix TeX octet font

### DIFF
--- a/config/langs.toml
+++ b/config/langs.toml
@@ -950,8 +950,6 @@ Hello, World!
     \advance\i by1
 \repeat
 
-% Use \octet to switch to a font that supports all bytes
-\octet
 % Accessing arguments
 \newcount\j
 \loop\ifnum\j<\argc\relax

--- a/langs/tex/octet.mf
+++ b/langs/tex/octet.mf
@@ -4,6 +4,14 @@ mode_setup;
 font_identifier "octet";
 font_coding_scheme "raw";
 
+font_size 10pt#;
+font_slant 0;
+font_normal_space 126/36pt#;
+font_normal_stretch 0;
+font_normal_shrink 0;
+font_quad 378/36pt#;
+font_x_height 155/36pt#;
+
 for code=0 upto 255:
 beginchar(code,10pt#,10pt#,0);
 pickup pencircle scaled .3pt; draw unitsquare scaled 1pt;

--- a/langs/tex/tex
+++ b/langs/tex/tex
@@ -38,12 +38,13 @@ init="\def\argc{$#}
 \catcode32=12\catcode10=12\catcode12=12\catcode13=13\catcode92=12
 globaldefargv[1]ifcase1'"$args"'elsefi'
 
+# \octet enables the octet font
 # \footline={} disables page numbers
 # \parindex=0pt prevents per-paragraph indentation
 # \hsize and \vsize set the page dimensions. I set them a bit less than the
 #   maximum legal dimension which is less than 16384pt.
 # \bye closes the document (TeX doesn't handle EOF how you might expect)
-code_to_run="\footline={}\parindent=0pt\hsize=16000pt\vsize=16000pt\relax
+code_to_run="\octet\footline={}\parindent=0pt\hsize=16000pt\vsize=16000pt\relax
 $init
 $code
 \bye"


### PR DESCRIPTION
- Provide length information for TeX octet font
- Enable TeX octet font by default
