### PR TITLE
CodeMirror support for `langs/jq`

### DIFF
--- a/js/_codemirror.ts
+++ b/js/_codemirror.ts
@@ -40,6 +40,7 @@ import { j }                  from 'codemirror-lang-j';
 import { janet }              from 'codemirror-lang-janet';
 import { java }               from '@codemirror/lang-java';
 import { javascriptLanguage } from '@codemirror/lang-javascript';
+import { jq }                 from 'codemirror-lang-jq';
 import { julia }              from '@codemirror/legacy-modes/mode/julia';
 import { k }                  from 'codemirror-lang-k';
 import { lua }                from '@codemirror/legacy-modes/mode/lua';
@@ -143,7 +144,7 @@ export const extensions : { [key: string]: any } = {
     'janet':         janet(),
     'java':          java(),
     'javascript':    javascript,
-    // TODO jq
+    'jq':            jq(),
     'julia':         StreamLanguage.define(julia),
     'k':             k(),
     'lisp':          StreamLanguage.define(commonLisp),

--- a/langs/jq/Dockerfile
+++ b/langs/jq/Dockerfile
@@ -9,7 +9,7 @@ RUN curl -L https://github.com/jqlang/jq/releases/download/jq-$VER/jq-$VER.tar.g
 RUN ./configure --with-oniguruma=builtin \
  && make LDFLAGS='-all-static' -j`nproc`
 
-FROM codegolf/lang-base
+FROM codegolf/lang-base-no-proc
 
 COPY --from=0 ./jq /usr/bin/
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "codemirror-lang-golfscript": "",
         "codemirror-lang-j": "",
         "codemirror-lang-janet": "",
+        "codemirror-lang-jq": "",
         "codemirror-lang-k": "",
         "codemirror-lang-prolog": "",
         "codemirror-lang-zig": "",
@@ -1458,6 +1459,17 @@
         "@codemirror/language": "^6.2.1",
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.2.0"
+      }
+    },
+    "node_modules/codemirror-lang-jq": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/codemirror-lang-jq/-/codemirror-lang-jq-1.0.0.tgz",
+      "integrity": "sha512-oE0kFbhPQekIykUMty9gN9SoijER5gScGbX+b1GYAUp+XtAekP/NPyUHNiFG3OeqGK/B3NWO0di2CYij9Pf48A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
       }
     },
     "node_modules/codemirror-lang-k": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "codemirror-lang-golfscript": "",
     "codemirror-lang-j": "",
     "codemirror-lang-janet": "",
+    "codemirror-lang-jq": "",
     "codemirror-lang-k": "",
     "codemirror-lang-prolog": "",
     "codemirror-lang-zig": "",


### PR DESCRIPTION
This commit adds the syntax highlighting that was still missing.