### PR TITLE
Simplify notes transform

### DIFF
--- a/js/hole-tabs.tsx
+++ b/js/hole-tabs.tsx
@@ -261,7 +261,7 @@ async function convertNotesAndRun(): Promise<boolean> {
     if (editor && holeLangNotesEditor) {
         let newCode = holeLangNotesEditor.state.doc.toString();
         for (const {pattern, replacement} of substitutions) {
-            newCode = newCode[pattern.global ? 'replaceAll' : 'replace'](pattern, replacement);
+            newCode = newCode.replace(pattern, replacement);
         }
         const code = editor.state.doc.toString();
         if (code !== newCode) {


### PR DESCRIPTION
`.replace` works with global regex (but `.replaceAll` doesn't with non-global).