### PR TITLE
discord bot: combine messages, even if the server is restarted.

### DIFF
--- a/null/null.go
+++ b/null/null.go
@@ -26,3 +26,18 @@ func (n Null[T]) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal(n.V)
 }
+
+func (n *Null[T]) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == 'n' {
+		n.Valid = false
+		return nil
+	}
+
+	if err := json.Unmarshal(data, &n.V); err != nil {
+		n.Valid = false
+		return err
+	}
+
+	n.Valid = true
+	return nil
+}

--- a/sql/a-schema.sql
+++ b/sql/a-schema.sql
@@ -84,6 +84,11 @@ CREATE TABLE discord_records (
     PRIMARY KEY (hole, lang)
 );
 
+CREATE TABLE discord_state (
+    key   text NOT NULL PRIMARY KEY,
+    value text NOT NULL
+);
+
 CREATE UNLOGGED TABLE ideas (
     id          int           NOT NULL PRIMARY KEY,
     thumbs_down int           NOT NULL,
@@ -289,6 +294,7 @@ ALTER MATERIALIZED VIEW rankings OWNER TO "code-golf";
 GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE authors         TO "code-golf";
 GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE connections     TO "code-golf";
 GRANT SELECT, INSERT, UPDATE         ON TABLE discord_records TO "code-golf";
+GRANT SELECT, INSERT, UPDATE         ON TABLE discord_state   TO "code-golf";
 GRANT SELECT, INSERT,         DELETE ON TABLE follows         TO "code-golf";
 GRANT SELECT, INSERT, TRUNCATE       ON TABLE ideas           TO "code-golf";
 GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE notes           TO "code-golf";


### PR DESCRIPTION
Store the last announcement state in the database. Before modifying the last announcement, check whether it was last message in the channel. The previous method of listening for new messages wouldn't be as reliable now that this state is persisted, because a message could be created when the server is offline.