### PR TITLE
Line 12 of JavaScript's sample code is so odd, kind of.

### DIFF
--- a/config/langs.toml
+++ b/config/langs.toml
@@ -653,8 +653,6 @@ for (let i = 0; i < 10; i++)
 // Accessing arguments
 for (let arg of arguments)
     print(arg);
-
-// write() outputs without a newline.
 '''
 
 [Julia]


### PR DESCRIPTION
There's very little added value in mentioning the purpose of `write` in the solution editor imho because it's properly documented on CG's wiki for JS.

> Arguments are accessed through the arguments variable; output is generated using the print (output with newline) and write (output without newline) functions.
> 
> Sample code:
> 
> 
> ```
> // Printing
> print("Hello, World!");
> 
> // Looping
> for (let i = 0; i < 10; i++)
>     print(i);
> 
> // Accessing arguments
> for (let arg of arguments)
>     print(arg);
> ```

It might've probably been forgotten at some point very very long ago but considering `// write() outputs without a newline.` was also excluded from the wiki page and there is not one other sample for a language, which I checked lol, where I came across similar "printing-without-new-line" comments, I think there's little to no harm in letting this one go.

Browsing docs and all sorts of stuff just to find that one freaking function you need is also part of our lives as programmers, am I right? Potentially lengthy and frustating processes but in the end, fun! ^^