### PR TITLE
Change `version` to `--version` due to wrapper utility for Go

### DIFF
--- a/langs/go/Dockerfile
+++ b/langs/go/Dockerfile
@@ -14,4 +14,4 @@ COPY go /usr/bin/
 
 ENTRYPOINT ["go"]
 
-CMD ["version"]
+CMD ["--version"]

--- a/langs/go/go
+++ b/langs/go/go
@@ -2,7 +2,7 @@
 
 export GOCACHE=/tmp/.cache GOPATH=/tmp
 
-[ "$1" = "version" ] && exec /usr/local/go/bin/go version
+[ "$1" = "--version" ] && exec /usr/local/go/bin/go version
 
 # Copy the cache to /tmp so it's mutable, this is hacky but faster than
 # running Go without the stdlib cached.


### PR DESCRIPTION
Similar to #1431

> Generally, people pass the --version flag to retrieve versioning data. The wrapper will still use version, but the call makes more sense like this.

Just now, Go tricked me, again...