### PR TITLE
add code.golf issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_language_suggestion.md
+++ b/.github/ISSUE_TEMPLATE/01_language_suggestion.md
@@ -1,0 +1,11 @@
+---
+name: Language suggestion
+about: Suggest a new language to be added to code.golf
+title: Add Python Lang
+labels: lang-idea, idea
+assignees: ""
+---
+
+https://www.python.org/
+
+**Description**

--- a/.github/ISSUE_TEMPLATE/02_hole_suggestion.md
+++ b/.github/ISSUE_TEMPLATE/02_hole_suggestion.md
@@ -1,0 +1,19 @@
+---
+name: Hole suggestion
+about: Suggest a new hole to be added to code.golf
+title: Add Maze hole
+labels: hole-idea, idea
+assignees: ""
+---
+
+**Description**
+
+**Example input (if any)**
+```
+
+```
+
+**Example output**
+```
+
+```

--- a/.github/ISSUE_TEMPLATE/03_cheevo_suggestion.md
+++ b/.github/ISSUE_TEMPLATE/03_cheevo_suggestion.md
@@ -1,0 +1,9 @@
+---
+name: Cheevo suggestion
+about: Suggest a new achievement to be added to code.golf
+title: Add Archivist cheevo
+labels: cheevo-idea, idea
+assignees: ""
+---
+
+**Description**

--- a/.github/ISSUE_TEMPLATE/04_general_suggestion.md
+++ b/.github/ISSUE_TEMPLATE/04_general_suggestion.md
@@ -1,0 +1,9 @@
+---
+name: General suggestion
+about: Suggest something other than a lang, hole or cheevo
+title: Make all solutions publicly visible
+labels: idea
+assignees: ""
+---
+
+**Description**

--- a/.github/ISSUE_TEMPLATE/05_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/05_bug_report.md
@@ -1,0 +1,13 @@
+---
+name: Bug report
+about: Report a bug
+title: Bug: 
+labels: bug
+assignees: ""
+---
+
+**Repro steps**
+
+**Actual result**
+
+**Expected result**


### PR DESCRIPTION
Adds issue templates to code.golf github.

Apart from making the issues look more consistent, this also has the added benefit that labels don't need to be manually asigned by me or James.