### PR TITLE
Add UI for multiple runs

### DIFF
--- a/css/common/base.css
+++ b/css/common/base.css
@@ -150,8 +150,11 @@ body > header svg {
 
 button {
     color: var(--color);
-    cursor: pointer;
     font: inherit;
+}
+
+button:not(:disabled) {
+    cursor: pointer;
 }
 
 dialog {

--- a/css/hole.css
+++ b/css/hole.css
@@ -324,22 +324,27 @@ thead { user-select: none }
 .run-result-btn {
     border: none;
     background: none;
+    padding: 0;
+    margin-inline: 2px;
 }
 
-.run-result-btn:is(:hover, :active, :focus, [disabled]:not(:only-child)) {
-    border-bottom: 2px solid var(--background);
+.run-result-btn:is(
+    :is(:hover, :active, :focus):not([disabled]),
+    [disabled]:not(:only-child)
+) {
+    border-bottom: 2px solid var(--color);
     margin-bottom: -2px;
 }
 
 h2 {
     display: flex;
     align-items: center;
+    gap: 0.2rem;
 }
 
 #runtime {
     font-size: 80%;
     text-align: center;
     font-weight: normal;
-    padding-left: 0.2rem;
     padding-bottom: 0.1rem;
 }

--- a/css/hole.css
+++ b/css/hole.css
@@ -330,3 +330,16 @@ thead { user-select: none }
     border-bottom: 2px solid var(--background);
     margin-bottom: -2px;
 }
+
+h2 {
+    display: flex;
+    align-items: center;
+}
+
+#runtime {
+    font-size: 80%;
+    text-align: center;
+    font-weight: normal;
+    padding-left: 0.2rem;
+    padding-bottom: 0.1rem;
+}

--- a/css/hole.css
+++ b/css/hole.css
@@ -320,3 +320,13 @@ thead { user-select: none }
 
     #thirdParty:empty { display: none }
 }
+
+.run-result-btn {
+    border: none;
+    background: none;
+}
+
+.run-result-btn:is(:hover, :active, :focus, [disabled]:not(:only-child)) {
+    border-bottom: 2px solid var(--background);
+    margin-bottom: -2px;
+}

--- a/js/_hole-common.tsx
+++ b/js/_hole-common.tsx
@@ -252,18 +252,34 @@ export interface RankUpdate {
     oldBestStrokes: number | null,
 }
 
-export interface SubmitResponse {
+export interface Run {
+    answer: string,
+    args: string[],
+    exit_code: number,
+    pass: boolean,
+    stderr: string,
+    stdout: string,
+    time_ns: number,
+    timeout: boolean
+}
+
+export interface ReadonlyPanelsData {
     Pass: boolean,
     Out: string,
     Exp: string,
     Err: string,
     Argv: string[],
+}
+
+export interface SubmitResponse {
+    Pass: boolean,
     Cheevos: {
         emoji: string,
         name: string
     }[],
     LoggedIn: boolean,
     RankUpdates: RankUpdate[],
+    runs: Run[]
 }
 
 const makeSingular = (strokes: number, units: string) =>
@@ -362,7 +378,11 @@ const diamondPopups = (updates: RankUpdate[]) => {
     return popups;
 };
 
-export async function submit(editor: any, updateReadonlyPanels: any) {
+export async function submit(
+    editor: any,
+    // eslint-disable-next-line no-unused-vars
+    updateReadonlyPanels: (d: ReadonlyPanelsData) => void,
+) {
     if (!editor) return;
     $('h2').innerText = '…';
     $('#status').className = 'grey';
@@ -441,26 +461,61 @@ export async function submit(editor: any, updateReadonlyPanels: any) {
     // solution.
     updateRestoreLinkVisibility(editor);
 
-    $('h2').innerText = data.Pass ? 'Pass 😀' : 'Fail ☹️';
+    function showRun(run: Run) {
+        updateReadonlyPanels({
+            Pass: run.pass,
+            Argv: run.args,
+            Exp: run.answer,
+            Err: run.stderr,
+            Out: run.stdout,
+        });
 
-    updateReadonlyPanels(data);
+        // 3rd party integrations.
+        let thirdParty = '';
+        if (lang == 'hexagony') {
+            const payload = LZString.compressToBase64(JSON.stringify({
+                code, input: run.args.join('\0') + '\0', inputMode: 'raw' }));
+
+            thirdParty = <a href={'//hexagony.net#lz' + payload}>
+                Run on Hexagony.net
+            </a>;
+        }
+        $('#thirdParty').replaceChildren(thirdParty);
+
+        if (hole == 'julia-set')
+            $('main').append(pbm(run.answer) as Node, pbm(run.stdout) ?? [] as any);
+    }
+
+    // Default run: first failing, else last overall.
+    const defaultRun = data.runs.find(run => !run.pass) ?? data.runs[data.runs.length-1];
+
+    const btns = data.runs.map((run, i) => {
+        const [emoji, label] = run.pass ? ['😀', 'Pass']
+            : run.timeout ? ['⏱️', 'Timeout']
+                : ['☹️', 'Fail'];
+        const btn = (
+            <button class="run-result-btn" aria-label={`Run ${i + 1}: ${label}`}>
+                {emoji}
+            </button>
+        );
+        function onPickRun() {
+            showRun(run);
+            $$<HTMLButtonElement>('.run-result-btn').forEach(b => b.disabled = false);
+            btn.disabled = true;
+        };
+        if (run === defaultRun) onPickRun();
+        btn.addEventListener('click', onPickRun);
+        return btn;
+    });
+
+    $('h2').replaceWith(<h2>
+        {data.Pass ? 'Pass' : 'Fail'}
+        <span class="btns">{btns}</span>
+    </h2>);
+
+    showRun(data.runs[0]);
 
     $('#status').className = data.Pass ? 'green' : 'red';
-
-    // 3rd party integrations.
-    let thirdParty = '';
-    if (lang == 'hexagony') {
-        const payload = LZString.compressToBase64(JSON.stringify({
-            code, input: data.Argv.join('\0') + '\0', inputMode: 'raw' }));
-
-        thirdParty = <a href={'//hexagony.net#lz' + payload}>
-            Run on Hexagony.net
-        </a>;
-    }
-    $('#thirdParty').replaceChildren(thirdParty);
-
-    if (hole == 'julia-set')
-        $('main').append(pbm(data.Exp) as Node, pbm(data.Out) ?? [] as any);
 
     // Show cheevos.
     $('#popups').replaceChildren(...scorePopups(data.RankUpdates),

--- a/js/_hole-common.tsx
+++ b/js/_hole-common.tsx
@@ -517,7 +517,7 @@ export async function submit(
     });
 
     $('h2').replaceChildren(
-        <span class="btns">{btns}</span>,
+        <span id="run-result-btns">{btns}</span>,
         <span id="pass-fail-msg"></span>,
         <span id="runtime"></span>,
     );

--- a/js/_hole-common.tsx
+++ b/js/_hole-common.tsx
@@ -490,9 +490,12 @@ export async function submit(
             $('main').append(pbm(run.answer) as Node, pbm(run.stdout) ?? [] as any);
     }
 
-    // Default run: first failing, else last overall.
-    let defaultRunIndex = data.runs.findIndex(run => !run.pass);
-    if (defaultRunIndex === -1) defaultRunIndex = data.runs.length - 1;
+    // Default run: first failing non-timeout, else first timeout, else last overall.
+    let defaultRunIndex = data.runs.findIndex(run => !run.pass && !run.timeout);
+    if (defaultRunIndex === -1)
+        defaultRunIndex = data.runs.findIndex(run => !run.pass);
+    if (defaultRunIndex === -1)
+        defaultRunIndex = data.runs.length - 1;
 
     const btns = data.runs.map((run, i) => {
         const [emoji, label] = run.pass ? ['😀', 'Pass']
@@ -506,17 +509,18 @@ export async function submit(
         function onPickRun() {
             showRun(run);
             $$<HTMLButtonElement>('.run-result-btn').forEach(b => b.disabled = false);
+            $('#pass-fail-msg').innerText = label;
             btn.disabled = true;
         };
         btn.addEventListener('click', onPickRun);
         return btn;
     });
 
-    $('h2').replaceWith(<h2>
-        {data.Pass ? 'Pass' : 'Fail'}
-        <span id="runtime"></span>
-        <span class="btns">{btns}</span>
-    </h2>);
+    $('h2').replaceChildren(
+        <span class="btns">{btns}</span>,
+        <span id="pass-fail-msg"></span>,
+        <span id="runtime"></span>,
+    );
 
     btns[defaultRunIndex].click();
 

--- a/js/_hole-common.tsx
+++ b/js/_hole-common.tsx
@@ -470,6 +470,10 @@ export async function submit(
             Out: run.stdout,
         });
 
+        const ms = Math.round(run.time_ns / 10**6);
+        // Only show runtime if it's more than 1000ms, for a bit less clutter in general.
+        $('#runtime').innerText = ms > 1000 ? `(${ms}ms)` : '';
+
         // 3rd party integrations.
         let thirdParty = '';
         if (lang == 'hexagony') {
@@ -487,7 +491,8 @@ export async function submit(
     }
 
     // Default run: first failing, else last overall.
-    const defaultRun = data.runs.find(run => !run.pass) ?? data.runs[data.runs.length-1];
+    let defaultRunIndex = data.runs.findIndex(run => !run.pass);
+    if (defaultRunIndex === -1) defaultRunIndex = data.runs.length - 1;
 
     const btns = data.runs.map((run, i) => {
         const [emoji, label] = run.pass ? ['😀', 'Pass']
@@ -503,17 +508,17 @@ export async function submit(
             $$<HTMLButtonElement>('.run-result-btn').forEach(b => b.disabled = false);
             btn.disabled = true;
         };
-        if (run === defaultRun) onPickRun();
         btn.addEventListener('click', onPickRun);
         return btn;
     });
 
     $('h2').replaceWith(<h2>
         {data.Pass ? 'Pass' : 'Fail'}
+        <span id="runtime"></span>
         <span class="btns">{btns}</span>
     </h2>);
 
-    showRun(data.runs[0]);
+    btns[defaultRunIndex].click();
 
     $('#status').className = data.Pass ? 'green' : 'red';
 

--- a/js/hole-tabs.tsx
+++ b/js/hole-tabs.tsx
@@ -8,7 +8,7 @@ import diffTable        from './_diff';
 import { $, $$, comma, debounce } from './_util';
 import {
     init, langs, getLang, hole, getAutoSaveKey, setSolution, getSolution,
-    setCode, refreshScores, getHideDeleteBtn, submit, SubmitResponse,
+    setCode, refreshScores, getHideDeleteBtn, submit, ReadonlyPanelsData,
     updateRestoreLinkVisibility, getSavedInDB, setCodeForLangAndSolution,
     populateScores, getCurrentSolutionCode, initDeleteBtn, initCopyJSONBtn,
     getScorings,
@@ -35,7 +35,7 @@ let isWide = false;
 let isMobile = false;
 let applyingDefault = false;
 
-let subRes: SubmitResponse | null = null;
+let subRes: ReadonlyPanelsData | null = null;
 const readonlyOutputs: {[key: string]: HTMLElement | undefined} = {};
 
 let editor: EditorView | null = null;
@@ -104,7 +104,7 @@ function updateReadonlyPanel(name: string) {
     }
 }
 
-function updateReadonlyPanels(data: SubmitResponse) {
+function updateReadonlyPanels(data: ReadonlyPanelsData) {
     subRes = data;
     for (const name in readonlyOutputs) {
         updateReadonlyPanel(name);

--- a/js/hole.tsx
+++ b/js/hole.tsx
@@ -4,7 +4,7 @@ import { $, $$, comma } from './_util';
 import {
     init, langs, getLang, hole, getAutoSaveKey, setSolution, getSolution,
     setCode, refreshScores, submit, getSavedInDB, updateRestoreLinkVisibility,
-    SubmitResponse, setCodeForLangAndSolution, getCurrentSolutionCode,
+    ReadonlyPanelsData, setCodeForLangAndSolution, getCurrentSolutionCode,
     initDeleteBtn, initCopyJSONBtn, getScorings,
 } from './_hole-common';
 
@@ -75,7 +75,7 @@ $$('#rankingsView a').forEach(a => a.onclick = e => {
     refreshScores(editor);
 });
 
-function updateReadonlyPanels(data: SubmitResponse) {
+function updateReadonlyPanels(data: ReadonlyPanelsData) {
     // Hide arguments unless we have some.
     $('#arg div').replaceChildren(...data.Argv.map(a => <span>{a}</span>));
     $('#arg').classList.toggle('hide', !data.Argv.length);

--- a/js/typings/_intrinsicJSX.ts
+++ b/js/typings/_intrinsicJSX.ts
@@ -18,6 +18,7 @@ declare global {
       span: any;
       img: any;
       a: any;
+      button: any;
       h1: any;
       h2: any;
       h3: any;

--- a/t/hole.rakumod
+++ b/t/hole.rakumod
@@ -97,12 +97,12 @@ class HoleWebDriver is WebDriver is export {
 
     # Methods whose names begin with "is" do exactly one assertion.
     method isFailing(Str:D $context) {
-        $.isResult: '☹️\nFail', $context;
+        $.isResult: "☹️\nFail", $context;
     }
 
     # Methods whose names begin with "is" do exactly one assertion.
     method isPassing(Str:D $context) {
-        $.isResult: '😀\nPass', $context;
+        $.isResult: "😀\nPass", $context;
     }
 
     # Methods whose names begin with "is" do exactly one assertion.

--- a/t/hole.rakumod
+++ b/t/hole.rakumod
@@ -97,12 +97,12 @@ class HoleWebDriver is WebDriver is export {
 
     # Methods whose names begin with "is" do exactly one assertion.
     method isFailing(Str:D $context) {
-        $.isResult: 'Fail ☹️', $context;
+        $.isResult: '☹️\nFail', $context;
     }
 
     # Methods whose names begin with "is" do exactly one assertion.
     method isPassing(Str:D $context) {
-        $.isResult: 'Pass 😀', $context;
+        $.isResult: '😀\nPass', $context;
     }
 
     # Methods whose names begin with "is" do exactly one assertion.


### PR DESCRIPTION
Screenshot: I took my https://code.golf/united-states#python solution and added
```py
import sys,time
if len(sys.argv)==26:
  while True:
    pass
time.sleep(1)
if len(sys.argv)==27:	
  print("fail")
```

![image](https://github.com/code-golf/code-golf/assets/20214911/c6e9dd1f-febf-4ac2-bbcf-d9b32e249750)

For multi-run holes, clicking on one of the other emoji buttons opens the corresponding run.

The default run shown is changed slightly: if there are both failing and timeout'd runs, a failing run is preferred to be the default before a timeout'd run.

The runtime is shown if a run is more than 1000ms.

For single-run holes, there are two changes: 
- The emoji appears before "Pass"/"Fail" instead of after.
  - (Motivation for this change in multi-run holes is that that switching from a "Pass" run to a "Timeout" run, or even two passing runs with different runtimes, would otherwise shift the emoji buttons left and right)
- The runtime is shown if a run is more than 1000ms.