### PR TITLE
Output to stdout. Errput to stderr.

### DIFF
--- a/langs/berry/berry.c
+++ b/langs/berry/berry.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "be_vm.h"
 #include "berry.h"
@@ -10,16 +11,19 @@ static int handle_result(bvm *vm, int res) {
     case BE_OK: /* everything is OK */
         return 0;
     case BE_EXCEPTION: /* uncaught exception */
+        dup2(2, 1);
         be_dumpexcept(vm);
         return 1;
     case BE_EXIT: /* return exit code */
         return be_toindex(vm, -1);
     case BE_IO_ERROR:
+        dup2(2, 1);
         be_writestring("error: "); 
         be_writestring(be_tostring(vm, -1));
         be_writenewline();
         return -2;
     case BE_MALLOC_FAIL:
+        dup2(2, 1);
         be_writestring("error: memory allocation failed.\n");
         return -1;
     default: /* unknown result */


### PR DESCRIPTION
This commit relates to #1181 and puts an end to Berry printing errors and/or warnings on stdout.

Before:

![before](https://github.com/user-attachments/assets/eea2b40f-7652-406f-8d22-bc0077f64d9b)

🤮

After:

![after](https://github.com/user-attachments/assets/bbb0a403-3488-45c1-9210-c5ec0b4db459)

🥳