### PR TITLE
Fix octet font spacing for TeX

### DIFF
--- a/langs/tex/octet.mf
+++ b/langs/tex/octet.mf
@@ -6,10 +6,10 @@ font_coding_scheme "raw";
 
 font_size 10pt#;
 font_slant 0;
-font_normal_space 126/36pt#;
+font_normal_space 120/36pt#;
 font_normal_stretch 0;
 font_normal_shrink 0;
-font_quad 378/36pt#;
+font_quad 360/36pt#;
 font_x_height 155/36pt#;
 
 for code=0 upto 255:


### PR DESCRIPTION
The size of spaces in the octet font now match that of the tenrm font on which dvi-to-text was tested. Previously, the space width was 5% too big, so 10 spaces would actually have the width of 10.5 spaces, which would round up to 11 spaces. Expect failures in any hole with 10 or more spaces in a row: sierpinski, hexdump, star-wars-opening-crawl, maybe one or two more.