### PR TITLE
Clarify Reversi description

### DIFF
--- a/config/holes.toml
+++ b/config/holes.toml
@@ -2587,24 +2587,26 @@ links = [
 released = 2024-06-01
 synopsis = 'Output possible moves for O on a Reversi board.'
 preamble = '''
-<p>Output the possible moves for O on a Reversi board.
+<p>Output the possible moves for <code>O</code> on a Reversi board.
 
 <p>
-    In Reversi, you can only place a tile in a free spot such that there are
-    one or more opponents tiles between the spot and a friendly tile in at least
-    one direction. Directions are either horizontal, vertical, or diagonal.
+    In Reversi, <code>X</code> and <code>O</code> take turns placing tiles
+    on empty squares on the board. To determine if a move is legal, draw
+    a straight line in any direction (horizontal, vertical, or diagonal)
+    starting from the square. If the line intersects another friendly tile,
+    separated from the square by only opponent tiles, that square is a legal move.
 <p>
     For example, given:
 
 <pre>
-.....
-.OXX!
-..X..
-...!.
+......
+.OXX!.
+..X...
+...!..
 </pre>
 
 <p>
-    <code>O</code> can only place on spots marked with <code>!</code>.
+    <code>O</code> can only place on squares marked with <code>!</code>.
 
 <p>
     Assume a board size of 8x8 and a position reachable on <code>O</code>'s turn,
@@ -2622,7 +2624,7 @@ preamble = '''
 </pre>
 
 <p>
-    <code>X</code> moves first so you can assume an odd number of tiles on the board.
+    <code>X</code> moves first, so you may assume an odd number of tiles on the board.
 
 <p>
     Your program should output the board with each possible legal <code>O</code> move


### PR DESCRIPTION
There are a few edge cases that I noticed while working on my solution:
- Legal moves must be adjacent to at least one other tile. For example, `OX.. -> OX!.`, not `OX!!`.
- Legal moves are separated from friendly tiles by *only* opponent tiles. For example, `OXO. -> OXO.`, not `OXO!`.

The test cases answer both of these, but the example and description do not. I've reworked the description to address them (relying on the fact that the second actually implies the first), though it's longer than I'd like. I'm not sure how to get around the wordiness, as even [the rules on Wikipedia](https://en.wikipedia.org/wiki/Reversi?useskin=vector#Rules) don't resolve the ambiguity (they mention "contiguous" opponent tiles separating the friendly tiles, but that's not quite right either).

@Yewzir also suggested wording the rules entirely from O's POV since that's what the hole asks, but I didn't want to completely redo the description for it. Votes in favor of doing that or any other suggestions are appreciated.