### PR TITLE
Preserve the order in which languages are specified to be built

### DIFF
--- a/build-langs
+++ b/build-langs
@@ -21,7 +21,7 @@ run <docker buildx build>,
     '--tag',    'codegolf/lang-base',
     '.';
 
-for %langs{ @langs || * }:p.sort: *.key.fc -> (:key($name), :value(%lang)) {
+for @langs Z %langs{ @langs } -> ($name, %lang) {
     my $id  = id($name);
     my $img = "codegolf/lang-$id";
 


### PR DESCRIPTION
There are already a number of scenarios where multiple languages use a different base language. It is essential that when something changes in such a base language, it is built before the dependents. For example: if C, B, F, and A depend on D and D gets an update, then only D and F are up-to-date because of the sorting that is currently happening. In my opinion, the simplest solution is not to sort at all, instead of calling the script multiple times.