### PR TITLE
Fix Dockerfiles' FromAsCasing warnings

### DIFF
--- a/langs/rockstar/Dockerfile
+++ b/langs/rockstar/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:22.0.1_8-jre-alpine as builder
+FROM eclipse-temurin:22.0.1_8-jre-alpine AS builder
 
 RUN apk add --no-cache build-base wget
 

--- a/langs/uiua/Dockerfile
+++ b/langs/uiua/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.78-bookworm as builder
+FROM rust:1.78-bookworm AS builder
 
 RUN cargo install uiua --version 0.11.1
 


### PR DESCRIPTION
Dockerfiles for Rockstar and Uiua return the following warning upon their builds.

```bash
1 warning found (use --debug to expand):
- FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
```

This PR eliminates those warnings.

@JRaspass and @KatieLG are the original authors of the Dockerfiles for [Rockstar](https://github.com/code-golf/code-golf/commit/490c5c0769616d3a45579673217e62ea141be091) and [Uiua](https://github.com/code-golf/code-golf/commit/71747af6263b5257021e05e7d76c8e60320490fd), respectively.