### PR TITLE
Simplify FEN description

### DIFF
--- a/config/holes.toml
+++ b/config/holes.toml
@@ -821,9 +821,9 @@ preamble = '''
     (the number of empty squares), and "/" separates ranks.
 
 <p>
-    Given a FEN, output the board using the chess unicode characters and “ ”
-    (U+0020 Space) for empty squares. The output corresponding to the FEN of
-    the starting position given above should be
+    Given a FEN, output the board using the chess unicode characters and a
+    space for empty squares. The output corresponding to the FEN of the
+    starting position given above should be
 
 <pre>♜♞♝♛♚♝♞♜
 ♟♟♟♟♟♟♟♟


### PR DESCRIPTION
Since the hole doesn't use the ideographic space U+3000 anymore, I don't see any reason to leave in a special mention of which Unicode character the space is.