### PR TITLE
Add Rosetta Code link to ROT13 hole

### DIFF
--- a/config/data/holes.toml
+++ b/config/data/holes.toml
@@ -3319,6 +3319,7 @@ preamble = '''
 category = 'Transform'
 links = [
     { name = 'Wikipedia', url = '//en.wikipedia.org/wiki/ROT13' },
+    { name = 'Rosetta Code', url = '//rosettacode.org/wiki/Rot-13' },
 ]
 released = 2025-01-05
 synopsis = 'Encode or decode ROT13 sequences.'


### PR DESCRIPTION
The latest [ROT13 hole](https://code.golf/rot13) seems to be missing a link to the associated [Rosetta Code page](https://rosettacode.org/wiki/Rot-13).