### PR TITLE
Load & use issue labels to categorize ideas

### DIFF
--- a/github/ideas.go
+++ b/github/ideas.go
@@ -19,6 +19,11 @@ func ideas(db *sqlx.DB) (limits []rateLimit) {
 					ThumbsDown thumbs `graphql:"thumbsDown: reactions(content: THUMBS_DOWN)"`
 					ThumbsUp   thumbs `graphql:"thumbsUp:   reactions(content: THUMBS_UP)"`
 					Title      string
+					Labels     struct {
+						Nodes []struct {
+							Name string
+						}
+					} `graphql:"labels(first: 100)"`
 				}
 				PageInfo pageInfo
 			} `graphql:"issues(after: $cursor first: 100 labels: \"idea\" states: OPEN)"`
@@ -40,12 +45,23 @@ func ideas(db *sqlx.DB) (limits []rateLimit) {
 		limits = append(limits, query.RateLimit)
 
 		for _, node := range query.Repository.Issues.Nodes {
+			kind := "other"
+			for _, label := range node.Labels.Nodes {
+				if label.Name == "lang-idea" {
+					kind = "lang"
+				} else if label.Name == "hole-idea" {
+					kind = "hole"
+				} else if label.Name == "cheevo-idea" {
+					kind = "cheevo"
+				}
+			}
 			tx.MustExec(
-				"INSERT INTO ideas VALUES ($1, $2, $3, $4)",
+				"INSERT INTO ideas VALUES ($1, $2, $3, $4, $5)",
 				node.Number,
 				node.ThumbsDown.TotalCount,
 				node.ThumbsUp.TotalCount,
 				node.Title,
+				kind,
 			)
 		}
 

--- a/routes/ideas.go
+++ b/routes/ideas.go
@@ -10,16 +10,28 @@ import (
 	"github.com/code-golf/code-golf/session"
 )
 
+func ideaColor(kind string) string {
+	switch kind {
+	case "hole":
+		return "purple"
+	case "lang":
+		return "yellow"
+	case "cheevo":
+		return "green"
+	}
+	return "red"
+}
+
 // GET /ideas
 func ideasGET(w http.ResponseWriter, r *http.Request) {
 	type idea struct {
 		Hole                     *config.Hole
 		ID, ThumbsDown, ThumbsUp int
-		Title                    string
+		Title, Kind, KindColor   string
 	}
 
 	data := struct {
-		Holes, Ideas, Langs []idea
+		Holes, Ideas []idea
 	}{Holes: make([]idea, len(config.ExpHoleList))}
 
 	for i, hole := range config.ExpHoleList {
@@ -46,11 +58,10 @@ rows:
 
 		if strings.HasPrefix(i.Title, "Add ") && strings.HasSuffix(i.Title, " Lang") {
 			i.Title = i.Title[len("Add ") : len(i.Title)-len(" Lang")]
-
-			data.Langs = append(data.Langs, i)
-		} else {
-			data.Ideas = append(data.Ideas, i)
 		}
+
+		i.KindColor = ideaColor(i.Kind)
+		data.Ideas = append(data.Ideas, i)
 	}
 
 	slices.SortStableFunc(data.Holes, func(a, b idea) int {

--- a/sql/a-schema.sql
+++ b/sql/a-schema.sql
@@ -76,6 +76,8 @@ CREATE TYPE scoring AS ENUM ('bytes', 'chars');
 
 CREATE TYPE theme AS ENUM ('auto', 'dark', 'light');
 
+CREATE TYPE idea_kind AS ENUM ('other', 'hole', 'cheevo', 'lang');
+
 CREATE TABLE discord_records (
     hole    hole NOT NULL,
     lang    lang NOT NULL,
@@ -84,10 +86,11 @@ CREATE TABLE discord_records (
 );
 
 CREATE UNLOGGED TABLE ideas (
-    id          int  NOT NULL PRIMARY KEY,
-    thumbs_down int  NOT NULL,
-    thumbs_up   int  NOT NULL,
-    title       text NOT NULL UNIQUE
+    id          int       NOT NULL PRIMARY KEY,
+    thumbs_down int       NOT NULL,
+    thumbs_up   int       NOT NULL,
+    title       text      NOT NULL UNIQUE,
+    kind        idea_kind NOT NULL DEFAULT 'other'  
 );
 
 CREATE TABLE users (

--- a/views/ideas.html
+++ b/views/ideas.html
@@ -9,7 +9,7 @@
 {{ with .Hole }}
     <a class="card {{ .CategoryColor }}" href="/{{ .ID }}" title="{{ .Name }} ({{ .Category }})">
 {{ else }}
-    <a class="card color" href="//github.com/code-golf/code-golf/issues/{{ .ID }}" title="{{ .Title }}">
+    <a class="card {{ .KindColor }}" href="//github.com/code-golf/code-golf/issues/{{ .ID }}" title="{{ .Title }}">
 {{ end }}
         <h2 class=span>{{ .Title }}</h2>
         <svg><use href="#thumbs-up"/></svg>
@@ -28,9 +28,6 @@
 
     <h1 class=span>Ideas</h1>
     {{ template "ideaGrid" .Data.Ideas }}
-
-    <h1 class=span>Language Suggestions</h1>
-    {{ template "ideaGrid" .Data.Langs }}
 
     <p class="right span">
         <a href="//github.com/code-golf/code-golf/issues/new/choose">


### PR DESCRIPTION
Modifies the github integration to use the issue labels to distinquish lang, hole, cheevo & other suggestions so that we don't have to rely on exact issue title form to recognize lang suggestions. Uses colors to visually distinquish each idea kind.
![image](https://github.com/code-golf/code-golf/assets/13916220/05ebfea6-a621-4d72-a015-78e3c18d17cc)
