### PR TITLE
Edit Emojify description

### DIFF
--- a/config/holes.toml
+++ b/config/holes.toml
@@ -797,7 +797,7 @@ preamble = '''
 
 <div id=emojify>
 {{ range . }}
-    <div>{{ .Value }}<pre>{{ .Key }}</pre></div>
+    <div><pre>{{ .Key }}</pre>{{ .Value }}</div>
 {{ end }}
 </div>
 '''

--- a/config/holes.toml
+++ b/config/holes.toml
@@ -795,11 +795,9 @@ preamble = '''
     Given each of the following ASCII emoticons print the corresponding
     Unicode emoji.
 
-<p>Note despite how they appear below, there are no spaces in the emoticons.
-
 <div id=emojify>
 {{ range . }}
-    <div>{{ .Value }}<pre>{{ .Key }}{{ if eq .Key ":-" }} {{ end }}</pre></div>
+    <div>{{ .Value }}<pre>{{ .Key }}</pre></div>
 {{ end }}
 </div>
 '''


### PR DESCRIPTION
Just display `:-` right-aligned like all the others:

![image](https://user-images.githubusercontent.com/16232127/215870081-1e763c0d-c816-47b4-98cb-990e91a8deb6.png)
