### PR TITLE
Remove Clojure implicit output of the last form. Fixes #1060.

### DIFF
--- a/hole/play.go
+++ b/hole/play.go
@@ -241,11 +241,10 @@ func play(ctx context.Context, holeID, langID, code string, run *Run) error {
 	case "c":
 		cmd.Args = []string{"/usr/bin/tcc", "-run", "-"}
 	case "clojure":
-		if holeID == "quine" {
-			// Prevent trivial solutions for Quine.
-			code += "(print)"
-		}
-		cmd.Args = []string{"/usr/bin/clojure", "-e", code}
+		// Appending (print) prevents implicit output of the last form, if it is not nil.
+		// This seems to be a quirk of the Babashka interpreter that only occurs when
+		// providing code via a command line argument.
+		cmd.Args = []string{"/usr/bin/clojure", "-e", code + "(print)"}
 	case "crystal":
 		cmd.Args = []string{"/usr/bin/crystal", "run", "--stdin-filename", "code.cr", "--"}
 		cmd.Env = []string{"CRYSTAL_CACHE_DIR=/tmp", "PATH=/usr/bin:/bin"}

--- a/views/hole-tabs.html
+++ b/views/hole-tabs.html
@@ -98,7 +98,7 @@
                 syscalls</a> to write output.
         </div>
     {{ if eq .Data.Hole.ID "quine" }}
-        <div class="hide info clojure golfscript r">
+        <div class="hide info golfscript r">
             Implicit output is disabled for this hole.
         </div>
         <div class="hide info k">

--- a/views/hole.html
+++ b/views/hole.html
@@ -121,7 +121,7 @@
             syscalls</a> to write output.
     </div>
 {{ if eq .Data.Hole.ID "quine" }}
-    <div class="hide info clojure golfscript r">
+    <div class="hide info golfscript r">
         Implicit output is disabled for this hole.
     </div>
     <div class="hide info k">


### PR DESCRIPTION
Clojure currently outputs the result of the last form, unless it is nil. This doesn't appear to be a standard feature of the language. Instead, it seems to be a quirk of the Babashka interpreter that only occurs when providing code via a command line argument. It's probably best to disable it, since people won't be expecting it and it's generally not too useful.