### PR TITLE
Disallow Uiua's implicit output for Quine

### DIFF
--- a/hole/play.go
+++ b/hole/play.go
@@ -381,8 +381,8 @@ func play(
 		}
 	case "uiua":
 		// Prevent trivial quines. Error out and return early.
-		if hole.ID == "quine" && len(code) > 0 && !strings.Contains(code, "&p") {
-			run.Stderr = `Quine in Uiua must use "&p".`
+		if hole.ID == "quine" && len(code) > 0 && !strings.Contains(code, "&p") || strings.Contains(code, `"&p"`) {
+			run.Stderr = "Quine in Uiua must use `&p` (without backticks) and cannot be enclosed in double quotes."
 			return nil
 		}
 	}

--- a/hole/play.go
+++ b/hole/play.go
@@ -381,8 +381,8 @@ func play(
 		}
 	case "uiua":
 		// Prevent trivial quines. Error out and return early.
-		if hole.ID == "quine" && len(code) > 0 && !strings.Contains(code, "&p") || strings.Contains(code, `"&p"`) {
-			run.Stderr = "Quine in Uiua must use `&p` (without backticks) and cannot be enclosed in double quotes."
+		if hole.ID == "quine" && len(code) > 0 && (!strings.Contains(code, "&p") || strings.Contains(code, `"`)) {
+			run.Stderr = "Quine in Uiua must use `&p` (without backticks) and cannot contain double quotes."
 			return nil
 		}
 	}

--- a/hole/play.go
+++ b/hole/play.go
@@ -379,6 +379,12 @@ func play(
 			run.Stderr = `Quine in TeX must have at least one '\' character.`
 			return nil
 		}
+	case "uiua":
+		// Prevent trivial quines. Error out and return early.
+		if hole.ID == "quine" && len(code) > 0 && !strings.Contains(code, "&p") {
+			run.Stderr = `Quine in Uiua must use "&p".`
+			return nil
+		}
 	}
 
 	var stderr, stdout bytes.Buffer


### PR DESCRIPTION
The notorious two-byte quine's still a thing with Uiua.