### PR TITLE
Show "copied" text after copying as JSON in tabs layout

### DIFF
--- a/views/hole-tabs.html
+++ b/views/hole-tabs.html
@@ -133,7 +133,7 @@
     <div class=grid>
         {{ .Data.Hole.Preamble }}
     {{ if .Data.Hole.Data }}
-        <div><button class="btn orange" id=copy>Copy as JSON</button></div>
+        <div><button class="btn orange" id=copy>Copy as JSON</button><span>Copied</span></div>
     {{ end }}
     </div>
 </template>


### PR DESCRIPTION
Fixes #796
