### PR TITLE
Haskell: Rename `Glasgow Haskell Compiler` to `GHC`

### DIFF
--- a/build-langs
+++ b/build-langs
@@ -80,7 +80,7 @@ for %langs{ @langs || * }:p.sort: *.key.fc -> (:key($name), :value(%lang)) {
                 $ver ~~ m/ v (\S+) /;
                 $ver = "D $0 on LDC $digits";
             }
-            when 'Haskell'    { $ver = "Glasgow Haskell Compiler $digits" }
+            when 'Haskell'    { $ver = "GHC $digits" }
             when 'Java'       { $ver = "OpenJDK $digits" }
             when 'JavaScript' { $ver = "V8 $digits" }
             when 'Lisp'       { $ver = "GNU CLISP $digits" }

--- a/config/data/langs.toml
+++ b/config/data/langs.toml
@@ -740,7 +740,7 @@ export fn main() void = {
 [Haskell]
 args    = [ '/usr/bin/haskell', '-' ]
 size    = '388 MiB'
-version = 'Glasgow Haskell Compiler 9.8.2'
+version = 'GHC 9.8.2'
 website = 'https://www.haskell.org/ghc/'
 example = '''
 import System.Environment


### PR DESCRIPTION
This is annoying.

![image](https://github.com/user-attachments/assets/e34cabe6-1e6f-42fe-a976-53484a66507a)