### PR TITLE
Fix hole navigation from the index to target the currently preferred language by default

### DIFF
--- a/views/html/home.html
+++ b/views/html/home.html
@@ -36,10 +36,14 @@
 {{ end }}
 {{ range .Data.Cards }}
     <a class="card {{ .Hole.CategoryColor }}"
-    {{ if and $.Golfer (eq (index $.Golfer.Settings "home" "navigate-to") "rankings") }}
+    {{ if $.Golfer }}
         {{ $lang    := index $.Golfer.Settings "home" "points-for" }}
         {{ $scoring := index $.Golfer.Settings "home" "scoring"    }}
-        href="rankings/holes/{{ .Hole.ID }}/{{ $lang }}/{{ $scoring }}"
+        {{ if eq (index $.Golfer.Settings "home" "navigate-to") "rankings" }}
+            href="rankings/holes/{{ .Hole.ID }}/{{ $lang }}/{{ $scoring }}"
+        {{ else }}
+            href="{{ .Hole.ID }}#{{ $lang }}"
+        {{ end }}
     {{ else }}
         href="{{ .Hole.ID }}"
     {{ end }}


### PR DESCRIPTION
In addition to the title description, I think it would be a good idea to make the index navigation target the scoring preference by default as well. It would make perfect sense to respect user preference and always target the preferred scoring tab as a matter of fact. Remembering last used scoring might be a good candidate for an additional setting when navigation is done by any of the previous, random, next or variant buttons, and by swapping languages on a hole.

Should I open an issue regarding the aforementioned idea and reference this PR?