### PR TITLE
Civet: Change `javascript` to `coffeeScript` for syntax highlighting

### DIFF
--- a/js/_codemirror.ts
+++ b/js/_codemirror.ts
@@ -128,7 +128,7 @@ export const extensions : { [key: string]: any } = {
     'brainfuck':     brainfuck(),
     'c':             StreamLanguage.define(c),
     'c-sharp':       StreamLanguage.define(csharp),
-    'civet':         javascript,
+    'civet':         coffeeScript,
     'clojure':       StreamLanguage.define(clojure),
     'cobol':         StreamLanguage.define(cobol),
     'coconut':       python,


### PR DESCRIPTION
```json
  "description": "CoffeeScript style syntax for TypeScript",
```