### PR TITLE
Build Ruby with LTO from the LLVM gold plugin interface, and set `RUBY_THREAD_VM_STACK_SIZE` to 500 million

### DIFF
--- a/config/data/langs.toml
+++ b/config/data/langs.toml
@@ -836,6 +836,7 @@ func main() {
 [GolfScript]
 args       = [ '/usr/bin/golfscript', '-n', '-e', '$code', '--' ]
 args-quine = [ '/usr/bin/golfscript', '-n', '-e', '$code', '-q', '--' ]
+env        = [ 'RUBY_THREAD_VM_STACK_SIZE=500000000' ]
 size       = '33.2 MiB'
 version    = '6155e9f'
 website    = 'https://golfscript.com/golfscript/'
@@ -1031,6 +1032,7 @@ example    = '''
 
 [iogii]
 args       = [ '/usr/bin/iogii', '-' ]
+env        = [ 'RUBY_THREAD_VM_STACK_SIZE=500000000' ]
 experiment = 1770
 size       = '34.1 MiB'
 version    = '0.2'
@@ -1594,6 +1596,7 @@ end
 
 [Ruby]
 args    = [ '/usr/bin/ruby', '-' ]
+env     = [ 'RUBY_THREAD_VM_STACK_SIZE=500000000' ]
 size    = '33.2 MiB'
 version = '3.4.2'
 website = 'https://www.ruby-lang.org'

--- a/langs/golfscript/Dockerfile
+++ b/langs/golfscript/Dockerfile
@@ -1,17 +1,14 @@
 FROM alpine:3.21 AS builder
 
-RUN apk add --no-cache curl
+ENV VER=6155e9f
 
-ENV VERSION=6155e9f
+RUN wget -O- https://github.com/lynn/golfscript/tarball/$VER \
+  | tar xz --strip-components 1
 
-RUN curl -L https://github.com/lynn/golfscript/tarball/$VERSION | tar xz \
- && cd /lynn-golfscript-$VERSION && mv golfscript.rb /
-
-# Make executable.
-RUN chmod +x /golfscript.rb
+RUN chmod +x golfscript.rb
 
 # Shebangs can only have one operand, "encoding ASCII" → "encoding=ASCII".
-RUN sed -i '1c#!/usr/bin/ruby --encoding=ASCII-8BIT' /golfscript.rb
+RUN sed -i '1c#!/usr/bin/ruby --encoding=ASCII-8BIT' golfscript.rb
 
 FROM codegolf/lang-ruby
 

--- a/langs/iogii/Dockerfile
+++ b/langs/iogii/Dockerfile
@@ -13,9 +13,9 @@ RUN gcc -Wall -Werror -Wextra -o /usr/bin/iogii -s -static iogii.c
 
 FROM codegolf/lang-ruby
 
-COPY --from=0 /usr/bin/env   \
-              /usr/bin/iogii /usr/bin/
-COPY --from=0 /usr/local/bin /usr/local/bin
+COPY --from=0 /usr/bin/env         \
+              /usr/bin/iogii       /usr/bin/
+COPY --from=0 /usr/local/bin/iogii /usr/local/bin/
 
 FROM codegolf/lang-base
 

--- a/langs/ruby/Dockerfile
+++ b/langs/ruby/Dockerfile
@@ -1,54 +1,57 @@
 FROM alpine:3.21 AS builder
 
-RUN apk add --no-cache build-base clang curl openssl-dev yaml-dev
+RUN apk add --no-cache bison clang curl git gmp-dev make mpfr-dev texinfo
 
 # Also rebuild GolfScript, iogii.
-RUN curl https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.2.tar.xz | tar xJ
+ENV VER=3.4.2
 
-# Clang produces the same size binary as using LTO with GCC, but GCC+LTO leads
-# to an issue where the stack size available for recursion is significantly
-# reduced. It may be worth trying to enable LTO for Clang. That appears to
-# require building the LLVMgold plugin.
-RUN cd ruby-*              \
- && CC=clang ./configure   \
+RUN git clone --depth 1 --progress git://sourceware.org/git/binutils-gdb.git binutils
+
+WORKDIR /gold
+
+RUN CC='clang' CXX='clang++' \
+    ../binutils/configure    \
+    --disable-werror         \
+    --enable-gold            \
+    --enable-plugins         \
+ && make -j`nproc` all-gold  \
+ && mv gold/ld-new /usr/bin/ld
+
+WORKDIR /ruby
+
+RUN curl -#L https://cache.ruby-lang.org/pub/ruby/3.4/ruby-$VER.tar.xz \
+  | tar xJ --strip-components 1
+
+RUN CC='clang' ./configure \
     --disable-install-doc  \
     --disable-jit-support  \
     --prefix=/usr          \
+    --without-gmp          \
  && make -j`nproc` install \
  && strip -s /usr/bin/ruby
 
 # Remove some default gems we don't need.
 RUN cd /usr/lib/ruby/3.4.0 && rm -rf \
                       English.rb     \
-                      benchmark      \
-                      benchmark.rb   \
-                      bundler        \
-                      bundler.rb     \
+                      benchmark*     \
+                      bundler*       \
     x86_64-linux-musl/bundler.so     \
-                      coverage       \
-                      coverage.rb    \
+                      coverage*      \
     x86_64-linux-musl/coverage.so    \
-                      csv            \
-                      csv.rb         \
+                      csv*           \
                       debug.rb       \
-                      fiddle         \
-                      fiddle.rb      \
+                      fiddle*        \
     x86_64-linux-musl/fiddle.so      \
                       mkmf.rb        \
-                      objspace       \
-                      objspace.rb    \
+                      objspace*      \
     x86_64-linux-musl/objspace.so    \
-                      openssl        \
-                      openssl.rb     \
+                      openssl*       \
     x86_64-linux-musl/openssl.so     \
-                      psych          \
-                      psych.rb       \
+                      psych*         \
     x86_64-linux-musl/psych.so       \
-                      rdoc           \
-                      rdoc.rb        \
+                      rdoc*          \
     x86_64-linux-musl/rdoc.so        \
-                      ripper         \
-                      ripper.rb      \
+                      ripper*        \
     x86_64-linux-musl/ripper.so
 
 FROM codegolf/lang-base


### PR DESCRIPTION
In line with the request in #1770, this commit mainly ensures that significant stack size limits are imposed for recursion in Ruby and Ruby-driven languages.