### PR TITLE
Fix a bug where the diff panel ignores non-printable characters.

### DIFF
--- a/js/_diff.tsx
+++ b/js/_diff.tsx
@@ -193,16 +193,16 @@ function diffHTMLRows(hole: string, exp: string, out: string, argv: string[], ig
 }
 
 function stringsEqual(a: string, b: string, ignoreCase: boolean) {
-    // https://stackoverflow.com/a/2140723/7481517
+    // Note: localeCompare ignores non-printable characters.
+    if (!ignoreCase) {
+        return a === b;
+    }
     return (
         a !== undefined &&
         a !== null &&
-        0 ===
-        a.localeCompare(
-            b,
-            undefined,
-            ignoreCase ? { sensitivity: 'accent' } : undefined,
-        )
+        b !== undefined &&
+        b !== null &&
+        a.toLowerCase() === b.toLowerCase()
     );
 }
 


### PR DESCRIPTION
This fixes an issue where the diff panel totally ignores non-printable characters when comparing strings. With this change, non-printable characters in the diff still aren't visible, but lines containing differences that consist only of non-printable characters are now highlighted.

<img width="1359" alt="localediff" src="https://github.com/code-golf/code-golf/assets/53135437/df3ff7f9-973a-4769-a2a4-5aeb4188e098">
