### PR TITLE
Update Hare's source of release announcements

### DIFF
--- a/latest-langs
+++ b/latest-langs
@@ -45,7 +45,7 @@ constant %paths = (
     'GolfScript'   => 'github.com/lynn/golfscript/tree/code-golf',
     'Groovy'       => 'en.wikipedia.org/wiki/Apache_Groovy',
     'Harbour'      => 'github.com/harbour/core',
-    'Hare'         => 'git.sr.ht/~sircmpwn/hare/refs',
+    'Hare'         => 'lists.sr.ht/~sircmpwn/hare-announce?search=release',
     'Haskell'      => 'pkgs.alpinelinux.org/package/edge/community/x86_64/ghc',
     'Haxe'         => 'github.com/HaxeFoundation/haxe/releases/latest',
     'Hexagony'     => 'github.com/SirBogman/Hexagony',
@@ -111,8 +111,8 @@ for %langs{ @langs || * }:p.sort: *.key.fc -> (:key($name), :value(%lang)) {
         when / 'endoflife'      / { $res.&from-json[0]<latest> }
         when / 'fennel-lang'    / { $res ~~ / 'downloads/fennel-' <(<ver>)> / }
         when / 'golfscript.com' / { $res ~~ / '(Alpha)' .+? <(<ver>)> / }
-        when / 'git.sr.ht'      / { $res ~~ / 'stable release' .+? <(<ver>)> / }
         when / 'jmvdveer'       / { $res ~~ / 'algol68g-' <(<ver>)> / }
+        when / 'lists.sr.ht'    / { $res ~~ / 'Hare ' <(<ver>)> ' release' / }
         when / 'npmjs.org'      / { $res.&from-json[0]<version> }
         when / 'pypi.org'       / { $res.&from-json<info><version> }
         when / 'regina-rexx'    / { $res ~~ / '<b>Current</b> ' <(<ver>)> / }


### PR DESCRIPTION
Currently, the script throws an exception upon reaching Hare, and terminates.

```bash
oh@Yewzir:~/code-golf$ ./latest-langs Hare
502 Bad Gateway
  in method request at /home/oh/.rakubrew/versions/moar-2024.06/install/share/perl6/site/sources/9FC2343A87BDDB635A0B9DEF0D5BB8AFBC23C471 (HTTP::Tiny) line 356
  in method request at /home/oh/.rakubrew/versions/moar-2024.06/install/share/perl6/site/sources/9FC2343A87BDDB635A0B9DEF0D5BB8AFBC23C471 (HTTP::Tiny) line 238
  in method get at /home/oh/.rakubrew/versions/moar-2024.06/install/share/perl6/site/sources/9FC2343A87BDDB635A0B9DEF0D5BB8AFBC23C471 (HTTP::Tiny) line 79
  in code  at ./latest-langs line 104
  in sub MAIN at ./latest-langs line 102
  in block <unit> at ./latest-langs line 5
```

Besides, I think the replacement provides a bit more accuracy since it only targets release announcement titles instead of looking for the current string in a rather large block of text.

```bash
oh@Yewzir:~/code-golf$ ./latest-langs Hare
        Hare      0.24.2 → 0.24.2
```