### PR TITLE
Prevent trivial TeX quines

### DIFF
--- a/hole/play.go
+++ b/hole/play.go
@@ -317,6 +317,14 @@ func play(ctx context.Context, holeID, langID, code string, score *Scorecard) {
 		cmd.Stdin = strings.NewReader(code)
 	}
 
+	// We do not allow quine in TeX to pass without at least one backslash
+	if langID == "tex" && holeID == "quine" && !strings.Contains(code, "\\") {
+		// don't even run the code; just mark error and return
+		score.Pass = false
+		score.Stderr = []byte("Quine in TeX must have at least one '\\' character.")
+		return
+	}
+
 	err := cmd.Run()
 
 	deadline, _ := ctx.Deadline()


### PR DESCRIPTION
Requires TeX quines to have at least one backslash. This works
because any nontrival quine must use a macro, which must
start with backslash. In the other direction, the first backslash
in a file always starts a macro and never represents a verbatim
backslash.

This is entirely in the play.go logic. An explanation of the
backslash requirement is provided by stderr if violated, avoiding
the clutter of an info banner.
