### PR TITLE
Move variants buttons to the second row

### DIFF
--- a/css/hole.css
+++ b/css/hole.css
@@ -206,6 +206,10 @@ main > header {
     gap: 1rem;
     justify-content: space-between;
 }
+main > header:nth-child(2) {
+    justify-content: end;
+    margin-top: 1rem;
+}
 
 main > header a { white-space: nowrap }
 

--- a/css/hole.css
+++ b/css/hole.css
@@ -206,9 +206,10 @@ main > header {
     gap: 1rem;
     justify-content: space-between;
 }
+
 main > header:nth-child(2) {
     justify-content: end;
-    margin-top: 1rem;
+    margin-top: 0.5rem;
 }
 
 main > header a { white-space: nowrap }

--- a/views/hole-tabs.html
+++ b/views/hole-tabs.html
@@ -66,11 +66,6 @@
         </nav>
     {{ end }}
         <nav>
-        {{ range .Data.Hole.Variants }}
-            {{ if ne . $.Data.Hole }}
-                <a class="btn blue" href="{{ .ID }}">{{ .Name }}</a>
-            {{ end }}
-        {{ end }}
             <a class="btn orange" href="{{ .Data.Hole.Prev }}">
                 {{ svg "chevron-double-left-light" }} Prev
             </a>
@@ -82,6 +77,17 @@
             </a>
         </nav>
     </header>
+{{ with .Data.Hole.Variants }}
+    <header>
+        <nav>
+        {{ range . }}
+            {{ if ne . $.Data.Hole }}
+                <a class="btn blue" href="{{ .ID }}">{{ .Name }}</a>
+            {{ end }}
+        {{ end }}
+        </nav>
+    </header>
+{{ end }}
     <nav class=tabs id=picker></nav>
     <div id=info-container>
         <div class="hide info assembly">

--- a/views/hole.html
+++ b/views/hole.html
@@ -57,11 +57,6 @@
         {{ end }}
         </nav>
         <nav>
-        {{ range .Data.Hole.Variants }}
-            {{ if ne . $.Data.Hole }}
-                <a class="btn blue" href="{{ .ID }}">{{ .Name }}</a>
-            {{ end }}
-        {{ end }}
             <a class="btn orange" href="{{ .Data.Hole.Prev }}">
                 {{ svg "chevron-double-left-light" }} Prev
             </a>
@@ -73,6 +68,17 @@
             </a>
         </nav>
     </header>
+{{ with .Data.Hole.Variants }}
+    <header>
+        <nav>
+        {{ range . }}
+            {{ if ne . $.Data.Hole }}
+                <a class="btn blue" href="{{ .ID }}">{{ .Name }}</a>
+            {{ end }}
+        {{ end }}
+        </nav>
+    </header>
+{{ end }}
     <details id=details {{ if not .Data.HideDetails }}open{{ end }}>
         <summary>Details</summary>
         <div class=grid>


### PR DESCRIPTION
This PR fixes the position of the Previous/Random/Next button group across different holes by moving the variants button group to the 2nd row.
Before:
![image](https://github.com/code-golf/code-golf/assets/13916220/214d82e9-a30f-4bd3-839d-dcea6029bc48)

After:
![image](https://github.com/code-golf/code-golf/assets/13916220/7e9183d3-8d3b-4a2f-9017-dc5a849834a6)

I thought there was an issue for this, but I cannot find it.