### PR TITLE
Fix arrow hole table spacing

### DIFF
--- a/css/hole.css
+++ b/css/hole.css
@@ -92,7 +92,6 @@ section header {
 
 #arrows code { font-size: 1.5rem }
 #arrows td   { font-family: emoji, mahjong, 'Source Code Pro', monospace }
-#arrows td:first-child { white-space: pre }
 #arrows td:last-child  { width: 100% }
 
 #authors-btn {


### PR DESCRIPTION
At some point recently, the "Coord" and "Arrows" column became misaligned.
<img width="1144" alt="before" src="https://github.com/user-attachments/assets/f8e707ae-0ed2-413d-93d1-002eb23fabc4">
My memory was the hole's table looked more like this (this PR):
<img width="1141" alt="after" src="https://github.com/user-attachments/assets/a13b01ca-928c-4c09-8afd-346d87728d8d">

This PR removes `white-space: pre` to get rid of the extra height spacing and thus align the entries vertically in the arrow table. I can understand if the extra spacing is actually desired (such as for improved readability), but then it feels like the entries in each column should be vertical aligned.