### PR TITLE
Remove `/usr/bin` prefixes from binary calls in CoffeeScript's wrapper shell

### DIFF
--- a/langs/coffeescript/coffeescript
+++ b/langs/coffeescript/coffeescript
@@ -1,8 +1,8 @@
 #!/bin/sh -e
 
-[ "$1" = "--version" ] && exec /usr/bin/coffee --version
+[ "$1" = "--version" ] && exec coffee --version
 
 cat - > /tmp/code.coffee
 
 shift
-exec /usr/bin/coffee /tmp/code.coffee "$@"
+exec coffee /tmp/code.coffee "$@"


### PR DESCRIPTION
They're redundant in that particular file, obviously.