### PR TITLE
Add some missing banners regarding the implicit output disabled for the Quine hole

### DIFF
--- a/views/html/hole-info.html
+++ b/views/html/hole-info.html
@@ -7,10 +7,10 @@
             syscalls</a> to write output.
     </div>
 {{ if eq .Data.Hole.ID "quine" }}
-    <div class="hide info golfscript kotlin r">
+    <div class="hide info cjam golfscript kotlin r racket">
         Implicit output is disabled for this hole.
     </div>
-    <div class="hide info k">
+    <div class="hide info 05ab1e jq k stax uiua">
         Implicit output is disabled for this hole. Code must end with a newline.
     </div>
     <div class="hide info powershell">


### PR DESCRIPTION
iogii and TeX are still missing. I haven't found them yet, so I can't say at this point whether a newline is needed. Actually I doubt whether TeX needs such a banner, but the code below made me suspect that it does.

https://github.com/code-golf/code-golf/blob/64985f6ee114f75775764cfae8973ae1630d3443/hole/play.go#L287-L292