### PR TITLE
Calendar: Add external links

### DIFF
--- a/config/data/holes.toml
+++ b/config/data/holes.toml
@@ -398,6 +398,10 @@ preamble = '''
 [Calendar]
 experiment = 908
 category = 'Transform'
+links = [
+    { name = 'Rosetta Code', url = '//rosettacode.org/wiki/Calendar' },
+    { name = 'Wikipedia',    url = '//en.wikipedia.org/wiki/Gregorian_calendar' },
+]
 synopsis = 'Print calendars for given months in given years.'
 preamble = '''
 <p>


### PR DESCRIPTION
I'm likely to fire an update soon to also include months and years in the output, be more calendary.

```
     March 2023
Mo Tu We Th Fr Sa Su
       1  2  3  4  5
 6  7  8  9 10 11 12
13 14 15 16 17 18 19
20 21 22 23 24 25 26
27 28 29 30 31
```