### PR TITLE
Add random cases to brainfuck

### DIFF
--- a/hole/brainfuck.go
+++ b/hole/brainfuck.go
@@ -53,10 +53,6 @@ func fixedBFCases() []test {
 	}
 }
 
-func randInt(min, max int) int {
-	return rand.IntN(max-min+1) + min
-}
-
 func intToBFString(n int) string {
 	if n < 1 {
 		return strings.Repeat("-", -n)

--- a/hole/brainfuck.go
+++ b/hole/brainfuck.go
@@ -62,8 +62,8 @@ func intToBFString(n int) string {
 }
 
 func randomBFCase(jumpSize, buckets, initialBucketSize, bucketSizeChange, charShift int) test {
-	const AsciiMin = 32
-	const AsciiMax = 126
+	const ASCIIMin = 32
+	const ASCIIMax = 126
 
 	bucketString := ""
 	out := ""
@@ -78,8 +78,8 @@ func randomBFCase(jumpSize, buckets, initialBucketSize, bucketSizeChange, charSh
 	for i := 0; i < buckets; i++ {
 		// Choose a base for this bucket that ensures all chars remain in the printable ASCII range
 		totalShift := charShift * (bucketSize - 1)
-		minChar := AsciiMin
-		maxChar := AsciiMax
+		minChar := ASCIIMin
+		maxChar := ASCIIMax
 		if totalShift > 0 {
 			maxChar -= totalShift
 		} else {

--- a/hole/brainfuck.go
+++ b/hole/brainfuck.go
@@ -13,8 +13,8 @@ func brainfuck() []Run {
 
 	for i := 0; i < 3; i++ {
 		jumpSize := randInt(5, 12)
-		buckets := randInt(2, 9)
-		initialBucketSize := randInt(1, 8)
+		buckets := randInt(2, 8)
+		initialBucketSize := randInt(1, 7)
 		bucketSizeChange := randInt(-1, 2)
 		charShift := randInt(-3, 3)
 		tests = append(tests, randomBFCase(jumpSize, buckets, initialBucketSize, bucketSizeChange, charShift))
@@ -49,8 +49,8 @@ func fixedBFCases() []test {
 			"eL34NfeOL454KdeJ44JOdefePK55gQ67ShfTL787KegJ77JTeghfUK88iV9:XjgYL:;:KfiJ::JYfijgZK;;k[<=]lh^L=>=KgkJ==J^gklh_K>>m`?@bnicL@A@KhmJ@@JchmnidKAA"},
 		test{"++++++++++[>++++++++++>++++++++++++<<-]>--->++>+++++++++++++[<.-<.+>>-]++++[<<-------------------------.>>-]",
 			"zaybxcwdveuftgshriqjpkolnmU<#"},
-		test{"++++++++++[>+++>+++++++++>+<<<-]>++>++++[<.+>-]>.",
-			" !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}"},
+		test{"++++++++++[>+++++>+++++++>+<<<-]>+>++[-<.+>]>.",
+			"3456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz"},
 	}
 }
 
@@ -62,8 +62,9 @@ func intToBFString(n int) string {
 }
 
 func randomBFCase(jumpSize, buckets, initialBucketSize, bucketSizeChange, charShift int) test {
-	const ASCIIMin = 32
-	const ASCIIMax = 126
+	// Only generates ASCII values in a range that was already used by fixed cases before random cases were added, in order to not break legacy solutions.
+	const ASCIIMin = 50
+	const ASCIIMax = 122
 
 	bucketString := ""
 	out := ""

--- a/hole/brainfuck.go
+++ b/hole/brainfuck.go
@@ -50,7 +50,7 @@ func fixedBFCases() []test {
 		test{"++++++++++[>++++++++++>++++++++++++<<-]>--->++>+++++++++++++[<.-<.+>>-]++++[<<-------------------------.>>-]",
 			"zaybxcwdveuftgshriqjpkolnmU<#"},
 		test{"++++++++++[>+++>+++++++++>+<<<-]>++>++++[<.+>-]>.",
-		     	" !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}"},
+			" !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}"},
 	}
 }
 

--- a/hole/brainfuck.go
+++ b/hole/brainfuck.go
@@ -60,8 +60,8 @@ func intToBFString(n int) string {
 }
 
 func randomBFCase(jumpSize, buckets, initialBucketSize, bucketSizeChange, charShift int) test {
-	const ASCII_MIN = 32
-	const ASCII_MAX = 126
+	const AsciiMin = 32
+	const AsciiMax = 126
 
 	bucketString := ""
 	out := ""
@@ -76,8 +76,8 @@ func randomBFCase(jumpSize, buckets, initialBucketSize, bucketSizeChange, charSh
 	for i := 0; i < buckets; i++ {
 		// Choose a base for this bucket that ensures all chars remain in the printable ASCII range
 		totalShift := charShift * (bucketSize - 1)
-		minChar := ASCII_MIN
-		maxChar := ASCII_MAX
+		minChar := AsciiMin
+		maxChar := AsciiMax
 		if totalShift > 0 {
 			maxChar -= totalShift
 		} else {

--- a/hole/brainfuck.go
+++ b/hole/brainfuck.go
@@ -49,6 +49,8 @@ func fixedBFCases() []test {
 			"eL34NfeOL454KdeJ44JOdefePK55gQ67ShfTL787KegJ77JTeghfUK88iV9:XjgYL:;:KfiJ::JYfijgZK;;k[<=]lh^L=>=KgkJ==J^gklh_K>>m`?@bnicL@A@KhmJ@@JchmnidKAA"},
 		test{"++++++++++[>++++++++++>++++++++++++<<-]>--->++>+++++++++++++[<.-<.+>>-]++++[<<-------------------------.>>-]",
 			"zaybxcwdveuftgshriqjpkolnmU<#"},
+		test{"++++++++++[>+++>+++++++++>+<<<-]>++>++++[<.+>-]>.",
+		     	" !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}"},
 	}
 }
 

--- a/hole/brainfuck.go
+++ b/hole/brainfuck.go
@@ -2,7 +2,6 @@ package hole
 
 import (
 	"fmt"
-	"math/rand/v2"
 	"strings"
 )
 

--- a/hole/brainfuck.go
+++ b/hole/brainfuck.go
@@ -1,45 +1,112 @@
 package hole
 
 import (
+	"fmt"
 	"math/rand/v2"
 	"strings"
 )
 
 func brainfuck() []Run {
-	args := []string{
-		"+++++++++++++++[>++>+++>++++>+++++>++++++>+++++++>++++++++<<<<<<<-]+++++++++++++++>>>++++++.>>+++++++.>>-----.<-.<<<<<<-----.",
-		"+++++++++++++++[>++>+++>++++>+++++>++++++>+++++++>++++++++<<<<<<<-]+++++++++++++++>>>>-.>+++++++.>>--.<<.<+++++++++.>++.>>----.<.>--.++++.<<<<<<<-----.",
-		"+++++++++++++++++++++++++[>++>+++>++++>+++++<<<<-]+++++++++++++++++++++++++>>+.>>--------.<---.<<<---------------.",
-		"+++++++++++++++++++++++++[>++>+++>++++>+++++<<<<-]+++++++++++++++++++++++++>>+++++.>+.>-----------.------.<<<<---------------.",
-		"+++++++++++++++[>++>+++>++++>+++++>++++++>+++++++>++++++++<<<<<<<-]+++++++++++++++>>>>+++++.>>----.>------.------.<<<<<<++.>>------.<<<-----.",
-		"+++++++++++++++++++++[>++>+++>++++>+++++>++++++<<<<<-]+++++++++++++++++++++>>>----.--------.++++++++.<<<-----------.",
-		"+++++++++++++++++++++[>++>+++>++++>+++++>++++++<<<<<-]+++++++++++++++++++++>>>----.>>-----.-----.<-.>-----.-.<<<<<-----------.",
-		"+++++++++++++++++++++[>++>+++>++++>+++++>++++++<<<<<-]+++++++++++++++++++++>>>--.>>---------.<-------.>++++.<<<<<-----------.",
-		"++++++++++++++++++[>++>+++>++++>+++++>++++++>+++++++<<<<<<-]++++++++++++++++++>>>-----.>>+++.<++++++++++.+.<<<----.>>++++.>>.---.<+.<<<<--------.",
-		">>>>>>>>>>>>>>>>>>>>>>>>>>>>++++++++++++++++++++++++++[-<<[+<]+[>]>][<<[[-]-----<]>[>]>]<<[++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++<]>[.>]++++++++++.",
-		"+++++[>+++++[>++>++>+++>+++>++++>++++<<<<<<-]<-]+++++[>>[>]<[+.<<]>[++.>>>]<[+.<]>[-.>>]<[-.<<<]>[.>]<[+.<]<-]++++++++++.",
-		"++++++++++[>++++++++++>++++++++++++<<-]>--->++>+++++++++++++[<.-<.+>>-]++++[<<-------------------------.>>-]",
+	var tests []test = fixedBFCases()
+
+	tests = append(tests, randomBFCase(5, 3, 8, -3, 2))
+	tests = append(tests, randomBFCase(10, 5, 1, 1, -3))
+
+	for i := 0; i < 3; i++ {
+		jumpSize := randInt(5, 12)
+		buckets := randInt(2, 9)
+		initialBucketSize := randInt(1, 8)
+		bucketSizeChange := randInt(-1, 2)
+		charShift := randInt(-3, 3)
+		tests = append(tests, randomBFCase(jumpSize, buckets, initialBucketSize, bucketSizeChange, charShift))
 	}
 
-	outs := []string{
-		"Bash",
-		"JavaScript",
-		"Lua",
-		"Perl",
-		"Perl 6",
-		"PHP",
-		"Python",
-		"Ruby",
-		"Code Golf",
-		"abcdefghijklmnopqrstuvwxyz",
-		"eL34NfeOL454KdeJ44JOdefePK55gQ67ShfTL787KegJ77JTeghfUK88iV9:XjgYL:;:KfiJ::JYfijgZK;;k[<=]lh^L=>=KgkJ==J^gklh_K>>m`?@bnicL@A@KhmJ@@JchmnidKAA",
-		"zaybxcwdveuftgshriqjpkolnmU<#",
+	return outputTests(shuffle(tests))
+}
+
+func fixedBFCases() []test {
+	return []test{
+		test{"+++++++++++++++[>++>+++>++++>+++++>++++++>+++++++>++++++++<<<<<<<-]+++++++++++++++>>>++++++.>>+++++++.>>-----.<-.<<<<<<-----.",
+			"Bash"},
+		test{"+++++++++++++++[>++>+++>++++>+++++>++++++>+++++++>++++++++<<<<<<<-]+++++++++++++++>>>>-.>+++++++.>>--.<<.<+++++++++.>++.>>----.<.>--.++++.<<<<<<<-----.",
+			"JavaScript"},
+		test{"+++++++++++++++++++++++++[>++>+++>++++>+++++<<<<-]+++++++++++++++++++++++++>>+.>>--------.<---.<<<---------------.",
+			"Lua"},
+		test{"+++++++++++++++++++++++++[>++>+++>++++>+++++<<<<-]+++++++++++++++++++++++++>>+++++.>+.>-----------.------.<<<<---------------.",
+			"Perl"},
+		test{"+++++++++++++++[>++>+++>++++>+++++>++++++>+++++++>++++++++<<<<<<<-]+++++++++++++++>>>>+++++.>>----.>------.------.<<<<<<++.>>------.<<<-----.",
+			"Perl 6"},
+		test{"+++++++++++++++++++++[>++>+++>++++>+++++>++++++<<<<<-]+++++++++++++++++++++>>>----.--------.++++++++.<<<-----------.",
+			"PHP"},
+		test{"+++++++++++++++++++++[>++>+++>++++>+++++>++++++<<<<<-]+++++++++++++++++++++>>>----.>>-----.-----.<-.>-----.-.<<<<<-----------.",
+			"Python"},
+		test{"+++++++++++++++++++++[>++>+++>++++>+++++>++++++<<<<<-]+++++++++++++++++++++>>>--.>>---------.<-------.>++++.<<<<<-----------.",
+			"Ruby"},
+		test{"++++++++++++++++++[>++>+++>++++>+++++>++++++>+++++++<<<<<<-]++++++++++++++++++>>>-----.>>+++.<++++++++++.+.<<<----.>>++++.>>.---.<+.<<<<--------.",
+			"Code Golf"},
+		test{">>>>>>>>>>>>>>>>>>>>>>>>>>>>++++++++++++++++++++++++++[-<<[+<]+[>]>][<<[[-]-----<]>[>]>]<<[++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++<]>[.>]++++++++++.",
+			"abcdefghijklmnopqrstuvwxyz"},
+		test{"+++++[>+++++[>++>++>+++>+++>++++>++++<<<<<<-]<-]+++++[>>[>]<[+.<<]>[++.>>>]<[+.<]>[-.>>]<[-.<<<]>[.>]<[+.<]<-]++++++++++.",
+			"eL34NfeOL454KdeJ44JOdefePK55gQ67ShfTL787KegJ77JTeghfUK88iV9:XjgYL:;:KfiJ::JYfijgZK;;k[<=]lh^L=>=KgkJ==J^gklh_K>>m`?@bnicL@A@KhmJ@@JchmnidKAA"},
+		test{"++++++++++[>++++++++++>++++++++++++<<-]>--->++>+++++++++++++[<.-<.+>>-]++++[<<-------------------------.>>-]",
+			"zaybxcwdveuftgshriqjpkolnmU<#"},
+	}
+}
+
+func randInt(min, max int) int {
+	return rand.IntN(max-min+1) + min
+}
+
+func intToBFString(n int) string {
+	if n < 1 {
+		return strings.Repeat("-", -n)
+	}
+	return strings.Repeat("+", n)
+}
+
+func randomBFCase(jumpSize, buckets, initialBucketSize, bucketSizeChange, charShift int) test {
+	const ASCII_MIN = 32
+	const ASCII_MAX = 126
+
+	bucketString := ""
+	out := ""
+
+	// Ensure all bucket sizes are strictly positive
+	if bucketSizeChange*buckets+initialBucketSize < 1 {
+		bucketSizeChange = 1
 	}
 
-	rand.Shuffle(len(args), func(i, j int) {
-		args[i], args[j] = args[j], args[i]
-		outs[i], outs[j] = outs[j], outs[i]
-	})
+	// Populate buckets
+	bucketSize := initialBucketSize
+	for i := 0; i < buckets; i++ {
+		// Choose a base for this bucket that ensures all chars remain in the printable ASCII range
+		totalShift := charShift * (bucketSize - 1)
+		minChar := ASCII_MIN
+		maxChar := ASCII_MAX
+		if totalShift > 0 {
+			maxChar -= totalShift
+		} else {
+			minChar -= totalShift
+		}
+		base := randInt(minChar/jumpSize+1, maxChar/jumpSize)
+		bucketString += ">" + intToBFString(base)
 
-	return []Run{{Args: args, Answer: strings.Join(outs, "\n")}}
+		// Add all the chars in the bucket to the solution
+		char := base * jumpSize
+		for j := 0; j < bucketSize; j++ {
+			out += fmt.Sprintf("%c", char)
+			char += charShift
+		}
+
+		bucketSize += bucketSizeChange
+	}
+
+	in := fmt.Sprintf(">%s[%s[<]>-]<%s>>[<<[>+>.%s<<-]>%s>[-]>[<]<<[>++++++++++.>]>>>]",
+		intToBFString(jumpSize),
+		bucketString,
+		intToBFString(initialBucketSize),
+		intToBFString(charShift),
+		intToBFString(bucketSizeChange))
+
+	return test{in, out}
 }


### PR DESCRIPTION
Based on discussion in the Discord, adds 5 semi-randomized test-cases to discourage hardcoding. Keeping in line with the fixed testcases, all randomized tests are printable ASCII and end with a newline.