### PR TITLE
Make 'Default Layout' include the tall toggle

### DIFF
--- a/js/hole-tabs.tsx
+++ b/js/hole-tabs.tsx
@@ -24,7 +24,6 @@ import { highlightCodeBlocks } from './_wiki';
 const poolDragSources: {[key: string]: DragSource} = {};
 const poolElements: {[key: string]: HTMLElement} = {};
 let isWide = false;
-let isTall = false;
 
 /**
  * Is mobile mode activated? Start at false as default since Golden Layout
@@ -441,14 +440,12 @@ const defaultViewState: ViewState = {
     version: 1,
     config: defaultLayout,
     isWide: false,
-    isTall: false,
 };
 
 interface ViewState {
     version: 1;
     config: ResolvedLayoutConfig | LayoutConfig;
     isWide: boolean;
-    isTall: boolean;
 }
 
 function getViewState(): ViewState {
@@ -456,7 +453,6 @@ function getViewState(): ViewState {
         version: 1,
         config: layout.saveLayout(),
         isWide,
-        isTall,
     };
 }
 
@@ -480,7 +476,7 @@ async function applyViewState(viewState: ViewState) {
     toggleMobile(false);
     Object.keys(poolElements).map(removePoolItem);
     setWide(viewState.isWide);
-    setTall(viewState.isTall);
+    setTall(false);
     let { config } = viewState;
     if (LayoutConfig.isResolved(config))
         config = LayoutConfig.fromResolved(config);
@@ -546,7 +542,6 @@ function setWide(b: boolean) {
 }
 
 function setTall(b: boolean) {
-    isTall = b;
     document.documentElement.classList.toggle('full-height', b);
 }
 

--- a/js/hole-tabs.tsx
+++ b/js/hole-tabs.tsx
@@ -24,6 +24,7 @@ import { highlightCodeBlocks } from './_wiki';
 const poolDragSources: {[key: string]: DragSource} = {};
 const poolElements: {[key: string]: HTMLElement} = {};
 let isWide = false;
+let isTall = false;
 
 /**
  * Is mobile mode activated? Start at false as default since Golden Layout
@@ -440,12 +441,14 @@ const defaultViewState: ViewState = {
     version: 1,
     config: defaultLayout,
     isWide: false,
+    isTall: false,
 };
 
 interface ViewState {
     version: 1;
     config: ResolvedLayoutConfig | LayoutConfig;
     isWide: boolean;
+    isTall: boolean;
 }
 
 function getViewState(): ViewState {
@@ -453,6 +456,7 @@ function getViewState(): ViewState {
         version: 1,
         config: layout.saveLayout(),
         isWide,
+        isTall,
     };
 }
 
@@ -476,6 +480,7 @@ async function applyViewState(viewState: ViewState) {
     toggleMobile(false);
     Object.keys(poolElements).map(removePoolItem);
     setWide(viewState.isWide);
+    setTall(viewState.isTall);
     let { config } = viewState;
     if (LayoutConfig.isResolved(config))
         config = LayoutConfig.fromResolved(config);
@@ -540,15 +545,16 @@ function setWide(b: boolean) {
     document.documentElement.classList.toggle('full-width', b);
 }
 
-function toggleTall() {
-    document.documentElement.classList.toggle('full-height');
+function setTall(b: boolean) {
+    isTall = b;
+    document.documentElement.classList.toggle('full-height', b);
 }
 
 $('#make-wide').addEventListener('click', () => setWide(true));
 $('#make-narrow').addEventListener('click', () => setWide(false));
 
-$('#make-tall').addEventListener('click', () => toggleTall());
-$('#make-short').addEventListener('click', () => toggleTall());
+$('#make-tall').addEventListener('click', () => setTall(true));
+$('#make-short').addEventListener('click', () => setTall(false));
 
 function addPoolItem(componentType: string) {
     poolElements[componentType]?.remove();


### PR DESCRIPTION
This makes the tall and wide settings for the multi-window-layout more consistent

Since the layout hides the language pickers when in "Tall" mode, I often change the layout to "Short" to switch language.

I'd expect the "Default Layout" button to do this, since the layout starts as short when first enabled, but it currently only respects the width setting.