### PR TITLE
quickfix to make rijndael-s-box case insensitive

### DIFF
--- a/hole/play.go
+++ b/hole/play.go
@@ -398,7 +398,7 @@ func play(ctx context.Context, holeID, langID, code string, run *Run) error {
 
 	// Timeouts and whitespace only output never pass.
 	if !run.Timeout && len(strings.TrimSpace(run.Stdout)) != 0 {
-		if holeID == "css-colors" {
+		if holeID == "css-colors" || holeID == "rijndael-s-box" {
 			// TODO Generalise case insensitivity, should it apply to others?
 			run.Pass = strings.EqualFold(run.Answer, run.Stdout)
 		} else {


### PR DESCRIPTION
inlined like css-colors.

Long term it might be more appropriate to create a field inside https://github.com/code-golf/code-golf/blob/master/hole/hole.go for case insensitivity.