### PR TITLE
Fix build errors on arm64 and add documentation #861.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,11 +74,11 @@ font:
 	    docker rm $$id
 
 lint:
-	@node_modules/typescript/bin/tsc --project tsconfig.json
-	@node_modules/.bin/eslint --ext ts,tsx js/
-
 	@docker run --rm -v $(CURDIR):/app -w /app \
 	    golangci/golangci-lint:v1.55.2 golangci-lint run
+
+	@node_modules/typescript/bin/tsc --project tsconfig.json
+	@node_modules/.bin/eslint --ext ts,tsx js/
 
 live:
 	@docker buildx build --pull --push \

--- a/README.md
+++ b/README.md
@@ -145,3 +145,36 @@ titles aren't (e.g. Achievements, Languages, Statistics).
 
 Paginated URLs use a trailing number but only on pages after the first (e.g.
 /rankings/medals/all, /rankings/medals/all/2, etc.).
+
+## arm64/aarch64 Architecture (Ex: Apple Silicon)
+
+If your machine has arm64 architecture, then there are a few options for running a local instance of the site.
+You can attempt to use QEMU emulation which is supported by Docker Desktop, but may be slower.
+The default when you `make dev` is that the docker images will be built with arm64 architecture.
+
+You may be able to use some languages without building them locally.
+Here is a list of some of the languages that are able to run the sample code, without rebuilding individual docker containers:
+AWK
+Bash
+Berry
+Lua
+Perl
+PHP
+Python
+Raku
+Ruby
+sed
+SQL
+Wren
+
+For other languages, you will need to build them locally. For example:
+```
+$ ./build-langs --no-push C
+```
+
+Otherwise, you may see the following error:
+```
+assertion failed [!result.is_error]: Unable to open /proc/sys/vm/mmap_min_addr
+(VMAllocationTracker.cpp:281 init)
+ signal: trace/breakpoint trap
+ ```

--- a/run-lang.c
+++ b/run-lang.c
@@ -97,6 +97,8 @@ int main(__attribute__((unused)) int argc, char *argv[]) {
     if (setuid(NOBODY) < 0)
         ERR_AND_EXIT("setuid");
 
+// Syscalls are architecture-specific.
+#if !defined(__aarch64__)
     // sudo journalctl -f _AUDIT_TYPE_NAME=SECCOMP
     // ... SECCOMP ... syscall=xxx ...
     struct sock_filter filter[] = {
@@ -639,6 +641,7 @@ int main(__attribute__((unused)) int argc, char *argv[]) {
 
     if (prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &fprog) < 0)
         ERR_AND_EXIT("prctl(SECCOMP)");
+#endif
 
     execvp(argv[0], argv);
     ERR_AND_EXIT("execvp");


### PR DESCRIPTION
Somewhat related: for `make lint`, run Go linting before ts/js, because the latter may fail when the development operating system is different from the one used in Docker.