### PR TITLE
Fix a bug where the discordbot could show the wrong score for a new d…

### DIFF
--- a/sql/c-other-functions.sql
+++ b/sql/c-other-functions.sql
@@ -101,8 +101,9 @@ BEGIN
 
     SELECT MIN(solutions.bytes) INTO ret.old_best_bytes
       FROM solutions
-     WHERE solutions.hole  = hole
-       AND solutions.lang  = lang;
+     WHERE solutions.failing = false
+       AND solutions.hole    = hole
+       AND solutions.lang    = lang;
 
     IF bytes <= ret.old_best_bytes THEN
         old_best := hole_best_except_user(hole, lang, 'bytes', user_id);
@@ -122,8 +123,9 @@ BEGIN
 
         SELECT MIN(solutions.chars) INTO ret.old_best_chars
           FROM solutions
-         WHERE solutions.hole  = hole
-           AND solutions.lang  = lang;
+         WHERE solutions.failing = false
+           AND solutions.hole    = hole
+           AND solutions.lang    = lang;
 
         IF chars <= ret.old_best_chars THEN
             old_best := hole_best_except_user(hole, lang, 'chars', user_id);


### PR DESCRIPTION
…iamond.

I forgot to filter out failing solutions when checking for the shortest solution for a hole. I copied this code from elsewhere and it would have previously had a bug where it posted the wrong old stroke count for a new diamond, but it would have been less noticeable, because the number was guaranteed to be greater than the strokes for the new diamond.