### PR TITLE
Show ascii delete \x7f in the editor.

### DIFF
--- a/js/_codemirror_unprintable.tsx
+++ b/js/_codemirror_unprintable.tsx
@@ -69,7 +69,7 @@ class UnprintableWidget extends WidgetType {
 }
 
 const unprintableDecorator = new MatchDecorator({
-    regexp: /[\x01-\x08\x0B-\x1F]/g,
+    regexp: /[\x01-\x08\x0B-\x1F\x7F]/g,
     decoration: match => Decoration.replace({
         widget: new UnprintableWidget(match[0].charCodeAt(0)),
     }),


### PR DESCRIPTION
Otherwise, it's not visible on all platforms.

With this change (this shows the tooltip too)
<img width="75" alt="del" src="https://github.com/code-golf/code-golf/assets/53135437/e89cb5fd-9bf4-4535-a881-968404003887">

Without (on some platforms):
<img width="68" alt="del1" src="https://github.com/code-golf/code-golf/assets/53135437/76acd8ff-2dff-4a2b-9ba1-04e2a0461f21">
