### PR TITLE
Bash: Using non-existent option `--disable-docs` during Makefile configuration

### DIFF
--- a/langs/bash/Dockerfile
+++ b/langs/bash/Dockerfile
@@ -14,7 +14,6 @@ RUN ./configure                \
     --disable-command-timing   \
     --disable-debugger         \
     --disable-directory-stack  \
-    --disable-docs             \
     --disable-help-builtin     \
     --disable-job-control      \
     --disable-net-redirections \


### PR DESCRIPTION
```bash
=> ERROR [builder 6/6] RUN ./configure                    --disable-command-timing       --disable-debugger             --disable-directory-stack      --disable-docs  51.7s
------
 > [builder 6/6] RUN ./configure                    --disable-command-timing       --disable-debugger             --disable-directory-stack      --disable-docs                 --disable-help-builtin         --disable-job-control          --disable-net-redirections     --disable-progcomp             --disable-select               --enable-static-link           --without-bash-malloc       && make dfsfsdfsfsfsf                       && strip bash:
0.654 configure: WARNING: unrecognized options: --disable-docs
```