### PR TITLE
Save the tabs layout between reloads

### DIFF
--- a/js/_util.ts
+++ b/js/_util.ts
@@ -43,3 +43,27 @@ export function $$<MatchType extends HTMLElement>(selector: string) {
     return document.querySelectorAll(selector) as NodeListOf<MatchType>;
 }
 export const comma = (i: number | undefined) => i?.toLocaleString('en');
+
+/**
+ * Debounce in the following sense:
+ *  - never fire more than once in any consecutive `interval` ms
+ *  - always fire at least once within the first `interval` ms after the call
+ *  - always fire as soon as possible, subject to these restrictions
+ */
+export function debounce(fn: () => void, interval: number) {
+    let pendingTimeout: number | undefined;
+    let needsAnother = false;
+    return () => {
+        if (pendingTimeout) {
+            needsAnother = true;
+            return;
+        }
+        else {
+            pendingTimeout = setTimeout(() => {
+                pendingTimeout = undefined;
+                if (needsAnother) fn();
+            }, interval);
+            fn();
+        }
+    };
+}

--- a/js/hole-tabs.tsx
+++ b/js/hole-tabs.tsx
@@ -60,8 +60,13 @@ for (const alertCloseBtn of $$('.main_close')) {
 // can't be done in CSS because the picker is one parent up
 const langToggle = $<HTMLDetailsElement>('#hole-lang details');
 langToggle.addEventListener('toggle', () => {
-    $('#picker').classList.toggle('hide', !langToggle.open);
+    setLangPickerOpen(langToggle.open);
 });
+function setLangPickerOpen(open: boolean) {
+    langToggle.open = open;
+    $('#picker').classList.toggle('hide', !open);
+    saveLayout();
+}
 
 const goldenContainer = $('#golden-container');
 
@@ -309,6 +314,7 @@ const defaultViewState: ViewState = {
     config: defaultLayout,
     poolNames: ['details'],
     isWide: false,
+    langPickerOpen: true,
 };
 
 interface ViewState {
@@ -316,6 +322,7 @@ interface ViewState {
     config: ResolvedLayoutConfig | LayoutConfig;
     poolNames: string[];
     isWide: boolean;
+    langPickerOpen: boolean;
 }
 
 function getViewState(): ViewState {
@@ -324,6 +331,7 @@ function getViewState(): ViewState {
         config: layout.saveLayout(),
         poolNames: Object.keys(poolElements),
         isWide: isWide,
+        langPickerOpen: langToggle.open,
     };
 }
 
@@ -346,6 +354,7 @@ async function applyViewState(viewState: ViewState) {
     Object.keys(poolElements).map(removePoolItem);
     viewState.poolNames.forEach(addPoolItem);
     setWide(viewState.isWide);
+    setLangPickerOpen(viewState.langPickerOpen);
     let config = viewState.config;
     if (LayoutConfig.isResolved(config))
         config = LayoutConfig.fromResolved(config);

--- a/js/hole-tabs.tsx
+++ b/js/hole-tabs.tsx
@@ -336,7 +336,9 @@ function getViewState(): ViewState {
 }
 
 const saveLayout = debounce(() => {
-    localStorage.setItem('lastViewState', JSON.stringify(getViewState()));
+    const state = getViewState();
+    if (!state.config.root) return;
+    localStorage.setItem('lastViewState', JSON.stringify(state));
 }, 2000);
 
 

--- a/js/hole-tabs.tsx
+++ b/js/hole-tabs.tsx
@@ -16,6 +16,7 @@ import {
 
 const poolDragSources: {[key: string]: DragSource} = {};
 const poolElements: {[key: string]: HTMLElement} = {};
+let isWide = false;
 
 /**
  * Is mobile mode activated? Start at false as default since Golden Layout
@@ -307,19 +308,22 @@ const defaultViewState: ViewState = {
     version: 1,
     config: defaultLayout,
     poolNames: ['details'],
+    isWide: false,
 };
 
 interface ViewState {
     version: 1;
     config: ResolvedLayoutConfig | LayoutConfig;
     poolNames: string[];
+    isWide: boolean;
 }
 
-function getViewState() {
+function getViewState(): ViewState {
     return {
         version: 1,
         config: layout.saveLayout(),
         poolNames: Object.keys(poolElements),
+        isWide: isWide,
     };
 }
 
@@ -336,11 +340,13 @@ async function applyInitialLayout() {
     await applyViewState(viewState);
 }
 
-async function applyViewState({config, poolNames}: ViewState) {
+async function applyViewState(viewState: ViewState) {
     applyingDefault = true;
     toggleMobile(false);
     Object.keys(poolElements).map(removePoolItem);
-    poolNames.forEach(addPoolItem);
+    viewState.poolNames.forEach(addPoolItem);
+    setWide(viewState.isWide);
+    let config = viewState.config;
     if (LayoutConfig.isResolved(config))
         config = LayoutConfig.fromResolved(config);
     layout.loadLayout(config);
@@ -398,13 +404,14 @@ $('#add-row').addEventListener('click', addRow);
 
 $('#revert-layout').addEventListener('click', () => applyViewState(defaultViewState));
 
-$('#make-wide').addEventListener('click',
-    () => document.documentElement.classList.toggle('full-width', true),
-);
+function setWide(b: boolean) {
+    isWide = b;
+    document.documentElement.classList.toggle('full-width', b);
+}
 
-$('#make-narrow').addEventListener('click',
-    () => document.documentElement.classList.toggle('full-width', false),
-);
+$('#make-wide').addEventListener('click', () => setWide(true));
+
+$('#make-narrow').addEventListener('click', () => setWide(false));
 
 function addPoolItem(componentType: string) {
     poolElements[componentType]?.remove();

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "dialog-polyfill": "",
         "diff": "",
         "esbuild": "",
-        "golden-layout": "^2.5.0",
+        "golden-layout": "^2.6.0",
         "lz-string": "",
         "nim-codemirror-mode": ""
       },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dialog-polyfill": "",
     "diff": "",
     "esbuild": "",
-    "golden-layout": "^2.5.0",
+    "golden-layout": "^2.6.0",
     "lz-string": "",
     "nim-codemirror-mode": ""
   },


### PR DESCRIPTION
After you reload the page or navigate to another hole, the tabs layout will remember:

- The position of all the tabs, and which tabs are in the pool at the top
- Status of if the "wide" button has been toggled

Saving to local storage is debounced on a 2 second timer.

Fixes #738