### PR TITLE
Add more links to cheevos

### DIFF
--- a/config/cheevos.toml
+++ b/config/cheevos.toml
@@ -81,7 +81,7 @@ description = 'Solve <a href=/seven-segment#assembly>Seven Segment in Assembly</
 [['Hole/Lang Specific']]
 name        = 'Bird Is the Word'
 emoji       = '🐦'
-description = 'Solve <a href=/levenshtein-distance>Levenshtein Distance</a> in any three of AWK, Prolog, SQL, Swift, Tcl, or Wren'
+description = 'Solve <a href=/levenshtein-distance>Levenshtein Distance</a> in any three of <a href=/levenshtein-distance#awk>AWK</a>, <a href=/levenshtein-distance#prolog>Prolog</a>, <a href=/levenshtein-distance#sql>SQL</a>, <a href=/levenshtein-distance#swift>Swift</a>, <a href=/levenshtein-distance#tcl>Tcl</a>, or <a href=/levenshtein-distance#wren>Wren</a>'
 target      = 3
 
 [['Hole/Lang Specific']]
@@ -138,7 +138,7 @@ description = 'Solve <a href=/brainfuck#brainfuck>brainfuck in brainfuck</a>.'
 [['Hole/Lang Specific']]
 name        = 'Jeweler'
 emoji       = '💍'
-description = 'Solve <a href=/diamonds>Diamonds</a> in Crystal and Ruby.'
+description = 'Solve <a href=/diamonds>Diamonds</a> in <a href=/diamonds#crystal>Crystal</a> and <a href=/diamonds#ruby>Ruby</a>.'
 target      = 2
 
 [['Hole/Lang Specific']]
@@ -149,7 +149,7 @@ description = 'Solve any hole in both J and K.'
 [['Hole/Lang Specific']]
 name        = 'Mary Had a Little Lambda'
 emoji       = '🐑'
-description = 'Solve <a href=/λ>λ</a> in Clojure, Haskell, and Lisp.'
+description = 'Solve <a href=/λ>λ</a> in <a href=/λ#clojure>Clojure</a>, <a href=/λ#haskell>Haskell</a>, and <a href=/λ#lisp>Lisp</a>.'
 target      = 3
 
 [['Hole/Lang Specific']]
@@ -176,7 +176,7 @@ description = 'Solve <a href=/quine>Quine</a>'
 [['Hole/Lang Specific']]
 name        = 'Sounds Quite Nice'
 emoji       = '🎺'
-description = 'Solve <a href=/musical-chords>Musical Chords</a> in any three of C, C#, D, or F#.'
+description = 'Solve <a href=/musical-chords>Musical Chords</a> in any three of <a href=/musical-chords#c>C</a>, <a href=/musical-chords#c-sharp>C#</a>, <a href=/musical-chords#d>D</a>, or <a href=/musical-chords#f-sharp>F#</a>.'
 target      = 3
 
 [['Hole/Lang Specific']]

--- a/views/golfer/profile.html
+++ b/views/golfer/profile.html
@@ -96,8 +96,9 @@
             </h2>
     {{ range $category, $cheevos := .Cheevos }}
         {{ range $cheevos }}
-            <div {{ if $.GolferInfo.Earned .ID }} class="earned" {{ end }}
-                title="{{ .Name }} - {{ .Description }}">{{ .Emoji }}</div>
+            <a {{ if $.GolferInfo.Earned .ID }} class="earned" {{ end }}
+                href="/rankings/cheevos/{{ .ID }}"
+                title="{{ .Name }} - {{ .Description }}">{{ .Emoji }}</a>
         {{ end }}
     {{ end }}
         </section>


### PR DESCRIPTION
#### Link to [the cheevo page](https://code.golf/rankings/cheevos/jeweler) from the profile page:
![image](https://github.com/code-golf/code-golf/assets/31797752/9f19badc-f8d0-49c2-8450-b0049257251e)

#### Link to [the required languages](https://code.golf/diamonds#crystal) from the cheevo description:
![image](https://github.com/code-golf/code-golf/assets/31797752/a72d20c4-cf81-449f-952a-fdf33701f06e)

We can also add hidden links from the Archivist cheevo description (not implemented in the PR):
```diff
- description = 'Solve <a href=/isbn>ISBN</a> in any three languages that predate ISBN.'
+ description = 'Solve <a href=/isbn>ISBN</a> in <a class=hidden href=/isbn#basic>any</a> <a class=hidden href=/isbn#cobol>three</a> <a class=hidden href=/isbn#forth>languages</a> <a class=hidden href=/isbn#fortran>that</a> <a href=/isbn#lisp>predate</a> ISBN.'
```
```css
a.hidden { color: var(--color); }
```
![image](https://github.com/code-golf/code-golf/assets/31797752/84392db2-3b6f-40e4-95bd-bb4eafab09be)


