### PR TITLE
Update `latest-langs`

### DIFF
--- a/latest-langs
+++ b/latest-langs
@@ -43,7 +43,7 @@ constant %paths = (
     'GolfScript'   => 'github.com/lynn/golfscript/tree/code-golf',
     'Groovy'       => 'en.wikipedia.org/wiki/Apache_Groovy',
     'Hare'         => 'git.sr.ht/~sircmpwn/hare/refs',
-    'Haskell'      => 'en.wikipedia.org/wiki/Glasgow_Haskell_Compiler',
+    'Haskell'      => 'pkgs.alpinelinux.org/package/edge/community/x86_64/ghc',
     'Haxe'         => 'github.com/HaxeFoundation/haxe/releases/latest',
     'Hexagony'     => 'github.com/SirBogman/Hexagony',
     'Hush'         => 'crates.io/api/v1/crates/hush',
@@ -101,6 +101,7 @@ for %langs{ @langs || * }:p.sort: *.key.fc -> (:key($name), :value(%lang)) {
         state $ua  = HTTP::Tiny.new :throw-exceptions;
         my    $res = $ua.get("https://$_")<content>.decode;
 
+        when / 'alpinelinux' / { $res ~~ / 'release' .+? <(<ver>)> / }
         when / 'aplwiki'     / { $res ~~ / ' release' .+? <(<ver>)> / }
         when / 'codeberg'    / { $res ~~ / '"shortsha">' <(<ver>)> / }
         when / 'crates.io'   / { $res.&from-json<crate><max_stable_version> }


### PR DESCRIPTION
The comparison for Haskell will most likely always be off. In my opinion, since we're currently depending on the Alpine Linux package manager, we're probably better off obtaining the data from the corresponding database.

> While they may lag behind the latest GHC release, we recommend using them anyway for the above reasons, unless you have a particular need for new features or bug fixes.

https://www.haskell.org/ghc/distribution_packages.html