### PR TITLE
Visible Editor Whitespace

### DIFF
--- a/css/hole.css
+++ b/css/hole.css
@@ -348,3 +348,16 @@ h2 {
     font-weight: normal;
     padding-bottom: 0.1rem;
 }
+
+#showWhitespaceCheckbox {
+    margin-left: .5rem;
+    margin-right: .5rem;
+}
+
+.cm-highlightSpace {
+    opacity: 0;
+}
+
+:has(#showWhitespaceCheckbox:checked) .cm-highlightSpace {
+    opacity: .25;
+}

--- a/js/_codemirror.ts
+++ b/js/_codemirror.ts
@@ -1,5 +1,6 @@
 import { EditorState }                                    from '@codemirror/state';
-import { EditorView, keymap, lineNumbers, drawSelection } from '@codemirror/view';
+import { EditorView, keymap, lineNumbers, drawSelection,
+    highlightWhitespace } from '@codemirror/view';
 import { $ }                                              from './_util';
 
 export { EditorState, EditorView };
@@ -89,6 +90,7 @@ export const extensions = {
             { key: 'Mod-/', run: toggleComment },
         ]),
         drawSelection(),
+        highlightWhitespace(),
         syntaxHighlighting(defaultHighlightStyle),
         EditorView.theme({
             '.cm-asm-error': { textDecoration: 'underline var(--asm-error)' },

--- a/js/hole-tabs.tsx
+++ b/js/hole-tabs.tsx
@@ -174,7 +174,10 @@ layout.registerComponentFactoryFunction('code', async container => {
     autoFocus(container);
 
     const header = (<header>
-        <div id="strokes">0 bytes, 0 chars</div>
+        <div>
+            <span id="strokes">0 bytes, 0 chars</span>
+            <input type="checkbox" id="showWhitespaceCheckbox" checked/><label for="showWhitespaceCheckbox">Show whitespace</label>
+        </div>
         <a class="hide" href="" id="restoreLink">Restore solution</a>
     </header>) as HTMLElement;
     const editorDiv = <div id="editor"></div> as HTMLDivElement;

--- a/js/typings/_intrinsicJSX.ts
+++ b/js/typings/_intrinsicJSX.ts
@@ -39,6 +39,8 @@ declare global {
       section: any;
       header: any;
       code: any;
+      input: any;
+      label: any;
     }
   }
 }

--- a/views/hole.html
+++ b/views/hole.html
@@ -91,7 +91,10 @@
     <nav class=tabs id=solutionPicker></nav>
     <section>
         <header>
-            <div id=strokes>0 bytes, 0 chars</div>
+            <div>
+                <span id=strokes>0 bytes, 0 chars</span>
+                <input type=checkbox id=showWhitespaceCheckbox checked><label for=showWhitespaceCheckbox>Show whitespace</label>
+            </div>
             <a class=hide href id=restoreLink>Restore solution</a>
         </header>
         <header class=wide>


### PR DESCRIPTION
Closes #332 
![image](https://github.com/code-golf/code-golf/assets/13916220/5807c38f-c27d-43c8-953a-f3e0e0b62dbb)

Alternatively, we could show only the trailing whitespace on each line.
![image](https://github.com/code-golf/code-golf/assets/13916220/98586224-e574-4f3d-8852-ac87baee1a02)
This might even make sense to have as a default without any settings at all since you don't want trailing whitespace in most langs anyway?

In this PR, the toggling is done trough css, there's no javascript. Should it instead be saved to a localstorage or to the database?

