### PR TITLE
Pascal: Replace miserable download mirror

### DIFF
--- a/langs/pascal/Dockerfile
+++ b/langs/pascal/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache build-base curl
 
 ENV ARCH=x86_64-linux VERSION=3.2.2
 
-RUN curl -L https://downloads.sourceforge.net/project/freepascal/Linux/$VERSION/fpc-$VERSION.$ARCH.tar | tar x
+RUN curl http://downloads.freepascal.org/fpc/dist/$VERSION/$ARCH/fpc-$VERSION.$ARCH.tar | tar x
 
 # Workaround musl vs glibc entrypoint for fpcmkcfg.
 RUN mkdir /lib64 \

--- a/langs/pascal/Dockerfile
+++ b/langs/pascal/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache build-base curl
 
 ENV ARCH=x86_64-linux VERSION=3.2.2
 
-RUN curl http://downloads.freepascal.org/fpc/dist/$VERSION/$ARCH/fpc-$VERSION.$ARCH.tar | tar x
+RUN curl https://downloads.freepascal.org/fpc/dist/$VERSION/$ARCH/fpc-$VERSION.$ARCH.tar | tar x
 
 # Workaround musl vs glibc entrypoint for fpcmkcfg.
 RUN mkdir /lib64 \


### PR DESCRIPTION
Slightly.

```bash
 => [builder 3/8] RUN curl http://downloads.freepascal.org/fpc/dist/3.2.2/x86_64-linux/fpc-3.2.2.x86_64-linux.tar | tar x                                     4.7s
 => => #   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
 => => #                                  Dload  Upload   Total   Spent    Left  Speed
 => => #  88 82.9M   88 73.3M    0     0  18.1M      0  0:00:04  0:00:04 --:--:-- 18.1M
```