### PR TITLE
Update `latest-langs` (Rexx)

### DIFF
--- a/latest-langs
+++ b/latest-langs
@@ -77,7 +77,7 @@ constant %paths = (
     'Racket'       => 'github.com/racket/racket/releases/latest',
     'Raku'         => 'github.com/rakudo/rakudo/releases/latest',
     'Rebol'        => 'en.wikipedia.org/wiki/Rebol',
-    'Rexx'         => 'regina-rexx.sourceforge.io',
+    'Rexx'         => 'sourceforge.net/projects/regina-rexx/files',
     'Rockstar 2'   => 'github.com/RockstarLang/rockstar/releases/latest',
     'Ruby'         => 'endoflife.date/api/ruby.json',
     'Rust'         => 'en.wikipedia.org/wiki/Rust_(programming_language)',
@@ -123,7 +123,6 @@ for %langs{ @langs || * }:p.sort: *.key.fc -> (:key($name), :value(%lang)) {
         when / 'npmjs.org'      / { $res.&from-json[0]<version> }
         when / 'picat-lang.org' / { $res ~~ / 'Version ' <(<ver>)> / }
         when / 'pypi.org'       / { $res.&from-json<info><version> }
-        when / 'regina-rexx'    / { $res ~~ / '<b>Current</b> ' <(<ver>)> / }
         when / 'sourceforge'    / { $res ~~ / 'Latest' .+? <(<ver>)> / }
         when / 'swi-prolog'     / { $res ~~ / 'stable' .+? <(<ver>)> / }
         when / 'github.com'     / {


### PR DESCRIPTION
I've been observing for a while now, and it's always something with the current source.

```bash
503 Service Temporarily Unavailable
  in method request at /home/oh/.rakubrew/versions/moar-2024.06/install/share/perl6/site/sources/9FC2343A87BDDB635A0B9DEF0D5BB8AFBC23C471 (HTTP::Tiny) line 356
  in method request at /home/oh/.rakubrew/versions/moar-2024.06/install/share/perl6/site/sources/9FC2343A87BDDB635A0B9DEF0D5BB8AFBC23C471 (HTTP::Tiny) line 238
  in method get at /home/oh/.rakubrew/versions/moar-2024.06/install/share/perl6/site/sources/9FC2343A87BDDB635A0B9DEF0D5BB8AFBC23C471 (HTTP::Tiny) line 79
  in code  at ./latest-langs line 110
  in sub MAIN at ./latest-langs line 108
  in block <unit> at ./latest-langs line 5
```