### PR TITLE
Enforce additional Calendar tests

### DIFF
--- a/config/data/holes.toml
+++ b/config/data/holes.toml
@@ -401,9 +401,8 @@ category = 'Transform'
 synopsis = 'Print calendars for given months in given years.'
 preamble = '''
 <p>
-    Given a <b>month</b> and a <b>year</b>, print that month's calendar for
-    each argument <code><b>MM YYYY</b></code>. Monday marks the first day of
-    the week.
+    Given a month and a year, print that month's calendar for each argument
+    <code><b>MM YYYY</b></code>. Monday marks the first day of the week.
 
 <p>
     For example, <code>03 2023</code> refers to the month of March in 2023.

--- a/hole/calendar.go
+++ b/hole/calendar.go
@@ -2,6 +2,7 @@ package hole
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"strings"
 	"time"
 )
@@ -16,7 +17,7 @@ func generate(s string) string {
 
 	first, total := int((time.Date(year, time.Month(month), 1, 0, 0, 0, 0, time.UTC).Weekday()-1+7)%7), time.Date(year, time.Month(month)+1, 0, 0, 0, 0, 0, time.UTC).Day()
 
-	for i := 0; i < first; i++ {
+	for range first {
 		calendar.WriteString("   ")
 	}
 
@@ -35,15 +36,39 @@ func generate(s string) string {
 	return calendar.String()
 }
 
-func calendar() []Run {
-	tests := make([]test, 0, 31)
+func isLeap(year int) bool {
+	return (year%4 != 0 && year%100 == 0) || year%400 != 0
+}
 
-	for range 31 {
-		argument := fmt.Sprintf("%.2d %d", randInt(1, 12), randInt(1800, 2400))
+func calendar() []Run {
+	tests := make([]test, 0, 50)
+
+	for i := 0; i < 50; {
+		var argument strings.Builder
+
+		month, year := rand.IntN(12), randInt(1800, 2400)
+
+		if i < 12 {
+			// Enforce at least one calendar for every month of the year, in random years.
+			month = i
+		} else if i < 18 {
+			// Enforce at least six calendars for months (five random, one February) in random leap years.
+			if i < 13 {
+				month = 1
+			}
+
+			if !isLeap(year) {
+				continue
+			}
+		}
+
+		i++
+
+		argument.WriteString(fmt.Sprintf("%.2d %d", month+1, year))
 
 		tests = append(tests, test{
-			argument,
-			generate(argument),
+			argument.String(),
+			generate(argument.String()),
 		})
 	}
 


### PR DESCRIPTION
This commit adds some additional tests to the Calendar hole, those being:

- Enforce at least one calendar for every month of the year, in random years.
- Enforce at least six calendars for months in random leap years, five of which are random and the other guarantees February.

The remainder of the tests still generates just random months in random years, but we're pretty much handling all of the possibilities now, I think. Finally, the number of command-line arguments was increased to fifty.