### PR TITLE
Disable SECCOMP for dev by default.

### DIFF
--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -65,7 +65,7 @@ COPY --from=codegolf/lang-brainfuck  ["/", "/langs/brainfuck/rootfs/" ] # 51.1 K
 
 COPY run-lang.c ./
 
-RUN gcc -Wall -Werror -Wextra -o /usr/bin/run-lang -s -static run-lang.c
+RUN gcc -Wall -Werror -Wextra -DDISABLE_SECCOMP -o /usr/bin/run-lang -s -static run-lang.c
 
 # reflex reruns a command when files change.
 CMD reflex -sd none -r '\.(css|go|html|json|pem|svg|toml)$' -R '_test\.go$' -- go run .

--- a/run-lang.c
+++ b/run-lang.c
@@ -115,6 +115,7 @@ int main(__attribute__((unused)) int argc, char *argv[]) {
     if (setuid(NOBODY) < 0)
         ERR_AND_EXIT("setuid");
 
+#ifndef DISABLE_SECCOMP
     // sudo journalctl -f _AUDIT_TYPE_NAME=SECCOMP
     // ... SECCOMP ... syscall=xxx ...
     struct sock_filter filter[] = {
@@ -667,6 +668,7 @@ int main(__attribute__((unused)) int argc, char *argv[]) {
 
     if (prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &fprog) < 0)
         ERR_AND_EXIT("prctl(SECCOMP)");
+#endif
 
     execvp(argv[0], argv);
     ERR_AND_EXIT("execvp");


### PR DESCRIPTION
I need this for my aarch64 MacBook Pro. It's getting to be inconvenient to have to manually make this change and then avoid committing it.