### PR TITLE
Prevent ROT13's arguments from starting with `@`

### DIFF
--- a/hole/rot13.go
+++ b/hole/rot13.go
@@ -5,8 +5,15 @@ import "strings"
 func rot13() []Run {
 	tests := make([]test, 0, 100)
 
-	for range 100 {
+	for i := 0; i < 100; {
 		argument := generateSequence()
+
+		// Prevent arguments from starting with '@' because some languages cannot handle them correctly.
+		if argument[0] == '@' {
+			continue
+		}
+
+		i++
 
 		tests = append(tests, test{
 			argument,


### PR DESCRIPTION
Some languages cannot handle them correctly. Known to date are D and Kotlin.