### PR TITLE
Add mutex for discord bot to ensure messages are combined.

### DIFF
--- a/discord/bot.go
+++ b/discord/bot.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sync"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/code-golf/code-golf/config"
@@ -16,6 +17,7 @@ import (
 
 var (
 	bot *discordgo.Session
+	mux sync.Mutex
 
 	// All the config keys!
 	botToken      = os.Getenv("DISCORD_BOT_TOKEN")       // Caddie
@@ -243,6 +245,14 @@ func LogFailedRejudge(golfer *Golfer.Golfer, hole *config.Hole, lang *config.Lan
 
 // LogNewRecord logs a record breaking solution in Discord.
 func LogNewRecord(
+	golfer *Golfer.Golfer, hole *config.Hole, lang *config.Lang, updates []Golfer.RankUpdate, db *sqlx.DB,
+) {
+	mux.Lock()
+	logNewRecord(golfer, hole, lang, updates, db)
+	mux.Unlock()
+}
+
+func logNewRecord(
 	golfer *Golfer.Golfer, hole *config.Hole, lang *config.Lang, updates []Golfer.RankUpdate, db *sqlx.DB,
 ) {
 	if bot == nil {


### PR DESCRIPTION
When new records were submitted rapidly, sometimes the messages weren't combined. Example: https://discord.com/channels/756829356155731988/800680710964903946/1196494376436764702