### PR TITLE
Cache /api/wiki

### DIFF
--- a/routes/api.go
+++ b/routes/api.go
@@ -260,6 +260,9 @@ func apiWikiPageGET(w http.ResponseWriter, r *http.Request) {
 		panic(err)
 	}
 
+	// Cache the wiki for 5 minutes, since it is fetched on every page navigation.
+	w.Header().Set("Cache-Control", "max-age=300, public")
+
 	encodeJSON(w, page)
 }
 


### PR DESCRIPTION
Every reload of https://code.golf/fibonacci#assembly with tabs (multi-window) layout re-fetches the 36kB wiki endpoint. Just don't.

The 5 minute timeframe matches the window for golfer avatars: https://github.com/code-golf/code-golf/blob/d9c167d3fbd8c0ae9ad283714ff56b9051428b43/routes/golfer_avatar.go#L30