### PR TITLE
Update command to allow successful provisioning of virtual machines with Vagrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ $ brew install vagrant virtualbox
 
 2. Create the virtual machine:
 ```
-$ vagrant up
+$ git config core.autocrlf false && git checkout utils/vagrant-bootstrap && vagrant up
 ```
 
 3. Install certificates. Ideally, you should run the following command outside of the virtual machine, the same as in the quickstart, because it will install the certificate in your browser. Alternatively, you can run the command in a virtual machine shell and then install the certificates manually.


### PR DESCRIPTION
It is not possible to successfully provision virtual machines by only running the command `vagrant up` on Windows host systems. Presumably, it affects macOS host systems likewise. Currently, post installation of Docker, the provisioning script terminates with an error because it cannot handle line endings correctly, so it seems.

```
==> default: Running provisioner: shell...
    default: Running: inline script
    default: /vagrant/utils/vagrant-bootstrap: line 2: $'\r': command not found
    default: /vagrant/utils/vagrant-bootstrap: line 3: $'sh\r': command not found
    default:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
    default:                                  Dload  Upload   Total   Spent    Left  Speed
100  1383  100  1383    0     0   4593      0 --:--:-- --:--:-- --:--:--  4610
    default: curl: Failed writing body
    default: /vagrant/utils/vagrant-bootstrap: line 5: /home/vagrant/.rakubrew/bin/rakubrew: No such file or directory
    default: /vagrant/utils/vagrant-bootstrap: line 5: $'\r': command not found
    default: /vagrant/utils/vagrant-bootstrap: line 6: rakubrew: command not found
    default: /vagrant/utils/vagrant-bootstrap: line 7: rakubrew: command not found
    default: /vagrant/utils/vagrant-bootstrap: line 8: cd: $'/vagrant/\r': No such file or directory
    default: /vagrant/utils/vagrant-bootstrap: line 9: zef: command not found
"   default: Unknown command: "install
    default:
    default:
    default: Did you mean one of these?
    default:   npm install # Install a package
    default:   npm uninstall # Remove a package
    default: To see a list of supported npm commands, run:
    default:   npm help
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.

Yewzir@Yewzir MINGW64 ~/code-golf (master)
```
However, running the next command guarantees successful continuation of the script.
`$ git config core.autocrlf false && git checkout utils/vagrant-bootstrap && vagrant up`

Eventually, the script terminates without errors and allows proceeding to the next step.
```
==> default: Running provisioner: shell...
    default: Running: inline script
    default:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
    default:                                  Dload  Upload   Total   Spent    Left  Speed
100  1383  100  1383    0     0   4901      0 --:--:-- --:--:-- --:--:--  4904
    default: Downloading rakubrew...
    default: Installing rakubrew to /home/vagrant/.rakubrew ...
    default:
    default: Load rakubrew automatically in `bash` by adding
    default:
    default:   eval "$(/home/vagrant/.rakubrew/bin/rakubrew init Bash)"
    default:
    default: to ~/.bashrc. This can be easily done using:
    default:
    default:   echo 'eval "$(/home/vagrant/.rakubrew/bin/rakubrew init Bash)"' >> ~/.bashrc
    default:
    default: Update git reference: rakudo
    default: Cloning into bare repository 'rakudo'...
.
.
.
    default: added 193 packages, and audited 194 packages in 1m
    default:
    default: 34 packages are looking for funding
    default:   run `npm fund` for details
    default:
    default: found 0 vulnerabilities

Yewzir@Yewzir MINGW64 ~/code-golf (master)
```