### PR TITLE
Save vertical space on hole-tabs

### DIFF
--- a/css/common/base.css
+++ b/css/common/base.css
@@ -63,12 +63,17 @@ body {
     overflow-x: hidden;
 }
 
+#all-but-footer {
+    display: flex;
+    flex-direction: column;
+}
+
 body, footer nav, #site-header nav, #popups {
     margin: auto;
     max-width: 1280px;
 }
 
-body > svg, .hide { display: none }
+body > svg, #all-but-footer > svg, .hide { display: none }
 
 details .grid { padding-top: 1rem }
 

--- a/css/hole-tabs.css
+++ b/css/hole-tabs.css
@@ -188,6 +188,7 @@ main {
     justify-self: center;
     display: flex;
     flex-wrap: wrap;
+    justify-content: flex-end;
     gap: 0.375rem;
 }
 

--- a/css/hole-tabs.css
+++ b/css/hole-tabs.css
@@ -111,7 +111,9 @@ section header {
 }
 
 #status {
-    padding: 0.5rem;
+    padding: 0;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
     grid-column: 3;
 }
 
@@ -134,7 +136,6 @@ main {
     gap: 0;
 }
 
-#picker,
 #info-container .info,
 #picker-status-row > *:not(:empty),
 #golden-container {
@@ -171,7 +172,7 @@ main {
 
 #pool span::before { content: "+" }
 
-#pool span { background: var(--background) }
+#layout-btns span { background: var(--background) }
 
 .mobile #golden-container { height: 150vh }
 
@@ -185,10 +186,16 @@ main {
 #layout-btns {
     grid-row: 6;
     justify-self: center;
-    margin-top: 5px;
-    margin-bottom: calc(5px - 1rem);
     display: flex;
-    gap: 1rem;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+}
+
+#panel-btns {
+    display: flex;
+    gap: 0.375rem;
+    justify-content: space-between;
+    width: 100%;
 }
 
 @media only screen and (max-width: 1280px) {
@@ -211,4 +218,8 @@ article>*:not(:first-child), article details>* {
 #convert-notes-btn {
     display: inline-block;
     margin-left: .5rem;
+}
+
+#all-but-footer {
+    min-height: 100vh;
 }

--- a/js/hole-tabs.tsx
+++ b/js/hole-tabs.tsx
@@ -336,7 +336,7 @@ const titles: Record<string, string | undefined> = {
     arg: 'Arguments',
     diff: 'Diff',
     code: 'Code',
-    langWiki: 'Language Wiki',
+    langWiki: 'Wiki',
     holeLangNotes: 'Notes',
 };
 

--- a/views/html/hole-tabs.html
+++ b/views/html/hole-tabs.html
@@ -1,117 +1,121 @@
-{{ template "header" . }}
+<div id=all-but-footer>
+    {{ template "header" . }}
 
-<div id=golferInfo data-is-sponsor="{{ .Data.IsSponsor }}" data-has-notes="{{ .Data.HasNotes }}"></div>
+    <div id=golferInfo data-is-sponsor="{{ .Data.IsSponsor }}" data-has-notes="{{ .Data.HasNotes }}"></div>
 
-<!-- For experimental lang picker -->
-<svg>{{ svg "flask-light" }}</svg>
+    <!-- For experimental lang picker -->
+    <svg>{{ svg "flask-light" }}</svg>
 
-{{ range .Data.Langs }}<svg>{{ svg .ID }}</svg>{{ end }}
+    {{ range .Data.Langs }}<svg>{{ svg .ID }}</svg>{{ end }}
 
-{{ with .Data.Hole.Experiment }}
-    <div class=alert>
-        {{ svg "flask-light" }}
-        <p>
-            This hole is experimental, no solutions will be saved.
-        {{ if ne . -1 }}
-            Please leave feedback on the
-            <a href="//github.com/code-golf/code-golf/issues/{{ . }}">
-                GitHub issue</a>.
-        {{ end }}
-    </div>
-{{ else }}{{ if not .Golfer }}
-    <div class=alert>
-        {{ svg "exclamation-circle" }}
-        <p>
-            Please
-            <a class=log-in href="{{ .LogInURL }}">log in with GitHub</a>
-            in order to save solutions and appear on the leaderboards.
-    </div>
-{{ end }}{{ end }}
-
-{{ template "hole-header" . }}
-
-{{ $showWhitespace := and .Golfer (index .Golfer.Settings "hole" "show-whitespace") }}
-<main id="hole-{{ .Data.Hole.ID }}" {{ if $showWhitespace }} class=show-whitespace {{ end }}>
-    <nav class=tabs id=picker {{ with .Golfer -}}
-        data-style='{{ index .Settings "hole" "lang-picker-style" }}'
-    {{- end }}></nav>
-    {{ template "hole-info" . }}
-    <div id="picker-status-row">
-        <nav class="tabs hide" id=solutionPicker></nav>
-        <div id=pool></div>
-        <div class=hide id=status>
-            <h2></h2>
-            <nav id=thirdParty></nav>
+    {{ with .Data.Hole.Experiment }}
+        <div class=alert>
+            {{ svg "flask-light" }}
+            <p>
+                This hole is experimental, no solutions will be saved.
+            {{ if ne . -1 }}
+                Please leave feedback on the
+                <a href="//github.com/code-golf/code-golf/issues/{{ . }}">
+                    GitHub issue</a>.
+            {{ end }}
         </div>
-    </div>
-    <div id=golden-container></div>
-    <div id=layout-btns>
-        <div id=revert-layout class=btn> {{ svg "default-layout" }} Default Layout</div>
-        <div id=make-wide class=btn> {{ svg "arrow-with-stroke-left-right" }} Wide</div>
-        <div id=make-narrow class=btn> {{ svg "arrow-with-stroke-right-left" }} Narrow</div>
-        <div id=add-row class=btn> {{ svg "downwards-arrow-to-bar" }} Add row</div>
-    </div>
-</main>
+    {{ else }}{{ if not .Golfer }}
+        <div class=alert>
+            {{ svg "exclamation-circle" }}
+            <p>
+                Please
+                <a class=log-in href="{{ .LogInURL }}">log in with GitHub</a>
+                in order to save solutions and appear on the leaderboards.
+        </div>
+    {{ end }}{{ end }}
 
-<template id=template-details>{{ template "hole-details" . }}</template>
+    {{ template "hole-header" . }}
 
-<template id=template-scoreboard>
-    <div id=scores-wrapper>
-        <header>
-            <nav class=tabs id=scoringTabs><a>Bytes</a><a href>Chars</a></nav>
-            <a href id=allLink>All</a>
-        </header>
-        <table class="nowrap-second" id=scores><tr><td></table>
-    </div>
-    <nav class=tabs id=rankingsView>
-        <a {{ if ne .Data.RankingsView "top" }} href {{ end }}>
-            {{ svg "trophy-fill" }} Top
-        </a>
-        <a {{ if ne .Data.RankingsView "me" }} href {{ end }}>
-            {{ svg "person-fill" }} Me
-        </a>
-        <a {{ if ne .Data.RankingsView "following" }} href {{ end }}>
-            {{ svg "people-fill" }} Following
-        </a>
-    </nav>
-</template>
+    {{ $showWhitespace := and .Golfer (index .Golfer.Settings "hole" "show-whitespace") }}
+    <main id="hole-{{ .Data.Hole.ID }}" {{ if $showWhitespace }} class=show-whitespace {{ end }}>
+        <nav class=tabs id=picker {{ with .Golfer -}}
+            data-style='{{ index .Settings "hole" "lang-picker-style" }}'
+        {{- end }}></nav>
+        {{ template "hole-info" . }}
+        <div id="picker-status-row">
+            <nav class="tabs hide" id=solutionPicker></nav>
+            <div id=panel-btns>
+                <div id=pool></div>
+                <div class=hide id=status>
+                    <h2></h2>
+                    <nav id=thirdParty></nav>
+                </div>
+                <div id=layout-btns>
+                    <span id=revert-layout class=btn> {{ svg "default-layout" }} Default Layout</span>
+                    <span id=make-wide class=btn> {{ svg "arrow-with-stroke-left-right" }} Wide</span>
+                    <span id=make-narrow class=btn> {{ svg "arrow-with-stroke-right-left" }} Narrow</span>
+                    <span id=add-row class=btn> {{ svg "downwards-arrow-to-bar" }} Add row</span>
+                </div>
+            </div>
+        </div>
+        <div id=golden-container></div>
+    </main>
 
-<template id=template-run>
-    <div id=run>
-    {{ if .Golfer }}
-        <button class="btn hide red" id=deleteBtn>
-            {{ svg "trash" }} Delete
-        </button>
-    {{ end }}
-        <span>ctrl + enter</span> or
-        <button class="btn blue" id=runBtn>{{ svg "play-light" }} Run</button>
-    </div>
-</template>
+    <template id=template-details>{{ template "hole-details" . }}</template>
 
-<dialog id=delete-dialog>
-    <form action=/golfer/delete-solution autocomplete=off method=post>
-        <h2>Delete Solution</h2>
-        <p>
-            Are you sure you want to delete your <b></b> solution(s) for
-            <b>{{ .Data.Hole.Name }}</b>?
-        <p>
-            If you have separate bytes and chars solutions then <b>both</b>
-            will be deleted.
-        <p>This is irreversible, please backup any code you care about.
-        <p>Type <b>I understand</b> and press confirm to continue.</p>
-        <input name=text placeholder="I understand">
-        <input name=hole value="{{ .Data.Hole.ID }}" type=hidden>
-        <input name=lang type=hidden>
-        <menu>
-            <!-- Enter submits the first button, we flip the order in CSS -->
-            <button class="btn green" disabled name=confirm>Confirm</button>
-            <button class="btn red" formmethod=dialog>Cancel</button>
-        </menu>
-    </form>
-</dialog>
+    <template id=template-scoreboard>
+        <div id=scores-wrapper>
+            <header>
+                <nav class=tabs id=scoringTabs><a>Bytes</a><a href>Chars</a></nav>
+                <a href id=allLink>All</a>
+            </header>
+            <table class="nowrap-second" id=scores><tr><td></table>
+        </div>
+        <nav class=tabs id=rankingsView>
+            <a {{ if ne .Data.RankingsView "top" }} href {{ end }}>
+                {{ svg "trophy-fill" }} Top
+            </a>
+            <a {{ if ne .Data.RankingsView "me" }} href {{ end }}>
+                {{ svg "person-fill" }} Me
+            </a>
+            <a {{ if ne .Data.RankingsView "following" }} href {{ end }}>
+                {{ svg "people-fill" }} Following
+            </a>
+        </nav>
+    </template>
 
-<div id=popups></div>
+    <template id=template-run>
+        <div id=run>
+        {{ if .Golfer }}
+            <button class="btn hide red" id=deleteBtn>
+                {{ svg "trash" }} Delete
+            </button>
+        {{ end }}
+            <span>ctrl + enter</span> or
+            <button class="btn blue" id=runBtn>{{ svg "play-light" }} Run</button>
+        </div>
+    </template>
 
-{{ template "settings-dialog" . }}
-{{ template "hole-json"       . }}
+    <dialog id=delete-dialog>
+        <form action=/golfer/delete-solution autocomplete=off method=post>
+            <h2>Delete Solution</h2>
+            <p>
+                Are you sure you want to delete your <b></b> solution(s) for
+                <b>{{ .Data.Hole.Name }}</b>?
+            <p>
+                If you have separate bytes and chars solutions then <b>both</b>
+                will be deleted.
+            <p>This is irreversible, please backup any code you care about.
+            <p>Type <b>I understand</b> and press confirm to continue.</p>
+            <input name=text placeholder="I understand">
+            <input name=hole value="{{ .Data.Hole.ID }}" type=hidden>
+            <input name=lang type=hidden>
+            <menu>
+                <!-- Enter submits the first button, we flip the order in CSS -->
+                <button class="btn green" disabled name=confirm>Confirm</button>
+                <button class="btn red" formmethod=dialog>Cancel</button>
+            </menu>
+        </form>
+    </dialog>
+
+    <div id=popups></div>
+
+    {{ template "settings-dialog" . }}
+    {{ template "hole-json"       . }}
+</div>
 {{ template "footer"            }}


### PR DESCRIPTION
- Moves layout buttons to the same row as "+ Tab" buttons.
- Moves the footer below the fold.
- Updates the Pass/Fail component to be the same height as the buttons, thus avoids the layout jumping around.
- Renames "Language Wiki" tab to "Wiki", since it's currently the only wiki tab.