### PR TITLE
Update the discord bot to log matched diamonds #629

### DIFF
--- a/golfer/golfer.go
+++ b/golfer/golfer.go
@@ -63,10 +63,9 @@ type RankUpdate struct {
 	Scoring            string           `json:"scoring"`
 	From               RankUpdateFromTo `json:"from"`
 	To                 RankUpdateFromTo `json:"to"`
-	Beat               null.Int         `json:"beat"`
-	OldBestGolferCount null.Int         `json:"oldBestGolferCount"` // Number of golfers that previously held the gold medal.
-	OldBestGolferID    null.Int         `json:"oldBestGolferID"`    // ID of the golfer that previously held the diamond.
-	OldBestStrokes     null.Int         `json:"oldBestStrokes"`
+	OldBestGolferCount null.Int         `json:"oldBestGolferCount"` // Number of golfers that previously held the gold medal (except current golfer).
+	OldBestGolferID    null.Int         `json:"oldBestGolferID"`    // ID of the golfer that previously held the diamond (except current golfer).
+	OldBestStrokes     null.Int         `json:"oldBestStrokes"`     // Number of strokes for previous diamond (including current golfer).
 }
 
 func (f *FailingSolutions) Scan(src any) error {

--- a/js/_hole-common.tsx
+++ b/js/_hole-common.tsx
@@ -247,7 +247,6 @@ export interface RankUpdate {
     scoring: string,
     from: RankFromTo,
     to: RankFromTo,
-    beat: number | null,
     oldBestGolferId: number | null,
     oldBestGolferCount: number | null,
     oldBestStrokes: number | null,
@@ -352,13 +351,21 @@ const diamondPopups = (updates: RankUpdate[]) => {
 
     for (const i of [0, 1] as const) {
         const update = updates[i];
-        if (update.from.rank != 1 && update.to.rank == 1) {
+        if (update.to.rank !== 1) {
+            continue;
+        }
+
+        if (update.from.rank !== 1) {
             if (!update.to.joint) {
                 newDiamonds.push(update.scoring);
             }
             else if (update.oldBestGolferCount === 1) {
                 matchedDiamonds.push(update.scoring);
             }
+        }
+        else if (update.from.joint && !update.to.joint) {
+            // Transition from golf to a new diamond.
+            newDiamonds.push(update.scoring);
         }
     }
 

--- a/sql/c-other-functions.sql
+++ b/sql/c-other-functions.sql
@@ -104,11 +104,13 @@ BEGIN
      WHERE solutions.hole  = hole
        AND solutions.lang  = lang;
 
-    old_best := hole_best_except_user(hole, lang, 'bytes', user_id);
-    IF old_best.strokes = ret.old_best_bytes THEN
-        ret.old_best_bytes_golfer_count := old_best.golfer_count;
-        IF old_best.golfer_count = 1 THEN
-            ret.old_best_bytes_golfer_id := old_best.user_id;
+    IF bytes <= ret.old_best_bytes THEN
+        old_best := hole_best_except_user(hole, lang, 'bytes', user_id);
+        IF old_best.strokes = ret.old_best_bytes THEN
+            ret.old_best_bytes_golfer_count := old_best.golfer_count;
+            IF old_best.golfer_count = 1 THEN
+                ret.old_best_bytes_golfer_id := old_best.user_id;
+            END IF;
         END IF;
     END IF;
 
@@ -123,11 +125,13 @@ BEGIN
          WHERE solutions.hole  = hole
            AND solutions.lang  = lang;
 
-        old_best := hole_best_except_user(hole, lang, 'chars', user_id);
-        IF old_best.strokes = ret.old_best_chars THEN
-            ret.old_best_chars_golfer_count := old_best.golfer_count;
-            IF old_best.golfer_count = 1 THEN
-                ret.old_best_chars_golfer_id := old_best.user_id;
+        IF chars <= ret.old_best_chars THEN
+            old_best := hole_best_except_user(hole, lang, 'chars', user_id);
+            IF old_best.strokes = ret.old_best_chars THEN
+                ret.old_best_chars_golfer_count := old_best.golfer_count;
+                IF old_best.golfer_count = 1 THEN
+                    ret.old_best_chars_golfer_id := old_best.user_id;
+                END IF;
             END IF;
         END IF;
     END IF;


### PR DESCRIPTION
Update existing discord messages so that the golfer who achieved a new diamond isn't included in the number/name of the golfer who held the previous record. If user A and B are tied for gold and then A achieves a new diamond, the discord post will now show (A) instead of (2 golfers) following the old score.

Remove unused fields beat_bytes and beat_chars from the save_solution SQL function.

Fixed a bug related to the client side notifications where we weren't showing the new diamond notification, if you previously had gold.