### PR TITLE
Replace `-e "puts RUBY_VERSION"` with `--version`

### DIFF
--- a/langs/ruby/Dockerfile
+++ b/langs/ruby/Dockerfile
@@ -59,4 +59,4 @@ COPY --from=0 /usr/lib/ruby            /usr/lib/ruby
 
 ENTRYPOINT ["ruby"]
 
-CMD ["-e", "puts RUBY_VERSION"]
+CMD ["--version"]


### PR DESCRIPTION
We can do just that, can't we? Figured the latter didn't work with the `build-langs` script, but it works just fine.