### PR TITLE
Strengthen leap year testing in Calendar

### DIFF
--- a/hole/calendar.go
+++ b/hole/calendar.go
@@ -49,17 +49,25 @@ var _ = answerFunc("calendar", func() []Answer {
 		month, year := rand.IntN(12), randInt(1800, 2400)
 
 		if i < 12 {
-			// Enforce at least one calendar for every month of the year, in random years.
+			// Enforce at least one calendar for every month of the year in random non-leap years.
 			month = i
+			
+			if isLeap(year) {
+				continue
+			}
 		} else if i < 18 {
-			// Enforce at least six calendars for months (five random, one February) in random leap years.
-			if i < 13 {
+			// Enforce at least six calendars for months (four random, two February) in random leap years.
+			if i < 14 {
 				month = 1
 			}
 
 			if !isLeap(year) {
 				continue
 			}
+		} else if i < 25 {
+			// Enforce February in each century
+			month = 1
+			year = 1800 + 100*(i-18)
 		}
 
 		i++

--- a/hole/calendar.go
+++ b/hole/calendar.go
@@ -51,7 +51,7 @@ var _ = answerFunc("calendar", func() []Answer {
 		if i < 12 {
 			// Enforce at least one calendar for every month of the year in random non-leap years.
 			month = i
-			
+
 			if isLeap(year) {
 				continue
 			}


### PR DESCRIPTION
The leap year check is now correct, but now it's possible to pass off just testing divisibility by 4. This adds checks for each February in each century year, among other things.