### PR TITLE
Add a 'Clear sample code' link.

### DIFF
--- a/js/_hole-common.tsx
+++ b/js/_hole-common.tsx
@@ -629,9 +629,16 @@ export async function submit(
 }
 
 export function updateRestoreLinkVisibility(editor: any) {
-    const serverCode = getSolutionCode(lang, solution);
-    $('#restoreLink')?.classList.toggle('hide',
-        !serverCode || editor?.state.doc.toString() == serverCode);
+    const restoreLink = $('#restoreLink');
+    if (restoreLink instanceof HTMLAnchorElement) {
+        const serverCode = getSolutionCode(lang, solution);
+        const sampleCode = langs[lang].example;
+        const currentCode = editor?.state.doc.toString();
+        restoreLink.classList.toggle('hide',
+            (!serverCode && currentCode !== sampleCode) || currentCode === serverCode);
+        restoreLink.textContent =
+            currentCode === sampleCode ? 'Clear sample code' : 'Restore solution';
+    }
 }
 
 export function setCodeForLangAndSolution(editor: any) {


### PR DESCRIPTION
This has been requested before, because otherwise it requires multiple steps to do this, select all and then delete, and this can be awkward on some phones.