### PR TITLE
Update `latest-langs` (AWK)

### DIFF
--- a/latest-langs
+++ b/latest-langs
@@ -14,6 +14,7 @@ constant %paths = (
     'APL'          => 'dyalog.com/download-zone.htm?p=download',
     'Arturo'       => 'github.com/arturo-lang/arturo/releases/latest',
     'Assembly'     => 'registry.npmjs.org/@defasm/core/latest',
+    'AWK'          => 'ftp.gnu.org/gnu/gawk/?C=M;O=D',
     'Bash'         => 'en.wikipedia.org/wiki/Bash_(Unix_shell)',
     'BASIC'        => 'en.wikipedia.org/wiki/FreeBASIC',
     'Befunge'      => 'github.com/VorpalBlade/cfunge',
@@ -111,6 +112,7 @@ for %langs{ @langs || * }:p.sort: *.key.fc -> (:key($name), :value(%lang)) {
         when / 'dyalog.com'     / { $res ~~ / <(<ver>)> ' for Linux (DEB)' / }
         when / 'endoflife'      / { $res.&from-json[0]<latest> }
         when / 'fennel-lang'    / { $res ~~ / 'downloads/fennel-' <(<ver>)> / }
+        when / 'ftp.gnu.org'    / { $res ~~ / 'gawk-' <(<ver>)> '.tar.xz' / }
         when / 'golfscript.com' / { $res ~~ / '(Alpha)' .+? <(<ver>)> / }
         when / 'jmvdveer'       / { $res ~~ / 'algol68g-' <(<ver>)> / }
         when / 'lists.sr.ht'    / { $res ~~ / 'Hare ' <(<ver>)> ' release' / }


### PR DESCRIPTION
This retrieves the latest version identifier for AWK, finally.