### PR TITLE
Fix Dockerfiles' LegacyKeyValueFormat warnings

### DIFF
--- a/langs/clojure/Dockerfile
+++ b/langs/clojure/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.20 AS builder
 
 RUN apk add --no-cache curl
 
-ENV VER 1.3.190
+ENV VER=1.3.190
 
 RUN curl -L https://github.com/babashka/babashka/releases/download/v$VER/babashka-$VER-linux-amd64-static.tar.gz | tar xz
 

--- a/langs/cpp/Dockerfile
+++ b/langs/cpp/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.20 AS builder
 
 RUN apk add --no-cache build-base cmake curl linux-headers python3
 
-ENV VER 18.1.6
+ENV VER=18.1.6
 
 RUN curl -L https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz | tar xJ
 

--- a/langs/haskell/Dockerfile
+++ b/langs/haskell/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.20 AS builder
 
-ENV VER 9.8.2
+ENV VER=9.8.2
 
 RUN apk add --no-cache build-base ghc=$VER-r1
 

--- a/langs/javascript/Dockerfile
+++ b/langs/javascript/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bullseye-slim AS builder
 RUN apt-get update \
  && apt-get install -y curl g++ git pkg-config procps python python3
 
-ENV PATH "/depot_tools:$PATH"
+ENV PATH="/depot_tools:$PATH"
 
 RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git \
  && fetch v8

--- a/langs/lisp/Dockerfile
+++ b/langs/lisp/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.20 AS builder
 
-ENV FORCE_UNSAFE_CONFIGURE 1
+ENV FORCE_UNSAFE_CONFIGURE=1
 
 RUN apk add --no-cache build-base curl
 

--- a/langs/python/Dockerfile
+++ b/langs/python/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.20 AS builder
 
 RUN apk add --no-cache build-base curl libffi-dev zlib-dev
 
-ENV VER 3.12.4
+ENV VER=3.12.4
 
 RUN curl https://www.python.org/ftp/python/$VER/Python-$VER.tar.xz | tar xJ
 

--- a/langs/swift/Dockerfile
+++ b/langs/swift/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bullseye-slim AS builder
 RUN apt-get update \
  && apt-get install -y binutils curl libatomic1 libc6-dev libedit2 libz3-4
 
-ENV VER 5.10.1
+ENV VER=5.10.1
 
 RUN curl https://download.swift.org/swift-$VER-release/ubuntu2004/swift-$VER-RELEASE/swift-$VER-RELEASE-ubuntu20.04.tar.gz \
   | tar xz --directory / --strip-components 1

--- a/langs/tcl/Dockerfile
+++ b/langs/tcl/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache build-base curl
 
 RUN curl -L https://github.com/tcltk/tcl/archive/refs/tags/core-8-6-14.tar.gz | tar xz
 
-ENV LDFLAGS -static
+ENV LDFLAGS=-static
 
 RUN mv /tcl-* /tcl   \
  && cd tcl/unix      \

--- a/langs/zig/Dockerfile
+++ b/langs/zig/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.20 AS builder
 
 RUN apk add --no-cache binutils curl
 
-ENV VER 0.13.0
+ENV VER=0.13.0
 
 RUN curl https://ziglang.org/download/$VER/zig-linux-x86_64-$VER.tar.xz \
   | tar xJC tmp --strip 1 \


### PR DESCRIPTION
Dockerfiles for Clojure, C++, Haskell, JavaScript, Lisp, Python, Swift, Tcl, and Zig return the following warning upon their builds.

```bash
1 warning found (use --debug to expand):
- LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line X)
```

This PR eliminates those warnings.

Regards
Yewzir