### PR TITLE
Use relative time for discord timestamps instead of absolute time

### DIFF
--- a/discord/bot.go
+++ b/discord/bot.go
@@ -101,7 +101,7 @@ func recAnnounceToEmbed(announce *RecAnnouncement, db *sqlx.DB) *discordgo.Messa
 				timestamp := update.OldBestSubmitted.Time
 				if time.Since(timestamp) > minElapsedTimeToShowDate {
 					// Show the data using a locale-specific short date format.
-					fieldValues[update.Scoring] += fmt.Sprintf(" (<t:%d:d>)", timestamp.Unix())
+					fieldValues[update.Scoring] += fmt.Sprintf(" (<t:%d:R>)", timestamp.Unix())
 				}
 
 				if update.OldBestGolferCount.Valid && update.OldBestGolferCount.Int64 > 1 {


### PR DESCRIPTION
I prefer so see a solution is "4 months old"  than seeing a time and needing to calculate how long ago it was.

You should still be able to hover over the timestamp and see the actual time.