### PR TITLE
Account for padding in diff view

### DIFF
--- a/js/_diff.tsx
+++ b/js/_diff.tsx
@@ -173,11 +173,12 @@ function makeCols(isArgDiff: boolean, maxLineNum: number, argv: string[]) {
     const col       = (width: number) => <col style={`width:${width}px`}/>;
     const cols      = [];
     const numLength = String(maxLineNum).length + 1;
-    const charWidth = 11;
+    const charWidth = 12;
 
     if (isArgDiff) {
         const longestArgLength = Math.max(6, ...argv.map(arg => arg.length));
-        cols.push(col(Math.min(longestArgLength * charWidth + 1, 350)));
+        const estimatedWidth = longestArgLength * charWidth + 2 * 8; // Width of characters + padding
+        cols.push(col(Math.min(estimatedWidth, 350)));
     }
     else {
         cols.push(col(numLength * charWidth));


### PR DESCRIPTION
Attempt to fix #853. Copying over my comment:

This seems to be because the width of the column is computed as `n * 11 + 1`, where `n` is the number of characters. Here it gives a width of `8 * 11 + 1 = 89px`, counting both spaces.

However, the characters have a width of `9.6` (in my browser, the ascii characters are displayed in `Source Code Pro` and the musical symbols fall back to `Deja Vu Sans Mono`). This makes the space required `8 * 9.6 = 76.8px`. Adding `8px` padding on both sides, we get `92.8px`, which makes our argument wrap.

It would make more sense to compute the width of the column as `n * 11 + 2 * 8` to account for padding. To make sure even larger characters fit, we could also increase the estimated width of a single character to 12. Of course, this is still a heuristic and could fail on characters like `🖳` (21px) or `﷽` (96px)