### PR TITLE
Update `views/html/about.html`

### DIFF
--- a/views/html/about.html
+++ b/views/html/about.html
@@ -74,7 +74,7 @@
         {{ end }}
             <p>
                 If you'd like to see another language added then raise an
-                <a href=//github.com/code-golf/code-golf/issues/new>issue</a>.
+                <a href=//github.com/code-golf/code-golf/issues/new/choose>issue</a>.
         <dt>Are warnings ignored?
         <dd>
             Yes. Only STDOUT is checked against the solution, STDERR is


### PR DESCRIPTION
It might be better to direct users to the selection page, don't you think? It probably didn't exist at the time though.

![image](https://github.com/user-attachments/assets/550951ea-43fd-41af-a6fc-f10bc6279885)
