### PR TITLE
J - Source tarball name contains confusing and irrelevant digit

### DIFF
--- a/langs/j/Dockerfile
+++ b/langs/j/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:bookworm-slim AS builder
 
 RUN apt-get update && apt-get install -y curl gcc
 
-RUN curl https://www.jsoftware.com/download/j9.5/install/j9.5.2_linux64.tar.gz \
+RUN curl https://www.jsoftware.com/download/j9.5/install/j9.5_linux64.tar.gz \
   | tar xz
 
 # FIXME Don't run updatejs.sh as it tries to update to AVX512 because my build


### PR DESCRIPTION
Even though it downloads the current version, 9.5.6, having 9.5._2_ in the file's name makes very little sense, and it's just confusing. This commit gets rid of the digit to match the source on [jsoftware](https://code.jsoftware.com/wiki/System/Installation/J9.5/Zips).