### PR TITLE
Addition of countries in statistics overview

### DIFF
--- a/views/html/stats.html
+++ b/views/html/stats.html
@@ -7,9 +7,10 @@
 
 {{ if eq .Title "Statistics" }}
     <div id=overview>
+        <div><h2>Countries</h2>{{ 0 }}</div>
+        <div><h2>Golfers</h2>{{ comma .Data.Golfers }}</div>
         <div><h2>Holes</h2>{{ len .Holes }}</div>
         <div><h2>Languages</h2>{{ len .Langs }}</div>
-        <div><h2>Golfers</h2>{{ comma .Data.Golfers }}</div>
 
         <div>
             <h2>Solutions</h2>


### PR DESCRIPTION
Right, so here's what I'm trying to do.

![image](https://github.com/code-golf/code-golf/assets/116750824/1f119111-b5c1-434c-8a72-5a94071d180e)

As you can see, it's nothing more than a tiny addition of the number of countries that are known to date.
Simple as I thought it was, it's not apparently. Either that or I woke up being a complete idiot once again.

I tried different things such as `{{ len .Countries }}`, `{{ len .Data.Countries }}`, `{{ len .Data.Countries.Ranks }}`, `{{ len .Country.Ranks }}` and many many more, moving things back and forth but none of my attempts are rendering the first image, unfortunately.

The website only renders content preceding the div I'm trying to add.

![image](https://github.com/code-golf/code-golf/assets/116750824/ce244598-4d0a-4b5b-8b80-622fb9cdb0a1)

![image](https://github.com/code-golf/code-golf/assets/116750824/ce209226-2dee-424e-ac8f-cc7952616110)

Hardcode works but that ain't an option. There are no countries in my local development besides "Rather not say" but then I figured it'd just say there's one country. Live works with shared ranks so obtaining the last one is enough unless I'm not hitting the correct field(s).