### PR TITLE
Allow users to hide cheevo banners, and re-fresh banners after 60 days

### DIFF
--- a/golfer/get.go
+++ b/golfer/get.go
@@ -41,6 +41,9 @@ func Get(db *sqlx.DB, sessionID uuid.UUID) *Golfer {
 		          u.sponsor                                 sponsor,
 		          u.theme                                   theme,
 		          u.time_zone                               time_zone,
+				  ARRAY(SELECT hide_key
+						  FROM hidden_banners
+						  WHERE user_id = u.id)             hidden_banners,
 		          ARRAY(SELECT trophy
 		                  FROM trophies
 		                 WHERE user_id = u.id

--- a/golfer/golfer.go
+++ b/golfer/golfer.go
@@ -25,7 +25,7 @@ type Golfer struct {
 	About, Keymap, Name, Referrer, Theme  string
 	Admin, HasNotes, ShowCountry, Sponsor bool
 	BytesPoints, CharsPoints, ID          int
-	Cheevos, Holes                        pq.StringArray
+	Cheevos, Holes, HiddenBanners         pq.StringArray
 	Country                               config.NullCountry
 	Delete                                null.Time
 	FailingSolutions                      FailingSolutions

--- a/main.go
+++ b/main.go
@@ -123,6 +123,11 @@ func main() {
 					"users scheduled for deletion",
 					"DELETE FROM users WHERE delete < TIMEZONE('UTC', NOW())",
 				},
+				{
+					"expired hidden banners",
+					`DELETE FROM hidden_banners
+					  WHERE delete < TIMEZONE('UTC', NOW())`,
+				},
 			} {
 				if res, err := db.Exec(job.sql); err != nil {
 					log.Println(err)

--- a/routes/banner.go
+++ b/routes/banner.go
@@ -19,6 +19,28 @@ type banner struct {
 	HideKey, Type string
 }
 
+func unHiddenBanners(golfer *golfer.Golfer, now time.Time) (ret []banner) {
+	// Currently all the global banners require a golfer.
+	if golfer == nil {
+		return
+	}
+
+	allBanners := banners(golfer, now)
+	if len(golfer.HiddenBanners) == 0 {
+		return allBanners
+	}
+	hiddenMap := map[string]bool{}
+	for _, hideKey := range golfer.HiddenBanners {
+		hiddenMap[hideKey] = true
+	}
+	for _, banner := range allBanners {
+		if !hiddenMap[banner.HideKey] {
+			ret = append(ret, banner)
+		}
+	}
+	return
+}
+
 func banners(golfer *golfer.Golfer, now time.Time) (banners []banner) {
 	// Upcoming hole.
 	if hole := nextHole; hole != nil {

--- a/routes/banner.go
+++ b/routes/banner.go
@@ -144,19 +144,26 @@ Cheevo:
 			end := cheevo.Times[i+1].AddDate(delta, 0, 0)
 
 			var body template.HTML
+			var hideKey string
 			if start.AddDate(0, 0, -7).Before(now) && now.Before(start) {
 				body = "be available in " +
 					pretty.Time(start.In(location)) + "."
+				hideKey = "cheevo-before-" + cheevo.ID
 			} else if start.Before(now) && now.Before(end) {
 				body = "stop being available in " +
 					pretty.Time(end.In(location)) + "."
+				hideKey = "cheevo-during-" + cheevo.ID
 			}
 
 			if body != "" {
 				body = template.HTML("The "+cheevo.Emoji+" <b>"+
 					cheevo.Name+"</b> achievement will ") + body
 
-				banners = append(banners, banner{Body: body, Type: "info"})
+				banners = append(banners, banner{
+					HideKey: hideKey,
+					Body:    body,
+					Type:    "info",
+				})
 
 				break Cheevo
 			}

--- a/routes/golfer_hide_banner.go
+++ b/routes/golfer_hide_banner.go
@@ -20,6 +20,10 @@ func golferHideBannerPOST(w http.ResponseWriter, r *http.Request) {
 		_, valid = config.HoleByID[holeID]
 	} else if holeID, ok := strings.CutPrefix(banner, "upcoming-hole-"); ok {
 		_, valid = config.ExpHoleByID[holeID]
+	} else if cheevoID, ok := strings.CutPrefix(banner, "cheevo-before-"); ok {
+		_, valid = config.CheevoByID[cheevoID]
+	} else if cheevoID, ok := strings.CutPrefix(banner, "cheevo-during-"); ok {
+		_, valid = config.CheevoByID[cheevoID]
 	}
 
 	if valid {

--- a/routes/golfer_hide_banner.go
+++ b/routes/golfer_hide_banner.go
@@ -26,8 +26,12 @@ func golferHideBannerPOST(w http.ResponseWriter, r *http.Request) {
 		golfer := session.Golfer(r)
 
 		if _, err := session.Database(r).Exec(
-			`INSERT INTO hidden_banners (hide_key, user_id)
-			      VALUES                ($1,       $2)
+			// 60 days is picked to be longer than any new hole window
+			// and any date-based cheevo window, but shorter than a year
+			// (so the date-based cheevo will show again next year).
+			`INSERT INTO hidden_banners
+				    (hide_key, user_id, delete)
+			 VALUES ($1,       $2,      TIMEZONE('UTC', NOW()) + INTERVAL '60 days')
 			 ON CONFLICT DO NOTHING`,
 			banner,
 			golfer.ID,

--- a/routes/golfer_hide_banner.go
+++ b/routes/golfer_hide_banner.go
@@ -10,10 +10,12 @@ import (
 
 // POST /golfer/hide-banner
 func golferHideBannerPOST(w http.ResponseWriter, r *http.Request) {
+	// banner = hide_key
 	banner := r.FormValue("banner")
 	valid := false
 
 	// Validate the banner is of a known form.
+	// cf. routes/banner.go for where the keys are created.
 	if holeID, ok := strings.CutPrefix(banner, "latest-hole-"); ok {
 		_, valid = config.HoleByID[holeID]
 	} else if holeID, ok := strings.CutPrefix(banner, "upcoming-hole-"); ok {
@@ -23,12 +25,15 @@ func golferHideBannerPOST(w http.ResponseWriter, r *http.Request) {
 	if valid {
 		golfer := session.Golfer(r)
 
-		if _, ok := golfer.Settings["hide-banner"]; !ok {
-			golfer.Settings["hide-banner"] = map[string]any{}
+		if _, err := session.Database(r).Exec(
+			`INSERT INTO hidden_banners (hide_key, user_id)
+			      VALUES                ($1,       $2)
+			 ON CONFLICT DO NOTHING`,
+			banner,
+			golfer.ID,
+		); err != nil {
+			panic(err)
 		}
-		golfer.Settings["hide-banner"][banner] = true
-
-		golfer.SaveSettings(session.Database(r))
 	}
 
 	http.Redirect(w, r, r.FormValue("path"), http.StatusFound)

--- a/routes/render.go
+++ b/routes/render.go
@@ -46,7 +46,7 @@ func render(w http.ResponseWriter, r *http.Request, name string, data ...any) {
 		Request                            *http.Request
 		Settings                           []*config.Setting
 	}{
-		Banners:     banners(theGolfer, time.Now().UTC()),
+		Banners:     unHiddenBanners(theGolfer, time.Now().UTC()),
 		Cheevos:     config.CheevoTree,
 		CSS:         []cssLink{{config.Assets["css/common/base.css"], ""}},
 		Data:        data[0],

--- a/sql/a-schema.sql
+++ b/sql/a-schema.sql
@@ -133,11 +133,13 @@ CREATE TABLE users (
     CHECK (login ~ '^[A-Za-z0-9_-]{1,42}$') -- 1 - 42 ASCII word/hyphen chars.
 );
 
--- A row ("latest-hole-24-game", 12345) says user 12345 already dismissed the
--- banner saying that 24-game is the latest hole.
+-- A row ("latest-hole-24-game", 12345, delete) says user 12345 already dismissed
+-- the banner saying that 24-game is the latest hole, but this dismissal should
+-- disappear at the time given by the `delete` timestamp.
 CREATE TABLE hidden_banners (
     hide_key text NOT NULL,
     user_id int REFERENCES users(id) ON DELETE CASCADE,
+    delete timestamp,
     PRIMARY KEY (hide_key, user_id)
 );
 

--- a/sql/a-schema.sql
+++ b/sql/a-schema.sql
@@ -133,6 +133,14 @@ CREATE TABLE users (
     CHECK (login ~ '^[A-Za-z0-9_-]{1,42}$') -- 1 - 42 ASCII word/hyphen chars.
 );
 
+-- A row ("latest-hole-24-game", 12345) says user 12345 already dismissed the
+-- banner saying that 24-game is the latest hole.
+CREATE TABLE hidden_banners (
+    hide_key text NOT NULL,
+    user_id int REFERENCES users(id) ON DELETE CASCADE,
+    PRIMARY KEY (hide_key, user_id)
+);
+
 CREATE TABLE authors (
     hole    hole NOT NULL,
     user_id int  REFERENCES users(id) ON DELETE CASCADE,
@@ -328,6 +336,7 @@ GRANT SELECT ON stable_passing_solutions TO "code-golf";
 
 -- Tables.
 GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE authors         TO "code-golf";
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE hidden_banners  TO "code-golf";
 GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE connections     TO "code-golf";
 GRANT SELECT, INSERT, UPDATE         ON TABLE discord_records TO "code-golf";
 GRANT SELECT, INSERT, UPDATE         ON TABLE discord_state   TO "code-golf";

--- a/views/html/header.html
+++ b/views/html/header.html
@@ -113,10 +113,6 @@
 </header>
 
 {{ range .Banners }}
-    {{ if and $.Golfer (index $.Golfer.Settings "hide-banner" .HideKey) }}
-        {{ continue }}
-    {{ end }}
-
     <div class="{{ .Type }}">
     {{ if eq .Type "alert" }}
         {{ svg "exclamation-circle" }}


### PR DESCRIPTION
Two potential behavior changes:
1. Remove the data on users' hidden banners after 60 days. (so they will re-show)
2. Allow users to hide date-based cheevo banners.

On its own, (1) would have no visible effect to users. The existing banners are all about "X is the latest hole" or "try the upcoming hole X", and holes get cycled within 60 days. However, it is useful in the context of (2) from the following scenario: I'm too busy to do the 4th of July cheevo rn, I just want to update some particular solution quick. But then the next year rolls around and the 4th of July cheevo reminder would be helpful.

Picture of change. Before PR, there was no X button on the first banner

![image](https://github.com/user-attachments/assets/2a3f172b-5475-4bee-9bb5-48e6f08bff7f)

## Migration: 2 steps

Copy existing hide-banner settings to a table
```sql
INSERT INTO hidden_banners
	(hide_key, user_id, delete)
SELECT
	jsonb_object_keys(settings::jsonb->'hide-banner') AS hide_key,
	id AS user_id,
	TIMEZONE('UTC', NOW()) + INTERVAL '60 days' AS delete
FROM users;
```

Delete the 'hide-banner' property from the JSON settings
```sql
UPDATE users SET settings = settings - 'hide-banner';
```