### PR TITLE
Change `version` to `--version` due to wrapper utility for Odin

### DIFF
--- a/langs/odin/Dockerfile
+++ b/langs/odin/Dockerfile
@@ -51,4 +51,4 @@ COPY /odinwrapper /usr/bin/
 
 ENTRYPOINT ["odinwrapper"]
 
-CMD ["version"]
+CMD ["--version"]

--- a/langs/odin/odinwrapper
+++ b/langs/odin/odinwrapper
@@ -3,7 +3,7 @@
 export ODIN_ROOT=/usr/local/bin
 export PATH=$ODIN_ROOT:$PATH
 
-[ "$1" = "version" ] && exec odin version
+[ "$1" = "--version" ] && exec odin version
 
 cd /tmp
 


### PR DESCRIPTION
Generally, people pass the `--version` flag to retrieve versioning data. The wrapper will still use `version`, but the call makes more sense like this.