### PR TITLE
Fix Haskell entry `latest-langs`

### DIFF
--- a/latest-langs
+++ b/latest-langs
@@ -101,7 +101,7 @@ for %langs{ @langs || * }:p.sort: *.key.fc -> (:key($name), :value(%lang)) {
         state $ua  = HTTP::Tiny.new :throw-exceptions;
         my    $res = $ua.get("https://$_")<content>.decode;
 
-        when / 'alpinelinux' / { $res ~~ / 'release' .+? <(<ver>)> / }
+        when / 'alpinelinux' / { $res ~~ / 'Version' .+? <(<ver>)> / }
         when / 'aplwiki'     / { $res ~~ / ' release' .+? <(<ver>)> / }
         when / 'codeberg'    / { $res ~~ / '"shortsha">' <(<ver>)> / }
         when / 'crates.io'   / { $res.&from-json<crate><max_stable_version> }


### PR DESCRIPTION
For some unknown reason, the recent change started failing.