### PR TITLE
Fix Snake hole

### DIFF
--- a/hole/snake.go
+++ b/hole/snake.go
@@ -58,14 +58,19 @@ func printTrail(s string) string {
 	xMin, xMax, yMin, yMax := 0, 0, 0, 0
 
 	for i := range visited {
-		switch true {
-		case i[0] < xMin:
+		if i[0] < xMin {
 			xMin = i[0]
-		case i[0] > xMax:
+		}
+
+		if i[0] > xMax {
 			xMax = i[0]
-		case i[1] < yMin:
+		}
+
+		if i[1] < yMin {
 			yMin = i[1]
-		case i[1] > yMax:
+		}
+
+		if i[1] > yMax {
 			yMax = i[1]
 		}
 	}


### PR DESCRIPTION
As pointed out by @GolfingSuccess, there's currently an issue with the `switch` statement in the `printTrail` method where the last column in the expected result is occasionally chopped off. He's correct, the `switch` statement does not allow for assigning multiple variables. As such, we've replaced the `switch` statement with multiple `if` statements to allow multiple assignments.