### PR TITLE
Install Clojure just that tiny bit faster

### DIFF
--- a/langs/clojure/Dockerfile
+++ b/langs/clojure/Dockerfile
@@ -1,10 +1,8 @@
 FROM alpine:3.20 AS builder
 
-RUN apk add --no-cache curl
-
 ENV VER=1.12.195
 
-RUN curl -L https://github.com/babashka/babashka/releases/download/v$VER/babashka-$VER-linux-amd64-static.tar.gz | tar xz
+RUN wget -O- https://github.com/babashka/babashka/releases/download/v$VER/babashka-$VER-linux-amd64-static.tar.gz | tar xz
 
 FROM codegolf/lang-base
 


### PR DESCRIPTION
Since all it requires is a download, obtaining `curl` from the package manager is a waste of time. Let's drop a run step here, use `wget`, and finish installation like on average one and a half seconds faster.