### PR TITLE
Fix VimL

### DIFF
--- a/langs/viml/viml.c
+++ b/langs/viml/viml.c
@@ -55,7 +55,7 @@ int main(int argc, char* argv[]) {
             ERR_AND_EXIT("fputc");
     }
 
-    if (fputs("]", fp))
+    if (fputs("]\n", fp))
         ERR_AND_EXIT("fputs");
 
     char stderr_buf[4096], stdout_buf[4096];


### PR DESCRIPTION
Currently, VimL requires at least one newline before anything else. The sample code actually has such newline, but is provided by a comment (which isn't executed) and thus made it look like everything was fine. It wasn't, but now it is.