### PR TITLE
Allow not using cache when building the image for a language

### DIFF
--- a/build-langs
+++ b/build-langs
@@ -2,7 +2,7 @@
 
 use TOML::Thumb;
 
-unit sub MAIN(Bool :$no-push, *@langs);
+unit sub MAIN(Bool :$no-cache, Bool :$no-push, *@langs);
 
 chdir $*PROGRAM.dirname;
 
@@ -25,9 +25,15 @@ for %langs{ @langs || * }:p.sort: *.key.fc -> (:key($name), :value(%lang)) {
     my $id  = id($name);
     my $img = "codegolf/lang-$id";
 
-    # Tag the builder stage so "docker system prune" won't remove it.
-    run «docker buildx build -t "{$img}-builder" --pull --target builder "langs/$id"»;
-    run «docker buildx build -t $img "langs/$id"»;
+    if !$no-cache {
+        # Tag the builder stage so "docker system prune" won't remove it.
+        run «docker buildx build -t "{$img}-builder" --pull --target builder "langs/$id"»;
+    }
+
+    run <docker buildx build>,
+         ( '--no-cache' when $no-cache ),
+         '--tag', $img,
+         "langs/$id";
 
     # Size.
     my $proc = run :out,


### PR DESCRIPTION
I find over and over again that sometimes, often even, it is desirable to start a compilation from scratch, i.e. without cache. Well, just `langs/$id/Dockerfile`. That's why I added the `--no-cache` flag, just like Docker, as an optional flag to the build script. I don't think that bothers anyone or anything.