### PR TITLE
Include link to wiki in wiki tab

### DIFF
--- a/js/_hole-common.tsx
+++ b/js/_hole-common.tsx
@@ -9,10 +9,24 @@ let tabLayout: boolean = false;
 const langWikiCache: Record<string, string | null> = {};
 async function getLangWikiContent(lang: string): Promise<string> {
     if (!(lang in langWikiCache)) {
-        const resp  = await fetch(`/api/wiki/langs/${lang}`);
-        langWikiCache[lang] = resp.status === 200 ? (await resp.json()).content : null;
+        langWikiCache[lang] = await _getLangWikiContent(lang);
     }
     return langWikiCache[lang] ?? 'No data for current lang.';
+}
+async function _getLangWikiContent(lang: string): Promise<string | null> {
+    const resp  = await fetch(`/api/wiki/langs/${lang}`);
+    const {content, title} = await resp.json() as {content: string, title: string};
+    if (resp.status !== 200) {
+        return null;
+    }
+    const header = (<p id={`lang-wiki-${lang}`}>
+        Wiki: {title}{' '}
+        <a href={`/wiki/langs/${lang}`} target="_blank">
+            (open in new tab)
+        </a>
+        .
+    </p>).outerHTML;
+    return header + content;
 }
 
 const holeLangNotesCache: Record<string, string | null> = {};


### PR DESCRIPTION
Adds a lil link in the "Wiki" Tab. Motivation: I was scrolling through the assembly wiki on mobile and wanted to easily open in a new tab.

![image](https://github.com/user-attachments/assets/008e2b39-c69b-4b40-bca8-64f32073b502)
![image](https://github.com/user-attachments/assets/7a16c96e-55b6-410c-935e-313df3bffa4d)

Note there is no "Wiki" Tab outside of the tabs (multi-window) layout.

## Alternative designs

My other idea of an h1 header link didn't really work well.
![image](https://github.com/user-attachments/assets/05f9de7f-b39b-4439-af9e-93e9a57d72e1)
![image](https://github.com/user-attachments/assets/3b107c12-4c51-4ece-9863-6a96054328a1)
