### PR TITLE
When determining the date of a previous solution for the discord bot filter by scoring type.

### DIFF
--- a/sql/c-other-functions.sql
+++ b/sql/c-other-functions.sql
@@ -107,6 +107,7 @@ BEGIN
      WHERE solutions.failing = false
        AND solutions.hole    = hole
        AND solutions.lang    = lang
+       AND solutions.scoring = 'bytes'
   ORDER BY solutions.bytes, solutions.submitted
      LIMIT 1;
 
@@ -132,6 +133,7 @@ BEGIN
          WHERE solutions.failing = false
            AND solutions.hole    = hole
            AND solutions.lang    = lang
+           AND solutions.scoring = 'chars'
       ORDER BY solutions.chars, solutions.submitted
          LIMIT 1;
 


### PR DESCRIPTION
Otherwise, a situation can arise where, for example, an earlier chars solution is replaced by a different one, with a lower byte count, but the chars solution keeps its date, because the char count is the same. Then the discord bot can erroneously report the earlier date for the bytes solution, unless we filter by scoring when doing the query.