### PR TITLE
Remove editor extensions from wiki

### DIFF
--- a/js/_codemirror.ts
+++ b/js/_codemirror.ts
@@ -81,14 +81,7 @@ const fontFamily = "'Source Code Pro', monospace";
 export const extensions = {
     // Extensions.
     'base': [
-        carriageReturn, history(), insertChar, lineNumbers(), showUnprintables,
-        keymap.of([
-            // Replace "enter" with a non auto indenting action.
-            ...historyKeymap, ...standardKeymap.filter(k => k.key != 'Enter'),
-            { key: 'Enter', run: insertNewline },
-            { key: 'Tab',   run: insertTab, shift: indentLess },
-            { key: 'Mod-/', run: toggleComment },
-        ]),
+        carriageReturn, showUnprintables,        
         drawSelection(),
         highlightWhitespace(),
         syntaxHighlighting(defaultHighlightStyle),
@@ -100,6 +93,18 @@ export const extensions = {
             '.cm-tooltip':              { fontFamily },
             '.cm-tooltip-autocomplete': { fontFamily },
         }, { dark: false }),
+    ],
+    'editor': [
+        history(),
+        insertChar,
+        keymap.of([
+            // Replace "enter" with a non auto indenting action.
+            ...historyKeymap, ...standardKeymap.filter(k => k.key != 'Enter'),
+            { key: 'Enter', run: insertNewline },
+            { key: 'Tab',   run: insertTab, shift: indentLess },
+            { key: 'Mod-/', run: toggleComment },
+        ]),
+        lineNumbers()
     ],
     'bracketMatching': bracketMatching(),
     'vim': vim({ status: true }),

--- a/js/_hole-common.tsx
+++ b/js/_hole-common.tsx
@@ -86,7 +86,7 @@ const solutions    = JSON.parse($('#solutions').innerText);
 const vimMode = JSON.parse($('#keymap').innerText) === 'vim';
 const vimModeExtensions = vimMode ? [extensions.vim] : [];
 
-const baseExtensions = [...vimModeExtensions, ...extensions.base];
+const baseExtensions = [...vimModeExtensions, ...extensions.base, ...extensions.editor];
 
 let latestSubmissionID = 0;
 let solution = scorings.indexOf(localStorage.getItem('solution') ?? 'Bytes') as 0 | 1;


### PR DESCRIPTION
Disables code mirror extensions that are related to editing source code from the wiki code blocks.
Hides line numbers in wiki.