### PR TITLE
Tighten up Clojure implicit output prevention

### DIFF
--- a/hole/play.go
+++ b/hole/play.go
@@ -315,7 +315,10 @@ func play(
 		// Appending (print) prevents implicit output of the last form, if it
 		// is not nil. This seems to be a quirk of the Babashka interpreter
 		// that only occurs when providing code via a command line argument.
-		code += "(print)"
+		//
+		// Add a newline in to avoid commenting it out via ;, and
+		// do it twice to avoid commenting it out via #_.
+		code += "\n(print)(print)"
 	case "go":
 		// Prevent trivial quines. Error out and return early.
 		if hole.ID == "quine" && strings.Contains(code, "//go:embed") {


### PR DESCRIPTION
It was possible to add a comment to the end of Clojure code and re-enable implicit output.

I haven't found a way to actually exploit this in any hole to save bytes, since the implicit output is printed as if with `pr`, so eg strings are quoted. I don't think it can be used to help with quine, for example.

I discovered it when I accidentally left a comment at the end of my code, and I was confused.

This adds a newline to render `;` comments ineffective, and adds an additional `(print)` so that `#_` will only comment out the first form.