### PR TITLE
[Mahjong] Clarify that seven pairs must be distinct

### DIFF
--- a/config/holes.toml
+++ b/config/holes.toml
@@ -1542,7 +1542,7 @@ preamble = '''
     A mahjong hand is <b>complete</b> if it consists of one of the following:
     <ul>
         <li> Four melds and a pair.
-        <li> Seven pairs.
+        <li> Seven distinct pairs. Four of the same tile do not count as two pairs.
         <li> All seven honor tiles and the 1 and 9 of each suit, plus one duplicate tile that forms a pair.
     </ul>
 


### PR DESCRIPTION
Update description for the Mahjong hole to clarify that seven pairs hands must have seven *distinct* pairs.