### PR TITLE
Improve Medal Tally details

### DIFF
--- a/config/holes.toml
+++ b/config/holes.toml
@@ -1412,8 +1412,11 @@ category = 'Transform'
 synopsis = 'Tally code golf medals.'
 preamble = '''
 <p>
-    Given a list of space separated scores in ascending order, print the total
-    number of diamonds and medals handed out.
+    Solutions on code.golf can be awarded one of three medals: bronze (🥉) for 3rd place, silver (🥈) for 2nd place, or gold (🥇) for 1st place.
+	In addition, an uncontested 1st place solution is awarded a diamond (💎). Tied solutions are all awarded the same medal.
+	
+<p>
+	Given a list of space-separated solution scores in ascending order, print the total number of diamonds and medals handed out.
 '''
 
 [Morse]

--- a/config/holes.toml
+++ b/config/holes.toml
@@ -1413,10 +1413,10 @@ synopsis = 'Tally code golf medals.'
 preamble = '''
 <p>
     Solutions on code.golf can be awarded one of three medals: bronze (🥉) for 3rd place, silver (🥈) for 2nd place, or gold (🥇) for 1st place.
-	In addition, an uncontested 1st place solution is awarded a diamond (💎). Tied solutions are all awarded the same medal.
-	
+    In addition, an uncontested 1st place solution is awarded a diamond (💎). Tied solutions are all awarded the same medal.
+
 <p>
-	Given a list of space-separated solution scores in ascending order, print the total number of diamonds and medals handed out.
+    Given a list of space-separated solution scores in ascending order, print the total number of diamonds and medals handed out.
 '''
 
 [Morse]


### PR DESCRIPTION
Addresses https://github.com/code-golf/code-golf/issues/958. Proposed adjustment is

> Solutions on code.golf can be awarded one of three medals: bronze (🥉) for 3rd place, silver (🥈) for 2nd place, or gold (🥇) for 1st place. In addition, an uncontested 1st place solution is awarded a diamond (💎). Tied solutions are all awarded the same medal.
>
> Given a list of space-separated solution scores in ascending order, print the total number of diamonds and medals handed out.