### PR TITLE
Move Hare's wrapper export to `env` array in `config/data/langs.toml`

### DIFF
--- a/config/data/langs.toml
+++ b/config/data/langs.toml
@@ -674,7 +674,7 @@ n*
 
 [Hare]
 args       = [ '/usr/bin/harewrapper', '-' ]
-env        = [ 'PATH=/usr/local/bin:/usr/bin:/bin:$PATH' ]
+env        = [ 'PATH=/usr/local/bin:/usr/bin:/bin' ]
 experiment = 1323
 size       = '13.5 MiB'
 version    = '0.24.2'

--- a/config/data/langs.toml
+++ b/config/data/langs.toml
@@ -674,6 +674,7 @@ n*
 
 [Hare]
 args       = [ '/usr/bin/harewrapper', '-' ]
+env        = [ 'PATH=/usr/local/bin:/usr/bin:/bin:$PATH' ]
 experiment = 1323
 size       = '13.5 MiB'
 version    = '0.24.2'

--- a/langs/hare/harewrapper
+++ b/langs/hare/harewrapper
@@ -1,7 +1,5 @@
 #!/bin/sh -e
 
-export PATH=/usr/local/bin:$PATH
-
 cd /tmp
 
 # Compile


### PR DESCRIPTION
Tested, and no change in behavior confirmed.