### PR TITLE
Explicitly display unprintable characters

### DIFF
--- a/js/_codemirror_unprintable.tsx
+++ b/js/_codemirror_unprintable.tsx
@@ -1,8 +1,7 @@
 // CodeMirror unprintable character extensions
 import { Decoration, EditorView, keymap, MatchDecorator, ViewPlugin, WidgetType } from '@codemirror/view';
 import { EditorState }                                                            from '@codemirror/state';
-
-import './_unprintable';
+import UnprintableElement                                                         from './_unprintable';
 
 export const carriageReturn = [
     EditorState.lineSeparator.of('\n'), // Prevent CM from treating carriage return as newline
@@ -71,7 +70,7 @@ class UnprintableWidget extends WidgetType {
 }
 
 const unprintableDecorator = new MatchDecorator({
-    regexp: /[\x00-\x08\x0B-\x1F\x7F]/g,
+    regexp: UnprintableElement.PATTERN,
     decoration: match => Decoration.replace({
         widget: new UnprintableWidget(match[0].charCodeAt(0)),
     }),

--- a/js/_codemirror_unprintable.tsx
+++ b/js/_codemirror_unprintable.tsx
@@ -2,6 +2,8 @@
 import { Decoration, EditorView, keymap, MatchDecorator, ViewPlugin, WidgetType } from '@codemirror/view';
 import { EditorState }                                                            from '@codemirror/state';
 
+import './_unprintable';
+
 export const carriageReturn = [
     EditorState.lineSeparator.of('\n'), // Prevent CM from treating carriage return as newline
     keymap.of({
@@ -64,12 +66,12 @@ class UnprintableWidget extends WidgetType {
         this.value = value;
     }
     toDOM() {
-        return <span title={'\\u' + this.value.toString(16)}>•</span>;
+        return <u-p c={String.fromCharCode(this.value)} />;
     }
 }
 
 const unprintableDecorator = new MatchDecorator({
-    regexp: /[\x01-\x08\x0B-\x1F\x7F]/g,
+    regexp: /[\x00-\x08\x0B-\x1F\x7F]/g,
     decoration: match => Decoration.replace({
         widget: new UnprintableWidget(match[0].charCodeAt(0)),
     }),

--- a/js/_diff.tsx
+++ b/js/_diff.tsx
@@ -1,5 +1,6 @@
 import * as Diff from 'diff';
 import { $ } from './_util';
+import UnprintableElement from './_unprintable';
 
 interface DiffPos {
     left: number;
@@ -388,11 +389,11 @@ function renderCharDiff(className: string, charDiff: Diff.Change[], isRight: boo
 
     for (const change of charDiff)
         if (change.added && isRight)
-            td.append(<span class="diff-char-addition">{change.value}</span>);
+            td.append(<span class="diff-char-addition">{UnprintableElement.escape(change.value)}</span>);
         else if (change.removed && !isRight)
-            td.append(<span class="diff-char-removal">{change.value}</span>);
+            td.append(<span class="diff-char-removal">{UnprintableElement.escape(change.value)}</span>);
         else if (!change.added && !change.removed)
-            td.append(change.value);
+            td.append(UnprintableElement.escape(change.value));
 
     return td;
 }

--- a/js/_hole-common.tsx
+++ b/js/_hole-common.tsx
@@ -97,20 +97,6 @@ export function initDeleteBtn(deleteBtn: HTMLElement | undefined, langs: any) {
     });
 }
 
-export function initOutputDiv(outputDiv: HTMLElement | undefined) {
-    outputDiv?.addEventListener('copy', event => {
-        const selection = document.getSelection();
-        if (selection?.rangeCount !== undefined && selection.rangeCount > 0) {
-            let text = '';
-            for (let index = 0; index < selection.rangeCount; index++) {
-                text += replacePlaceholdersInRange(selection, selection.getRangeAt(index));
-            }
-            event.clipboardData?.setData('text/plain', text);
-            event.preventDefault();
-        }
-    });
-}
-
 export function initCopyJSONBtn(copyBtn: HTMLElement | undefined) {
     copyBtn?.addEventListener('click', () =>
         navigator.clipboard.writeText($('#data').innerText));
@@ -843,46 +829,6 @@ export function getScorings(tr: any, editor: any) {
     }
 
     return (selection.byte || selection.char) ? {total, selection} : {total};
-}
-
-export function replaceUnprintablesInOutput(output: string) {
-    return output.replace(/[\x00-\x08\x0B-\x1F\x7F]/g,
-        x => `<span title=${'\\u' + x.charCodeAt(0).toString(16)}>•</span>`);
-}
-
-// Extracts the text, replacing any unprintable placeholders with the actual text.
-function replacePlaceholdersInRange(selection: Selection, range: Range) {
-    let containers = [];
-    if (range.startContainer === range.endContainer) {
-        if (range.startContainer.parentElement instanceof HTMLSpanElement) {
-            containers.push(range.startContainer.parentElement);
-        }
-        else {
-            containers.push(range.startContainer);
-        }
-    }
-    else {
-        containers = Array.from(range.commonAncestorContainer.childNodes).filter(node => selection.containsNode(node, true));
-    }
-
-    let text = '';
-    for (const container of containers) {
-        if (container instanceof HTMLSpanElement) {
-            // Decode placeholder character.
-            text += String.fromCharCode(parseInt(container.title.substring(2), 16));
-        }
-        else if (container instanceof HTMLBRElement) {
-            text += '\n';
-        }
-        else {
-            const childText = container.textContent || '';
-            const start = container === containers[0] ? range.startOffset : 0;
-            const end = container === containers[containers.length - 1] ? range.endOffset : childText.length;
-            text += childText.substring(start, end);
-        }
-    }
-
-    return text;
 }
 
 export function ctrlEnter(func: Function) {

--- a/js/_unprintable.ts
+++ b/js/_unprintable.ts
@@ -1,0 +1,99 @@
+import { StyleModule } from "style-mod"; // Already used by CodeMirror
+
+const shadowStyle = new StyleModule({
+    ":host": {
+        display: "inline-block",
+        position: "relative",
+        verticalAlign: "middle",
+        width: "1ch",
+        height: "1em",
+        // Omit emoji because Apple Color Emoji has a full-width glyph for non-emoji '0'. (???)
+        fontFamily: "'Source Code Pro', monospace",
+        lineHeight: 0.8,
+        cursor: "text",
+    },
+    ":host > span": {
+        WebkitTextFillColor: "transparent",
+        "&:before, &:after": {
+            WebkitTextFillColor: "currentcolor",
+            fontSize: "70%",
+            position: "absolute",
+            pointerEvents: "none",
+        },
+        "&:before": {
+            content: "attr(data-h)",
+            left: 0,
+            top: 0,
+        },
+        "&:after": {
+            content: "attr(data-l)",
+            right: 0,
+            bottom: 0,
+        },
+    },
+
+    ":host([c])": {
+        pointerEvents: "none",
+    },
+    ":host([c]) > span": {
+        pointerEvents: "auto",
+    },
+});
+
+// <u-p>&#...;</u-p> renders a single character and allows selection and copying.
+// <u-p c="&#...;"></u-p> renders a single character but doesn't allow copying.
+//
+// TODO:
+// Title doesn't show up for the attribute use case in Safari and others.
+// Firefox doesn't (yet) let the selection cross shadow root boundaries. (cf. bug #1867058)
+export default class UnprintableElement extends HTMLElement {
+    #span;
+
+    constructor(text = '') {
+        super();
+
+        const shadow = this.attachShadow({ mode: 'closed' });
+        StyleModule.mount(shadow, shadowStyle);
+
+        this.#span = document.createElement('span');
+        shadow.append(this.#span);
+
+        if (text) this.textContent = text;
+    }
+
+    // For the simplicity, we only update the shadow DOM when connected.
+    connectedCallback() {
+        let c = this.getAttribute('c'), h, l, t;
+        const ignoreTextContent = !!c;
+        c = c || this.textContent || '';
+        if (c.length == 0) {
+            h = '⌜';
+            l = '⌟';
+            t = '(empty)';
+        } else if (c.length == 1) {
+            const code = c.charCodeAt(0);
+            h = '0123456789ABCDEF'[code / 16 | 0];
+            l = '0123456789ABCDEF'[code % 16];
+            t = '\\u' + code.toString(16);
+        } else {
+            h = '+';
+            l = '+';
+            c = '';
+            t = '(multiple)';
+        }
+        this.#span.setAttribute('data-h', h);
+        this.#span.setAttribute('data-l', l);
+        this.#span.textContent = ignoreTextContent ? '' : c;
+        this.#span.title = t;
+    }
+}
+
+customElements.define('u-p', UnprintableElement);
+
+declare global {
+    namespace JSX {
+        interface IntrinsicElements {
+            ['u-p']: any;
+        }
+    }
+}

--- a/js/_unprintable.ts
+++ b/js/_unprintable.ts
@@ -1,42 +1,44 @@
-import { StyleModule } from "style-mod"; // Already used by CodeMirror
+import { StyleModule } from 'style-mod'; // Already used by CodeMirror
+
+/* eslint no-unused-vars: ["off"] */
 
 const shadowStyle = new StyleModule({
-    ":host": {
-        display: "inline-block",
-        position: "relative",
-        verticalAlign: "middle",
-        width: "1ch",
-        height: "1em",
+    ':host': {
+        display: 'inline-block',
+        position: 'relative',
+        verticalAlign: 'middle',
+        width: '1ch',
+        height: '1em',
         // Omit emoji because Apple Color Emoji has a full-width glyph for non-emoji '0'. (???)
         fontFamily: "'Source Code Pro', monospace",
         lineHeight: 0.8,
-        cursor: "text",
+        cursor: 'text',
     },
-    ":host > span": {
-        WebkitTextFillColor: "transparent",
-        "&:before, &:after": {
-            WebkitTextFillColor: "currentcolor",
-            fontSize: "70%",
-            position: "absolute",
-            pointerEvents: "none",
+    ':host > span': {
+        'WebkitTextFillColor': 'transparent',
+        '&:before, &:after': {
+            WebkitTextFillColor: 'currentcolor',
+            fontSize: '70%',
+            position: 'absolute',
+            pointerEvents: 'none',
         },
-        "&:before": {
-            content: "attr(data-h)",
+        '&:before': {
+            content: 'attr(data-h)',
             left: 0,
             top: 0,
         },
-        "&:after": {
-            content: "attr(data-l)",
+        '&:after': {
+            content: 'attr(data-l)',
             right: 0,
             bottom: 0,
         },
     },
 
-    ":host([c])": {
-        pointerEvents: "none",
+    ':host([c])': {
+        pointerEvents: 'none',
     },
-    ":host([c]) > span": {
-        pointerEvents: "auto",
+    ':host([c]) > span': {
+        pointerEvents: 'auto',
     },
 });
 
@@ -70,12 +72,14 @@ export default class UnprintableElement extends HTMLElement {
             h = '⌜';
             l = '⌟';
             t = '(empty)';
-        } else if (c.length == 1) {
+        }
+        else if (c.length == 1) {
             const code = c.charCodeAt(0);
             h = '0123456789ABCDEF'[code / 16 | 0];
             l = '0123456789ABCDEF'[code % 16];
             t = '\\u' + code.toString(16);
-        } else {
+        }
+        else {
             h = '+';
             l = '+';
             c = '';

--- a/js/_unprintable.ts
+++ b/js/_unprintable.ts
@@ -86,6 +86,18 @@ export default class UnprintableElement extends HTMLElement {
         this.#span.textContent = ignoreTextContent ? '' : c;
         this.#span.title = t;
     }
+
+    static PATTERN = /([\x00-\x08\x0B-\x1F\x7F-\xA0])/g;
+
+    static escape(text: string): DocumentFragment {
+        const frag = document.createDocumentFragment();
+        const parts = text.split(UnprintableElement.PATTERN);
+        for (let i = 0; i < parts.length - 1; i += 2) {
+            frag.append(parts[i], new UnprintableElement(parts[i + 1]));
+        }
+        frag.append(parts[parts.length - 1]);
+        return frag;
+    }
 }
 
 customElements.define('u-p', UnprintableElement);

--- a/js/hole-tabs.tsx
+++ b/js/hole-tabs.tsx
@@ -12,7 +12,7 @@ import {
     setCode, refreshScores, getHideDeleteBtn, submit, ReadonlyPanelsData,
     updateRestoreLinkVisibility, setCodeForLangAndSolution,
     populateScores, getCurrentSolutionCode, initDeleteBtn, initCopyJSONBtn,
-    getScorings, replaceUnprintablesInOutput, initOutputDiv,
+    getScorings,
     updateLocalStorage,
     getLang,
     setState,
@@ -20,6 +20,7 @@ import {
     getLastSubmittedCode,
 } from './_hole-common';
 import { highlightCodeBlocks } from './_wiki';
+import UnprintableElement from './_unprintable';
 
 const poolDragSources: {[key: string]: DragSource} = {};
 const poolElements: {[key: string]: HTMLElement} = {};
@@ -76,8 +77,7 @@ function updateReadonlyPanel(name: string) {
         output.innerHTML = subRes.Err.replace(/\n/g,'<br>');
         break;
     case 'out':
-        output.innerText = subRes.Out;
-        output.innerHTML = replaceUnprintablesInOutput(output.innerHTML);
+        output.replaceChildren(UnprintableElement.escape(subRes.Out));
         break;
     case 'exp':
         output.innerText = subRes.Exp;
@@ -131,9 +131,6 @@ for (const name of ['exp', 'out', 'err', 'arg', 'diff']) {
         autoFocus(container);
         container.element.id = name;
         container.element.classList.add('readonly-output');
-        if (name === 'out') {
-            initOutputDiv(container.element);
-        }
         readonlyOutputs[name] = container.element;
         updateReadonlyPanel(name);
     });

--- a/js/hole.tsx
+++ b/js/hole.tsx
@@ -5,11 +5,12 @@ import {
     init, langs, hole, setSolution,
     setCode, refreshScores, submit, updateRestoreLinkVisibility,
     ReadonlyPanelsData, setCodeForLangAndSolution, getCurrentSolutionCode,
-    initDeleteBtn, initCopyJSONBtn, initOutputDiv, getScorings, replaceUnprintablesInOutput,
+    initDeleteBtn, initCopyJSONBtn, getScorings,
     updateLocalStorage,
     ctrlEnter,
     getLastSubmittedCode,
 } from './_hole-common';
+import UnprintableElement from './_unprintable';
 
 const editor = new EditorView({
     dispatch: tr => {
@@ -43,7 +44,6 @@ const editor = new EditorView({
 editor.contentDOM.setAttribute('data-gramm', 'false');  // Disable Grammarly.
 
 init(false, setSolution, setCodeForLangAndSolution, updateReadonlyPanels, () => editor);
-initOutputDiv($('#out div'));
 
 // Set/clear the hide-details cookie on details toggling.
 $('#details').ontoggle = (e: Event) => document.cookie =
@@ -85,8 +85,7 @@ function updateReadonlyPanels(data: ReadonlyPanelsData) {
 
     // Always show exp & out.
     $('#exp div').innerText = data.Exp;
-    $('#out div').innerText = data.Out;
-    $('#out div').innerHTML = replaceUnprintablesInOutput($('#out div').innerHTML);
+    $('#out div').replaceChildren(UnprintableElement.escape(data.Out));
 
     const ignoreCase = JSON.parse($('#case-fold').innerText);
     const diff = diffView(hole, data.Exp, data.Out, data.Argv, ignoreCase, data.MultisetDelimiter, data.ItemDelimiter);

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,8 @@
         "luxon": "",
         "lz-string": "",
         "mathjax": "",
-        "nim-codemirror-mode": ""
+        "nim-codemirror-mode": "",
+        "style-mod": ""
       },
       "devDependencies": {
         "@types/diff": "",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "luxon": "",
     "lz-string": "",
     "mathjax": "",
-    "nim-codemirror-mode": ""
+    "nim-codemirror-mode": "",
+    "style-mod": ""
   },
   "devDependencies": {
     "@types/diff": "",


### PR DESCRIPTION
There was already some existing code to produce placeholders, but those placeholders were visually identical until hovered. This PR introduces a new custom element `<u-p>` which displays character codes and tries to do its best to remain copyable without additional tweaks like handling the `copy` event. Once I've got the element working, it enabled a uniform handling of unprintable characters due to the simpler interface.