### PR TITLE
Fix discord/getUsername()

### DIFF
--- a/discord/bot.go
+++ b/discord/bot.go
@@ -62,7 +62,7 @@ func init() {
 }
 
 func getUsername(id int, db *sqlx.DB) (name string) {
-	err := db.Select(&name, "SELECT login FROM users WHERE id = $1", id)
+	err := db.Get(&name, "SELECT login FROM users WHERE id = $1", id)
 	if err != nil {
 		log.Println(err)
 	}


### PR DESCRIPTION
`db.Select` is for array of results, `db.Get` is single result, based on documentation, untested

I suspect this is why showing the previous golfer name is broken in Caddie