### PR TITLE
Improve pangram grep test cases

### DIFF
--- a/hole/pangram-grep.go
+++ b/hole/pangram-grep.go
@@ -16,7 +16,7 @@ func pangramGrep() []Run {
 func pangramGrepTests(l, r int) []test {
 	// They all start lowercase and valid.
 	pangrams := shuffle([][]byte{
-		[]byte("6>_4\"gv9lb?2!ic7}=-m'fd30ph].o%@w+[8unk&t1es<az(x;${^y#)q,rj\\5/*:"),
+		[]byte("6>_4\"gv9lb?2!ic7}=-m'fd30ph].o%@w+[8unk&t1es<az(x;${^y#)q,rj\\5/*:`"),
 		[]byte(`a large fawn jumped quickly over white zinc boxes.`),
 		[]byte(`all questions asked by five watched experts amaze the judge.`),
 		[]byte(`a quick movement of the enemy will jeopardize six gunboats.`),

--- a/hole/pangram-grep.go
+++ b/hole/pangram-grep.go
@@ -16,7 +16,7 @@ func pangramGrep() []Run {
 func pangramGrepTests(l, r int) []test {
 	// They all start lowercase and valid.
 	pangrams := shuffle([][]byte{
-		[]byte("6>_4\"gv9lb?2!ic7}=-m'fd30ph].o%@w+[8unk&t1es<az(x;${^y#)q,rj\\5/*:`"),
+		[]byte("6>_4\"gv9lb?2!ic7}=-m'fd30ph].o%@w+[8unk&t1es<az(x;${^y#)q,rj\\5/*:" + "`"),
 		[]byte(`a large fawn jumped quickly over white zinc boxes.`),
 		[]byte(`all questions asked by five watched experts amaze the judge.`),
 		[]byte(`a quick movement of the enemy will jeopardize six gunboats.`),


### PR DESCRIPTION
Include the ` character to a test case. The given character is special as it is the only character between 'Z' and 'a' in the ascii table, that is 0 for the lowest 5 bits. This will definitely break some, but not all, of the submissions.

I didn't see a test including it, or any way for the current tests to generate it.