### PR TITLE
Start line numbers from 0 for ><>

### DIFF
--- a/js/_codemirror.ts
+++ b/js/_codemirror.ts
@@ -119,15 +119,15 @@ export const extensions : { [key: string]: any } = {
             { key: 'Tab',   run: insertTab, shift: indentLess },
             { key: 'Mod-/', run: toggleComment },
         ]),
-        highlightWhitespace()
+        highlightWhitespace(),
     ],
     'lineNumbers': lineNumbers(),
     'zeroIndexedLineNumbers': lineNumbers(
         {
             formatNumber(num: number) {
-                return `${num - 1}`
-            }
-        }
+                return `${num - 1}`;
+            },
+        },
     ),
     'bracketMatching': bracketMatching(),
     'vim': vim({ status: true }),

--- a/js/_codemirror.ts
+++ b/js/_codemirror.ts
@@ -119,9 +119,16 @@ export const extensions : { [key: string]: any } = {
             { key: 'Tab',   run: insertTab, shift: indentLess },
             { key: 'Mod-/', run: toggleComment },
         ]),
-        highlightWhitespace(),
-        lineNumbers(),
+        highlightWhitespace()
     ],
+    'lineNumbers': lineNumbers(),
+    'zeroIndexedLineNumbers': lineNumbers(
+        {
+            formatNumber(num: number) {
+                return `${num - 1}`
+            }
+        }
+    ),
     'bracketMatching': bracketMatching(),
     'vim': vim({ status: true }),
 

--- a/js/_hole-common.tsx
+++ b/js/_hole-common.tsx
@@ -198,7 +198,7 @@ export function setState(code: string, editor: EditorView) {
                 extensions[lang as keyof typeof extensions] ?? [],
                 // These languages shouldn't match brackets.
                 ['fish', 'hexagony'].includes(lang)
-                    ? [] : extensions.bracketMatching,
+                    ? [extensions.zeroIndexedLineNumbers] : [extensions.lineNumbers, extensions.bracketMatching],
                 // These languages shouldn't wrap lines.
                 ['assembly', 'fish', 'hexagony'].includes(lang)
                     ? [] : EditorView.lineWrapping,

--- a/js/_hole-common.tsx
+++ b/js/_hole-common.tsx
@@ -198,7 +198,7 @@ export function setState(code: string, editor: EditorView) {
                 extensions[lang as keyof typeof extensions] ?? [],
                 // These languages shouldn't match brackets.
                 ['fish', 'hexagony'].includes(lang)
-                    ? [extensions.zeroIndexedLineNumbers] : [extensions.lineNumbers, extensions.bracketMatching],
+                    ? extensions.zeroIndexedLineNumbers : [extensions.lineNumbers, extensions.bracketMatching],
                 // These languages shouldn't wrap lines.
                 ['assembly', 'fish', 'hexagony'].includes(lang)
                     ? [] : EditorView.lineWrapping,


### PR DESCRIPTION
In ><>, the coordinates of each cell is important and they start from 0. So it is more convenient to have the line numbering match so you know what line the coordinates refer to. 