### PR TITLE
Suppress the implicit output on each hole in Racket

### DIFF
--- a/hole/play.go
+++ b/hole/play.go
@@ -286,11 +286,9 @@ func play(
 	case "php":
 		code = "<?php " + code + " ;"
 	case "racket":
-		if hole.ID == "quine" {
-			// Inserting `(current-print (λ (x) (void)))` before the code in the editor
-			// suppresses the implicit output of expressions in Racket.
-			code = "(current-print (λ (x) (void)))" + code
-		}
+		// Inserting `(current-print (λ (x) (void)))` before the code in the editor
+		// suppresses the implicit output of expressions in Racket.
+		code = "(current-print (λ (x) (void)))" + code
 	case "tex":
 		// Prevent trivial quines. Error out and return early.
 		if hole.ID == "quine" && !strings.Contains(code, `\`) {


### PR DESCRIPTION
This commit suppresses implicit output of expressions on each hole in Racket, similar to Clojure and PHP.