### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ dev:
 e2e-iterate: export COMPOSE_FILE=docker/core.yml:docker/e2e.yml
 e2e-iterate: export COMPOSE_PROJECT_NAME=code-golf-e2e
 e2e-iterate:
-	@docker compose run e2e
+	@docker compose run --rm e2e
 
 e2e: export COMPOSE_FILE=docker/core.yml:docker/e2e.yml
 e2e: export COMPOSE_PROJECT_NAME=code-golf-e2e
@@ -60,7 +60,7 @@ e2e:
 	@touch docker/.env
 	@docker compose rm -fsv &>/dev/null
 	@docker compose build --pull -q
-	@docker compose run e2e || (docker compose logs; false)
+	@docker compose run --rm e2e || (docker compose logs; false)
 	@docker compose rm -fsv &>/dev/null
 
 fmt:


### PR DESCRIPTION
Exported Docker images from which containers are created for servicing `e2e` and/or `e2e-iterate` tests are _leaking_ their containers. I noticed that one container persists in lurking around post conclusion of any of these tests.

```bash
All tests successful.
Files=19, Tests=500,  779 wallclock secs
Result: PASS
.
.
.
CONTAINER ID   IMAGE                  COMMAND                  CREATED             STATUS                      PORTS                                      NAMES
8b77275b3a45   code-golf-e2e-e2e      "prove6 -It"             13 minutes ago      Exited (0) 13 seconds ago                                              code-golf-e2e-e2e-run-166d18d9098f # << Hello
55a0d0cf7666   docker-app             "/bin/sh -c 'reflex …"   About an hour ago   Up 15 minutes               0.0.0.0:80->80/tcp, 0.0.0.0:443->443/tcp   app
520ec98db172   postgres:16.3-alpine   "docker-entrypoint.s…"   About an hour ago   Up 15 minutes               0.0.0.0:5432->5432/tcp                     db
2dd433cc5c33   node:22-alpine         "docker-entrypoint.s…"   About an hour ago   Up 15 minutes                                                          ass
```

As such, subsequent tests continue to not clean up after themselves, and stack up dead containers.

```bash
All tests successful.
Files=19, Tests=500,  729 wallclock secs
Result: PASS
.
.
.
CONTAINER ID   IMAGE                  COMMAND                  CREATED          STATUS                      PORTS                                      NAMES
d5f311ce17ad   code-golf-e2e-e2e      "prove6 -It"             12 minutes ago   Exited (0) 12 seconds ago                                              code-golf-e2e-e2e-run-51239498a2c5 # << Hello
8b77275b3a45   code-golf-e2e-e2e      "prove6 -It"             27 minutes ago   Exited (0) 14 minutes ago                                              code-golf-e2e-e2e-run-166d18d9098f # << Hello
55a0d0cf7666   docker-app             "/bin/sh -c 'reflex …"   2 hours ago      Up 14 minutes               0.0.0.0:80->80/tcp, 0.0.0.0:443->443/tcp   app
520ec98db172   postgres:16.3-alpine   "docker-entrypoint.s…"   2 hours ago      Up 14 minutes               0.0.0.0:5432->5432/tcp                     db
2dd433cc5c33   node:22-alpine         "docker-entrypoint.s…"   2 hours ago      Up 14 minutes                                                          ass
```

This PR guarantees proper removal of the temporary containers. I have tested `e2e-iterate` and it successfully cleaned up after itself. The remaining containers with `code-golf-e2e` in their names are scheduled for removal post `e2e`.

```bash
oh@Yewzir:~/code-golf$ docker ps -a
CONTAINER ID   IMAGE                  COMMAND                  CREATED       STATUS          PORTS                                      NAMES
55a0d0cf7666   docker-app             "/bin/sh -c 'reflex …"   3 hours ago   Up 24 minutes   0.0.0.0:80->80/tcp, 0.0.0.0:443->443/tcp   app
520ec98db172   postgres:16.3-alpine   "docker-entrypoint.s…"   3 hours ago   Up 24 minutes   0.0.0.0:5432->5432/tcp                     db
2dd433cc5c33   node:22-alpine         "docker-entrypoint.s…"   3 hours ago   Up 24 minutes                                              ass
oh@Yewzir:~/code-golf$ make e2e-iterate
[+] Building 3.8s (245/245) FINISHED
.
.
.
All tests successful.
Files=19, Tests=500,  671 wallclock secs
Result: PASS
oh@Yewzir:~/code-golf$ docker ps -a
CONTAINER ID   IMAGE                   COMMAND                  CREATED          STATUS                    PORTS                                      NAMES
bd73c2e7f6bb   code-golf-e2e-app       "go run ."               11 minutes ago   Up 11 minutes (healthy)                                              code-golf-e2e-app-1
4d85ca29bff4   code-golf-e2e-firefox   "geckodriver --allow…"   11 minutes ago   Up 11 minutes                                                        code-golf-e2e-firefox-1
3210d686649d   postgres:16.3-alpine    "docker-entrypoint.s…"   11 minutes ago   Up 11 minutes             5432/tcp                                   code-golf-e2e-db-1
55a0d0cf7666   docker-app              "/bin/sh -c 'reflex …"   3 hours ago      Up 36 minutes             0.0.0.0:80->80/tcp, 0.0.0.0:443->443/tcp   app
520ec98db172   postgres:16.3-alpine    "docker-entrypoint.s…"   3 hours ago      Up 36 minutes             0.0.0.0:5432->5432/tcp                     db
2dd433cc5c33   node:22-alpine          "docker-entrypoint.s…"   3 hours ago      Up 36 minutes                                                        ass
```

The next results were acquired while the final `e2e` test was in progress.

```bash
oh@Yewzir:~/code-golf$ docker ps -a
CONTAINER ID   IMAGE                   COMMAND                  CREATED         STATUS                   PORTS                                      NAMES
3c297eaecbcf   code-golf-e2e-e2e       "prove6 -It"             9 minutes ago   Up 9 minutes                                                        code-golf-e2e-e2e-run-68b59b538955
0cac57bed206   code-golf-e2e-app       "go run ."               9 minutes ago   Up 9 minutes (healthy)                                              code-golf-e2e-app-1
b16d0832ecf7   postgres:16.3-alpine    "docker-entrypoint.s…"   9 minutes ago   Up 9 minutes             5432/tcp                                   code-golf-e2e-db-1
cc76dfab92da   code-golf-e2e-firefox   "geckodriver --allow…"   9 minutes ago   Up 9 minutes                                                        code-golf-e2e-firefox-1
55a0d0cf7666   docker-app              "/bin/sh -c 'reflex …"   3 hours ago     Up 14 minutes            0.0.0.0:80->80/tcp, 0.0.0.0:443->443/tcp   app
520ec98db172   postgres:16.3-alpine    "docker-entrypoint.s…"   3 hours ago     Up 14 minutes            0.0.0.0:5432->5432/tcp                     db
2dd433cc5c33   node:22-alpine          "docker-entrypoint.s…"   3 hours ago     Up 14 minutes                                                       ass
```

Here's the final `lint`, `test`, and `e2e` run, followed by the result of `docker ps -a`.

```bash
oh@Yewzir:~/code-golf$ make lint
Unable to find image 'golangci/golangci-lint:v1.59.1' locally
v1.59.1: Pulling from golangci/golangci-lint
c6cf28de8a06: Pull complete
891494355808: Pull complete
6582c62583ef: Pull complete
2c67c6db9d9f: Pull complete
308711a9f351: Pull complete
ae711a3e82cb: Pull complete
4f4fb700ef54: Pull complete
2c168a60006c: Pull complete
3ed10dc178db: Pull complete
Digest: sha256:b5f8712114561f1e2fbe74d04ed07ddfd992768705033a6251f3c7b848eac38e
Status: Downloaded newer image for golangci/golangci-lint:v1.59.1
oh@Yewzir:~/code-golf$ make test
?       github.com/code-golf/code-golf  [no test files]
?       github.com/code-golf/code-golf/discord  [no test files]
ok      github.com/code-golf/code-golf/config   (cached)
ok      github.com/code-golf/code-golf/db       (cached)
?       github.com/code-golf/code-golf/github   [no test files]
ok      github.com/code-golf/code-golf/golfer   (cached)
?       github.com/code-golf/code-golf/middleware       [no test files]
?       github.com/code-golf/code-golf/oauth    [no test files]
ok      github.com/code-golf/code-golf/hole     (cached) [no tests to run]
?       github.com/code-golf/code-golf/ordered  [no test files]
?       github.com/code-golf/code-golf/pager    [no test files]
ok      github.com/code-golf/code-golf/null     (cached)
ok      github.com/code-golf/code-golf/pretty   (cached)
?       github.com/code-golf/code-golf/session  [no test files]
?       github.com/code-golf/code-golf/utils    [no test files]
ok      github.com/code-golf/code-golf/routes   (cached)
?       github.com/code-golf/code-golf/views    [no test files]
ok      github.com/code-golf/code-golf/zone     (cached) [no tests to run]
oh@Yewzir:~/code-golf$ make e2e

up to date, audited 194 packages in 938ms

34 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

  dist/js/hole-tabs-YBS7G5IW.js                                   2.6mb ⚠️
  dist/js/wiki-ODE6RV5M.js                                        2.5mb ⚠️
  dist/js/hole-J4BAHOC2.js                                        1.4mb ⚠️
  dist/js/stats-47RDICWT.js                                     217.6kb
  dist/fonts/twemoji-IQY3QWVL.woff2                             100.1kb
  dist/fonts/source-code-pro-ILST5JV6.woff2                      51.0kb
  dist/css/hole-tabs-HYIT6PE5.css                                23.7kb
  dist/fonts/noto-sans-symbols-2-mahjong-subset-W7JGGGSA.woff2   15.7kb
  dist/css/hole-2JXCDAAJ.css                                     12.8kb
  dist/js/base-TGQG3HAR.js                                       12.6kb
  dist/css/common/base-7TADJKB6.css                              10.6kb
  dist/css/admin/solutions-CMMFBNSM.css                           7.8kb
  dist/fonts/chess-dark-DOPBCEOL.woff2                            7.3kb
  dist/fonts/chess-XZGIFHSH.woff2                                 7.2kb
  dist/css/golfer/profile-2ZCK563M.css                            3.0kb
  dist/css/golfer/cheevos-QR7YBTBO.css                            2.2kb
  dist/css/golfer/holes-NWV5NSL6.css                              2.2kb
  dist/css/golfer/settings-XCMMI57E.css                           1.7kb
  dist/js/admin/solutions-MZGPBNBP.js                             1.7kb
  dist/css/common/dark-657HTWNP.css                               1.6kb
  dist/css/common/light-KV3FPEKF.css                              1.2kb
  dist/css/golfer/solution-P6FTF5E3.css                           1.1kb
  dist/css/golfer/follow-limit-YVRSPQTJ.css                       1.1kb
  dist/css/about-N4IUAHW2.css                                     962b
  dist/css/stats-N5DDGOPP.css                                     672b
  dist/css/rankings/recent-holes-MUBHZ3NA.css                     627b
  dist/css/rankings/holes-WJHZ7X5O.css                            620b
  dist/css/rankings/langs-676ZGSLY.css                            559b
  dist/css/rankings/cheevos-P4OAVRYI.css                          544b
  dist/css/rankings/misc-DF3GZ4MK.css                             541b
  dist/css/rankings/medals-E3FCK524.css                           483b
  dist/css/wiki-VGGL6WAC.css                                      390b
  dist/css/ideas-FXVM7JAJ.css                                     368b
  dist/css/recent/golfers-JS2I2KCB.css                            339b
  dist/css/recent/solutions-EODLPVP2.css                          260b
  dist/css/admin/info-UIEREAM5.css                                242b
  dist/css/feeds-SOQGOCYU.css                                      78b
  dist/js/hole-tabs-YBS7G5IW.js.map                               6.9mb
  dist/js/wiki-ODE6RV5M.js.map                                    6.1mb
  dist/js/hole-J4BAHOC2.js.map                                    3.8mb
  dist/js/stats-47RDICWT.js.map                                   1.2mb
  ...and 28 more output files...

⚡ Done in 733ms
[+] Creating 3/3
 ✔ Container code-golf-e2e-firefox-1  Created                     0.2s
 ✔ Container code-golf-e2e-db-1       Created                     0.2s
 ✔ Container code-golf-e2e-app-1      Created                     0.1s
[+] Running 3/3
 ✔ Container code-golf-e2e-db-1       Started                     0.7s
 ✔ Container code-golf-e2e-firefox-1  Started                     0.6s
 ✔ Container code-golf-e2e-app-1      Started                     0.5s
t/answers.t ..................... ok
t/api.t ......................... ok
t/asm-reg-dump.t ................ ok
t/cheevos.t ..................... ok
t/delete-golfer.t ............... ok
t/examples.t .................... ok
t/golfer-actions.t .............. ok
t/golfer-export.t ............... ok
t/golfer-settings.t ............. ok
t/hole-general.t ................ ok
t/hole-logged-in.t .............. ok
t/inspect.t ..................... ok
t/lang-features.t ............... ok
t/limits.t ...................... ok
t/pangramglot.t ................. ok
t/redirects.t ................... ok
t/solution.t .................... ok
t/timeout.t ..................... ok
t/truncate.t .................... ok
All tests successful.
Files=19, Tests=500,  706 wallclock secs
Result: PASS
oh@Yewzir:~/code-golf$ docker ps -a
CONTAINER ID   IMAGE                  COMMAND                  CREATED       STATUS          PORTS                                      NAMES
55a0d0cf7666   docker-app             "/bin/sh -c 'reflex …"   3 hours ago   Up 17 minutes   0.0.0.0:80->80/tcp, 0.0.0.0:443->443/tcp   app
520ec98db172   postgres:16.3-alpine   "docker-entrypoint.s…"   3 hours ago   Up 17 minutes   0.0.0.0:5432->5432/tcp                     db
2dd433cc5c33   node:22-alpine         "docker-entrypoint.s…"   3 hours ago   Up 17 minutes                                              ass
```