### PR TITLE
Disallow Unicode output in Arabic to Roman

### DIFF
--- a/config/holes.toml
+++ b/config/holes.toml
@@ -125,8 +125,6 @@ preamble = '''
 <p>
     For each numeric argument in Arabic numerals, print the same number in
     Roman numerals.
-
-<p>You may use either ASCII or UTF-8 (U+2160 to U+2188) for Roman numerals.
 {{ else }}
 <p>
     For each numeric argument in Roman numerals, print the same number in
@@ -148,13 +146,13 @@ preamble = '''
             <td>1000
         <tr>
             <th>Roman
-            <td>Ⅰ
-            <td>Ⅴ
-            <td>Ⅹ
-            <td>Ⅼ
-            <td>Ⅽ
-            <td>Ⅾ
-            <td>Ⅿ
+            <td>I
+            <td>V
+            <td>X
+            <td>L
+            <td>C
+            <td>D
+            <td>M
     </table>
 </div>
 '''

--- a/hole/play.go
+++ b/hole/play.go
@@ -32,12 +32,6 @@ var answers embed.FS
 // All ASCII whitespace except newline, up to a newline or the end.
 var stdoutTrimmer = regexp.MustCompile(`[\t\x0B\f\r ]+(?:\n|$)`)
 
-var romanToASCII = strings.NewReplacer(
-	"Ⅰ", "I", "Ⅱ", "II", "Ⅲ", "III", "Ⅳ", "IV", "Ⅴ", "V",
-	"Ⅵ", "VI", "Ⅶ", "VII", "Ⅷ", "VIII", "Ⅸ", "IX", "Ⅹ", "X",
-	"Ⅺ", "XI", "Ⅻ", "XII", "Ⅼ", "L", "Ⅽ", "C", "Ⅾ", "D", "Ⅿ", "M",
-)
-
 // Run holds the results of running a given solution once.
 type Run struct {
 	Answer   string        `json:"answer"`
@@ -389,11 +383,6 @@ func play(ctx context.Context, holeID, langID, code string, run *Run) error {
 	} else {
 		run.Stdout = string(bytes.TrimRight(stdoutTrimmer.ReplaceAll(
 			stdoutContents, []byte{'\n'}), "\n"))
-	}
-
-	// ASCII-ify roman numerals
-	if holeID == "arabic-to-roman" {
-		run.Stdout = romanToASCII.Replace(run.Stdout)
 	}
 
 	// Timeouts and whitespace only output never pass.


### PR DESCRIPTION
All other holes* on the site have very simple I/O rules: you must match the output presented by the judge, modulo trailing whitespace. IMHO this exception to that rule is surprising, inelegant, and unnecessary. Moreover, the Unicode standard discourages the use of these characters and states they are included for compatibility with other character sets.

> **_Roman Numerals._** For most purposes, it is preferable to compose the Roman numerals from sequences of the appropriate Latin letters. However, the uppercase and lowercase variants of the Roman numerals through 12, plus L, C, D, and M, have been encoded in the Number Forms block (U+2150..U+218F) for compatibility with East Asian standards.  

This is just my opinion, so feel free to close this PR if you disagree. It should probably be closed if it invalidates any existing solutions, but I kinda doubt it (the codepoint assignments are too weird to be useful for golf).

<sup>*Actually, CSS Colors specifically has case-insensitive output. But I want to PR that out too 🙂 
