### PR TITLE
Narrow sql gitignore to *.gz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 /localhost.pem
 /localhost-key.pem
 /node_modules/
-/sql/
+/sql/*.gz
 /t/.precomp/
 .DS_Store
 


### PR DESCRIPTION
The sql/*.gz is created by `make db-dump`.

This removes the source sql files like `sql/a-schema.sql` from gitignore, which lets them show up in Ctrl+Shift-F search results in VS code by default.

I left the `/sql/` in .dockerignore as-is.