### PR TITLE
Notes UI

### DIFF
--- a/css/hole-tabs.css
+++ b/css/hole-tabs.css
@@ -31,8 +31,8 @@ section header {
     padding: 0 .5rem;
 }
 
-#editor-section header {
-    margin-top: 1px;
+#editor-section header, #holeLangNotesEditor-section header {
+    margin-top: 2px;
     margin-bottom: 2px;
 }
 
@@ -47,7 +47,7 @@ section header {
     gap: .375rem;
 }
 
-#editor-section {
+#editor-section, #holeLangNotesEditor-section {
     height: 100%;
     overflow: hidden;
 }
@@ -59,10 +59,10 @@ section header {
     font-size: 1rem;
 }
 
-#editor {
+#editor, #holeLangNotesEditor {
     border: none;
     /* Button = 1rem (contents) + 2*0.5 rem (padding) + 2px (border) + 4px (margin) */
-    height: calc(100% - (2rem + 6px));
+    height: calc(100% - (2rem + 7px));
 }
 
 main > header nav { max-width: 100% }
@@ -223,4 +223,9 @@ main {
 
 article>*:not(:first-child), article details>* {
     margin-top: 1rem;
+}
+
+#convert-notes-btn {
+    display: inline-block;
+    margin-left: .5rem;
 }

--- a/js/_hole-common.tsx
+++ b/js/_hole-common.tsx
@@ -6,7 +6,7 @@ import LZString                                from 'lz-string';
 
 let tabLayout: boolean = false;
 
-const langWikiCache: Record<string, string> = {};
+const langWikiCache: Record<string, string | null> = {};
 async function getLangWikiContent(lang: string): Promise<string> {
     if (!(lang in langWikiCache)) {
         const resp  = await fetch(`/api/wiki/langs/${lang}`, { method: 'GET' });
@@ -15,11 +15,11 @@ async function getLangWikiContent(lang: string): Promise<string> {
     return langWikiCache[lang] ?? 'No data for current lang.';
 }
 
-const holeLangNotesCache: Record<string, string> = {};
+const holeLangNotesCache: Record<string, string | null> = {};
 async function getHoleLangNotesContent(lang: string): Promise<string> {
     if (!(lang in holeLangNotesCache)) {
         const resp  = await fetch(`/api/notes/${hole}/${lang}`, { method: 'GET' });
-        holeLangNotesCache[lang] = resp.status === 200 ? (await resp.json()).content : null;
+        holeLangNotesCache[lang] = resp.status === 200 ? (await resp.text()) : null;
     }
     return holeLangNotesCache[lang] ?? '';
 }

--- a/js/_hole-common.tsx
+++ b/js/_hole-common.tsx
@@ -8,11 +8,20 @@ let tabLayout: boolean = false;
 
 const langWikiCache: Record<string, string> = {};
 async function getLangWikiContent(lang: string): Promise<string> {
-    if (!(lang in langWikiCache)){
+    if (!(lang in langWikiCache)) {
         const resp  = await fetch(`/api/wiki/langs/${lang}`, { method: 'GET' });
         langWikiCache[lang] = resp.status === 200 ? (await resp.json()).content : null;
     }
     return langWikiCache[lang] ?? 'No data for current lang.';
+}
+
+const holeLangNotesCache: Record<string, string> = {};
+async function getHoleLangNotesContent(lang: string): Promise<string> {
+    if (!(lang in holeLangNotesCache)) {
+        const resp  = await fetch(`/api/notes/${hole}/${lang}`, { method: 'GET' });
+        holeLangNotesCache[lang] = resp.status === 200 ? (await resp.json()).content : null;
+    }
+    return holeLangNotesCache[lang] ?? '';
 }
 
 const renamedHoles: Record<string, string> = {
@@ -51,8 +60,10 @@ export function init(_tabLayout: boolean, setSolution: any, setCodeForLangAndSol
         }
         setCodeForLangAndSolution(editor);
 
-        if (tabLayout)
+        if (tabLayout) {
             updateReadonlyPanels({langWiki: await getLangWikiContent(lang)});
+            updateReadonlyPanels({holeLangNotes: await getHoleLangNotesContent(lang)});
+        }
     })();
 
     $('dialog [name=text]').addEventListener('input', (e: Event) => {

--- a/js/hole-tabs.tsx
+++ b/js/hole-tabs.tsx
@@ -253,7 +253,7 @@ async function upsertNotes() {
 };
 
 function parseSubstitutions() {
-    const value = $<HTMLInputElement>('#notes-substitutions').value;
+    const { value } = $<HTMLInputElement>('#notes-substitutions');
     localStorage.setItem(`${getLang()}-substitutions`, value);
     const pattern = /s\/((?:[^\/]|\\\/)*)\/((?:[^\/]|\\\/)*)\/([dgimsuvy]*)/g;
     substitutions = [...value.matchAll(pattern)]

--- a/js/hole-tabs.tsx
+++ b/js/hole-tabs.tsx
@@ -190,7 +190,7 @@ function makeHoleLangNotesEditor(parent: HTMLDivElement) {
             if (!holeLangNotesEditor) return;
             const result = holeLangNotesEditor.update([tr]) as unknown;
             const content = tr.state.doc.toString();
-            $<HTMLButtonElement>("#upsert-notes-btn").disabled = content === holeLangNotesContent;
+            $<HTMLButtonElement>("#upsert-notes-btn").disabled = content === holeLangNotesContent || (!!content && !isSponsor());
             return result;
         },
         parent,
@@ -407,10 +407,10 @@ const defaultLayout: LayoutConfig = {
     },
 };
 
-function isSponsor(){
-    return true || $('golferInfo')?.dataset.isSponsor;
+function isSponsor() {
+    return $('golferInfo')?.dataset.isSponsor;
 }
-function hasNotes(){
+function hasNotes() {
     return $('golferInfo')?.dataset.hasNotes;
 }
 

--- a/js/hole-tabs.tsx
+++ b/js/hole-tabs.tsx
@@ -48,7 +48,7 @@ const readonlyOutputs: {[key: string]: HTMLElement | undefined} = {};
 let editor: EditorView | null = null;
 let holeLangNotesEditor: EditorView | null = null;
 
-let substitutions: {pattern: RegExp, replacement: string}[] = []
+let substitutions: {pattern: RegExp, replacement: string}[] = [];
 
 init(true, setSolution, setCodeForLangAndSolution, updateReadonlyPanels, () => editor);
 
@@ -110,7 +110,7 @@ function updateWikiContent() {
 }
 
 function updateHoleLangNotesContent() {
-    $<HTMLInputElement>("#notes-substitutions").value = localStorage.getItem(`${getLang()}-substitutions`) ?? "";
+    $<HTMLInputElement>('#notes-substitutions').value = localStorage.getItem(`${getLang()}-substitutions`) ?? '';
     if (holeLangNotesEditor) setState(holeLangNotesContent, holeLangNotesEditor);
 }
 
@@ -118,7 +118,8 @@ function updateReadonlyPanels(data: ReadonlyPanelsData | {langWiki: string}| {ho
     if ('langWiki' in data) {
         langWikiContent = data.langWiki;
         updateWikiContent();
-    } else if ('holeLangNotes' in data) {
+    }
+    else if ('holeLangNotes' in data) {
         holeLangNotesContent = data.holeLangNotes;
         updateHoleLangNotesContent();
     }
@@ -190,7 +191,7 @@ function makeHoleLangNotesEditor(parent: HTMLDivElement) {
             if (!holeLangNotesEditor) return;
             const result = holeLangNotesEditor.update([tr]) as unknown;
             const content = tr.state.doc.toString();
-            $<HTMLButtonElement>("#upsert-notes-btn").disabled = content === holeLangNotesContent || (!!content && !isSponsor());
+            $<HTMLButtonElement>('#upsert-notes-btn').disabled = content === holeLangNotesContent || (!!content && !isSponsor());
             return result;
         },
         parent,
@@ -241,31 +242,31 @@ layout.registerComponentFactoryFunction('code', async container => {
 });
 
 async function upsertNotes() {
-    $<HTMLButtonElement>("#upsert-notes-btn").disabled = true;
+    $<HTMLButtonElement>('#upsert-notes-btn').disabled = true;
     const content = holeLangNotesEditor!.state.doc.toString();
-    var resp = await fetch(
+    const resp = await fetch(
         `/api/notes/${hole}/${getLang()}`,
-        content ? { method: 'PUT', body: content} : { method: 'DELETE' }
+        content ? { method: 'PUT', body: content} : { method: 'DELETE' },
     );
-    if (resp.status !== 204) $<HTMLButtonElement>("#upsert-notes-btn").disabled = false;
+    if (resp.status !== 204) $<HTMLButtonElement>('#upsert-notes-btn').disabled = false;
     else holeLangNotesContent = content;
 };
 
 function parseSubstitutions() {
-    const value = $<HTMLInputElement>("#notes-substitutions").value;
+    const value = $<HTMLInputElement>('#notes-substitutions').value;
     localStorage.setItem(`${getLang()}-substitutions`, value);
-    const pattern = /s\/((?:[^\/]|\\\/)*)\/((?:[^\/]|\\\/)*)\/([dgimsuvy]*)/g
+    const pattern = /s\/((?:[^\/]|\\\/)*)\/((?:[^\/]|\\\/)*)\/([dgimsuvy]*)/g;
     substitutions = [...value.matchAll(pattern)]
         .map(match => (
-            {pattern: new RegExp(match[1], [...new Set(match[3])].join("")), replacement: JSON.parse(`"${match[2]}"`)}
+            {pattern: new RegExp(match[1], [...new Set(match[3])].join('')), replacement: JSON.parse(`"${match[2]}"`)}
         ));
-    $<HTMLButtonElement>("#convert-notes-btn").disabled = substitutions.length < 1;
+    $<HTMLButtonElement>('#convert-notes-btn').disabled = substitutions.length < 1;
 }
 
 function convertNotesAndRun(){
-    if(editor && holeLangNotesEditor){
+    if (editor && holeLangNotesEditor) {
         let notes = holeLangNotesEditor.state.doc.toString();
-        for(const {pattern, replacement} of substitutions){
+        for (const {pattern, replacement} of substitutions) {
             notes = notes[pattern.global ? 'replaceAll' : 'replace'](pattern, replacement);
         }
         setState(notes, editor);
@@ -292,10 +293,10 @@ layout.registerComponentFactoryFunction('holeLangNotes', async container => {
     await afterDOM();
     makeHoleLangNotesEditor(editorDiv);
 
-    $("#upsert-notes-btn").onclick = upsertNotes;
-    $("#convert-notes-btn").onclick = convertNotesAndRun;
-    $("#notes-substitutions").oninput = parseSubstitutions;
-    
+    $('#upsert-notes-btn').onclick = upsertNotes;
+    $('#convert-notes-btn').onclick = convertNotesAndRun;
+    $('#notes-substitutions').oninput = parseSubstitutions;
+
     updateHoleLangNotesContent();
     parseSubstitutions();
 });

--- a/routes/api.go
+++ b/routes/api.go
@@ -249,8 +249,8 @@ func apiNotesGET(w http.ResponseWriter, r *http.Request) {
 
 // DELETE /api/notes/{hole}/{lang}
 func apiNoteDELETE(w http.ResponseWriter, r *http.Request) {
-	hole := config.HoleByID[param(r,"hole")]
-	lang := config.LangByID[param(r,"lang")]
+	hole := config.HoleByID[param(r, "hole")]
+	lang := config.LangByID[param(r, "lang")]
 	if hole == nil || lang == nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return
@@ -269,8 +269,8 @@ func apiNoteDELETE(w http.ResponseWriter, r *http.Request) {
 
 // GET /api/notes/{hole}/{lang}
 func apiNoteGET(w http.ResponseWriter, r *http.Request) {
-	hole := config.HoleByID[param(r,"hole")]
-	lang := config.LangByID[param(r,"lang")]
+	hole := config.HoleByID[param(r, "hole")]
+	lang := config.LangByID[param(r, "lang")]
 	if hole == nil || lang == nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return
@@ -299,8 +299,8 @@ func apiNoteGET(w http.ResponseWriter, r *http.Request) {
 
 // PUT /api/notes/{hole}/{lang}
 func apiNotePUT(w http.ResponseWriter, r *http.Request) {
-	hole := config.HoleByID[param(r,"hole")]
-	lang := config.LangByID[param(r,"lang")]
+	hole := config.HoleByID[param(r, "hole")]
+	lang := config.LangByID[param(r, "lang")]
 	note, _ := io.ReadAll(r.Body)
 
 	if hole == nil || lang == nil || len(note) == 0 || len(note) >= 128*1024 {

--- a/routes/api.go
+++ b/routes/api.go
@@ -249,8 +249,8 @@ func apiNotesGET(w http.ResponseWriter, r *http.Request) {
 
 // DELETE /api/notes/{hole}/{lang}
 func apiNoteDELETE(w http.ResponseWriter, r *http.Request) {
-	hole := config.HoleByID[r.FormValue("hole")]
-	lang := config.LangByID[r.FormValue("lang")]
+	hole := config.HoleByID[param(r,"hole")]
+	lang := config.LangByID[param(r,"lang")]
 	if hole == nil || lang == nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return
@@ -269,8 +269,8 @@ func apiNoteDELETE(w http.ResponseWriter, r *http.Request) {
 
 // GET /api/notes/{hole}/{lang}
 func apiNoteGET(w http.ResponseWriter, r *http.Request) {
-	hole := config.HoleByID[r.FormValue("hole")]
-	lang := config.LangByID[r.FormValue("lang")]
+	hole := config.HoleByID[param(r,"hole")]
+	lang := config.LangByID[param(r,"lang")]
 	if hole == nil || lang == nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return
@@ -286,7 +286,10 @@ func apiNoteGET(w http.ResponseWriter, r *http.Request) {
 		session.Golfer(r).ID,
 		hole.ID,
 		lang.ID,
-	); err != nil {
+	); errors.Is(err, sql.ErrNoRows) {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	} else if err != nil {
 		panic(err)
 	}
 
@@ -296,8 +299,8 @@ func apiNoteGET(w http.ResponseWriter, r *http.Request) {
 
 // PUT /api/notes/{hole}/{lang}
 func apiNotePUT(w http.ResponseWriter, r *http.Request) {
-	hole := config.HoleByID[r.FormValue("hole")]
-	lang := config.LangByID[r.FormValue("lang")]
+	hole := config.HoleByID[param(r,"hole")]
+	lang := config.LangByID[param(r,"lang")]
 	note, _ := io.ReadAll(r.Body)
 
 	if hole == nil || lang == nil || len(note) == 0 || len(note) >= 128*1024 {

--- a/routes/hole.go
+++ b/routes/hole.go
@@ -17,8 +17,8 @@ func holeGET(w http.ResponseWriter, r *http.Request) {
 		Langs                    map[string]*config.Lang
 		RankingsView             string
 		Solutions                []map[string]string
-		IsSponsor				 bool
-		HasNotes				 bool
+		IsSponsor                bool
+		HasNotes                 bool
 	}{
 		Langs:        config.AllLangByID,
 		RankingsView: "me",

--- a/routes/hole.go
+++ b/routes/hole.go
@@ -17,6 +17,8 @@ func holeGET(w http.ResponseWriter, r *http.Request) {
 		Langs                    map[string]*config.Lang
 		RankingsView             string
 		Solutions                []map[string]string
+		IsSponsor				 bool
+		HasNotes				 bool
 	}{
 		Langs:        config.AllLangByID,
 		RankingsView: "me",
@@ -55,6 +57,20 @@ func holeGET(w http.ResponseWriter, r *http.Request) {
 	}
 
 	golfer := session.Golfer(r)
+
+	if golfer != nil {
+		data.IsSponsor = golfer.Sponsor
+		if !data.IsSponsor {
+			var notesCount int
+			if err := session.Database(r).QueryRow(
+				`SELECT COUNT(*) FROM notes WHERE user_id = $1`,
+				session.Golfer(r).ID,
+			).Scan(&notesCount); err != nil {
+				panic(err)
+			}
+			data.HasNotes = notesCount > 0
+		}
+	}
 
 	if golfer != nil && data.Hole.Experiment == 0 {
 		// Fetch all the code per lang.

--- a/views/html/hole-tabs.html
+++ b/views/html/hole-tabs.html
@@ -1,5 +1,7 @@
 {{ template "header" . }}
 
+<div id=golferInfo data-is-sponsor="{{ .Data.IsSponsor }}" data-has-notes="{{ .Data.HasNotes }}"></div>
+
 <!-- For experimental lang picker -->
 <svg>{{ svg "flask-light" }}</svg>
 


### PR DESCRIPTION
Closes #489 

- Adds Notes UI to the tab layout. The feature is only available to sponsors.
- Fixes notes API to return 404, rather than 500 on missing notes.
- Updates API to match the commented form `// PUT /api/notes/{hole}/{lang}`
- Fixes the row below editor being 1px too short and thus clipping the buttons.
![image](https://github.com/user-attachments/assets/eb6800be-d49d-49d8-a1ba-cc9ed9a2655b)

Notes can be automatically converted to code by providing a sequence of `s///` expressions defining substitutions.
These substitutions are stored in localstorage, separate for each lang (but shared across holes).
They are used like this
![image](https://github.com/user-attachments/assets/c239cc75-e905-47ad-b321-21e87e310980)
