### PR TITLE
Show unprintables in the output window the same way we do in the editor

### DIFF
--- a/js/_hole-common.tsx
+++ b/js/_hole-common.tsx
@@ -696,6 +696,6 @@ export function getScorings(tr: any, editor: any) {
 }
 
 export function replaceUnprintablesInOutput(output: string) {
-    return output.replace(/[\x01-\x08\x0B-\x1F\x7F]/g,
+    return output.replace(/[\x00-\x08\x0B-\x1F\x7F]/g,
         x => `<span title=${'\\u' + x.charCodeAt(0).toString(16)}>•</span>`);
 }

--- a/js/_hole-common.tsx
+++ b/js/_hole-common.tsx
@@ -694,3 +694,8 @@ export function getScorings(tr: any, editor: any) {
 
     return (selection.byte || selection.char) ? {total, selection} : {total};
 }
+
+export function replaceUnprintablesInOutput(output: string) {
+    return output.replace(/[\x01-\x08\x0B-\x1F\x7F]/g,
+        x => `<span title=${'\\u' + x.charCodeAt(0).toString(16)}>•</span>`);
+}

--- a/js/hole-tabs.tsx
+++ b/js/hole-tabs.tsx
@@ -11,7 +11,7 @@ import {
     setCode, refreshScores, getHideDeleteBtn, submit, ReadonlyPanelsData,
     updateRestoreLinkVisibility, getSavedInDB, setCodeForLangAndSolution,
     populateScores, getCurrentSolutionCode, initDeleteBtn, initCopyJSONBtn,
-    getScorings,
+    getScorings, replaceUnprintablesInOutput,
 } from './_hole-common';
 
 const poolDragSources: {[key: string]: DragSource} = {};
@@ -87,7 +87,7 @@ function updateReadonlyPanel(name: string) {
         output.innerHTML = subRes.Err.replace(/\n/g,'<br>');
         break;
     case 'out':
-        output.innerText = subRes.Out;
+        output.innerHTML = replaceUnprintablesInOutput(subRes.Out);
         break;
     case 'exp':
         output.innerText = subRes.Exp;

--- a/js/hole.tsx
+++ b/js/hole.tsx
@@ -5,7 +5,7 @@ import {
     init, langs, getLang, hole, getAutoSaveKey, setSolution, getSolution,
     setCode, refreshScores, submit, getSavedInDB, updateRestoreLinkVisibility,
     ReadonlyPanelsData, setCodeForLangAndSolution, getCurrentSolutionCode,
-    initDeleteBtn, initCopyJSONBtn, getScorings,
+    initDeleteBtn, initCopyJSONBtn, getScorings, replaceUnprintablesInOutput,
 } from './_hole-common';
 
 const editor = new EditorView({
@@ -86,7 +86,7 @@ function updateReadonlyPanels(data: ReadonlyPanelsData) {
 
     // Always show exp & out.
     $('#exp div').innerText = data.Exp;
-    $('#out div').innerText = data.Out;
+    $('#out div').innerHTML = replaceUnprintablesInOutput(data.Out);
 
     const diff = diffTable(hole, data.Exp, data.Out, data.Argv);
     $('#diff-content').replaceChildren(diff);


### PR DESCRIPTION
#906 #1089.

Image also shows tooltip at the bottom to show the character.

The diff view still doesn't support this.

<img width="380" alt="out" src="https://github.com/code-golf/code-golf/assets/53135437/5fb08bb2-d9e1-43a4-ab91-5780e8e95fe5">
