### PR TITLE
Fix #1059

### DIFF
--- a/css/golfer/profile.css
+++ b/css/golfer/profile.css
@@ -46,7 +46,7 @@ section > a, section > div {
     text-decoration: none;
 }
 
-.icons div:not(.earned) {
+#cheevos a:not(.earned) {
     background: var(--light-grey);
     color: transparent;
     text-shadow: 0 0 var(--cheevo-not-earned);

--- a/views/golfer/profile.html
+++ b/views/golfer/profile.html
@@ -89,7 +89,7 @@
         </section>
     {{ end }}
 
-        <section class=icons>
+        <section id=cheevos class=icons>
             <h2>
                 {{ len .GolferInfo.Cheevos }} / {{ .GolferInfo.CheevosTotal }}
                 Achievements


### PR DESCRIPTION
Unearned cheevos are displayed as earned.

Before:
![image](https://github.com/code-golf/code-golf/assets/31797752/cb5f5b24-ec9a-4844-b53d-262a35d71457)
After:
![image](https://github.com/code-golf/code-golf/assets/31797752/db70d8df-728d-4687-86fc-c5b5f3c088fd)
