### PR TITLE
make topological-sort multi-run

### DIFF
--- a/hole/topological-sort.go
+++ b/hole/topological-sort.go
@@ -82,5 +82,7 @@ var _ = answerFunc("topological-sort", func() []Answer {
 			}
 		}
 	}
-	return outputTests(shuffle(tests))
+	shuffle(tests)
+	mid := len(tests) / 2
+	return outputTests(tests[:mid], tests[mid:])
 })


### PR DESCRIPTION
J currently gives `exit status 100` on the hole, the tests barely exceeds the ~30KB limit J has on the combined length of all args. This fixes it by splitting the tests into two runs.

Alternatively we could reduce the number of tests a bit.