### PR TITLE
Compile Odin with '-march=x86-64-v3' instead

### DIFF
--- a/langs/odin/Dockerfile
+++ b/langs/odin/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.22 AS builder
 
 RUN apk add --no-cache clang curl dash llvm-dev make
 
-ENV VER=2025-07
+ENV CPPFLAGS='-march=x86-64-v3' VER=2025-07
 
 RUN curl -#L https://github.com/odin-lang/Odin/archive/refs/tags/dev-$VER.tar.gz \
   | tar xz --directory /usr/local/lib --strip-components 1


### PR DESCRIPTION
As indicated in the description of commit [`227de07`](https://github.com/code-golf/code-golf/commit/227de0746be35c8b66085371f03125a2c0438e3b), this seems possible.

```bash
=> => # ./build_odin.sh release
=> => # + clang++ src/main.cpp src/libtommath.cpp -Wno-switch -Wno-macro-redefined -Wno-unused-value '-march=x86-64-v3' '-DODIN_VERSION_RAW="dev-2025-07"' '-std=c++14' -I/usr/lib/llvm20/include '-std=c++17'
=> => # -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -L/usr/lib/llvm20/lib -O3 -pthread -lm -lstdc++ -ldl /usr/lib/llvm20/lib/libLLVM-20.so '-Wl,-rpath=$ORIGIN' -o odin
```

```bash
oh@Yewzir:~/code-golf$ make lint
Unable to find image 'golangci/golangci-lint:v2.2.1' locally
v2.2.1: Pulling from golangci/golangci-lint
1d7643c81d03: Pull complete
3b1eb73e9939: Pull complete
b1b8a0660a31: Pull complete
420c602e8633: Pull complete
a8f67fead7e3: Pull complete
1f64d3b080be: Pull complete
4f4fb700ef54: Pull complete
71af8e46d243: Pull complete
10d8ff931eda: Pull complete
Digest: sha256:2085f63aee644093ae9a2572af6ab517021514525cfb264ff2ecdf8f23c847ff
Status: Downloaded newer image for golangci/golangci-lint:v2.2.1
0 issues.
oh@Yewzir:~/code-golf$ make test
?       github.com/code-golf/code-golf  [no test files]
?       github.com/code-golf/code-golf/cmd/hash-langs   [no test files]
ok      github.com/code-golf/code-golf/config   0.035s
ok      github.com/code-golf/code-golf/db       (cached)
?       github.com/code-golf/code-golf/discord  [no test files]
?       github.com/code-golf/code-golf/github   [no test files]
ok      github.com/code-golf/code-golf/golfer   0.043s
ok      github.com/code-golf/code-golf/hole     0.031s [no tests to run]
?       github.com/code-golf/code-golf/middleware       [no test files]
ok      github.com/code-golf/code-golf/null     (cached)
?       github.com/code-golf/code-golf/oauth    [no test files]
?       github.com/code-golf/code-golf/ordered  [no test files]
?       github.com/code-golf/code-golf/pager    [no test files]
ok      github.com/code-golf/code-golf/pretty   (cached)
ok      github.com/code-golf/code-golf/routes   0.128s
?       github.com/code-golf/code-golf/session  [no test files]
?       github.com/code-golf/code-golf/utils    [no test files]
?       github.com/code-golf/code-golf/views    [no test files]
ok      github.com/code-golf/code-golf/zone     (cached) [no tests to run]
oh@Yewzir:~/code-golf$ make e2e

up to date, audited 209 packages in 1s

46 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

  dist/js/hole-tabs-3IJIJBBH.js                                   2.7mb ⚠️
  dist/js/wiki-DDHOMXK4.js                                        2.5mb ⚠️
  dist/js/hole-2U3DVD2V.js                                        1.4mb ⚠️
  dist/js/stats-VDVYORXS.js                                     221.4kb
  dist/js/golfer/profile-3OBZ3AZK.js                            157.3kb
  dist/js/rankings-BESD56V3.js                                  151.0kb
  dist/fonts/twemoji-3WDUJABL.woff2                             103.0kb
  dist/fonts/source-code-pro-ILST5JV6.woff2                      51.0kb
  dist/svg/hare-LN4T42AC.svg                                     37.3kb
  dist/svg/civet-UOGIVEHY.svg                                    26.0kb
  dist/css/hole-tabs-XS6HD3SF.css                                24.0kb
  dist/svg/scala-KASVEC4S.svg                                    21.6kb
  dist/fonts/noto-sans-symbols-2-mahjong-subset-W7JGGGSA.woff2   15.7kb
  dist/css/hole-LWC3UQAD.css                                     13.3kb
  dist/css/common/base-3FCZORGG.css                              11.3kb
  dist/svg/picat-VXGY6DBF.svg                                    10.9kb
  dist/svg/factor-ZHEYPSIV.svg                                   10.5kb
  dist/svg/awk-4CORQXPB.svg                                       8.4kb
  dist/css/admin/solutions-3SFJ4GNT.css                           7.9kb
  dist/svg/raku-U4AGOU3J.svg                                      7.5kb
  dist/svg/arturo-VZG7HMZ2.svg                                    7.3kb
  dist/fonts/chess-dark-DOPBCEOL.woff2                            7.3kb
  dist/fonts/chess-XZGIFHSH.woff2                                 7.2kb
  dist/svg/brainfuck-3J447XP7.svg                                 7.1kb
  dist/svg/perl-7MTINIWK.svg                                      4.0kb
  dist/svg/egel-HZXBBYQD.svg                                      4.0kb
  dist/svg/qore-HRBIBUEY.svg                                      3.9kb
  ...and 189 more output files...

⚡ Done in 453ms
[+] Creating 4/4
 ✔ Network code-golf-e2e_default      Created                                                                                                                                                               0.1s
 ✔ Container code-golf-e2e-db-1       Created                                                                                                                                                               0.2s
 ✔ Container code-golf-e2e-firefox-1  Created                                                                                                                                                               0.2s
 ✔ Container code-golf-e2e-app-1      Created                                                                                                                                                               0.1s
[+] Running 3/3
 ✔ Container code-golf-e2e-firefox-1  Started                                                                                                                                                               0.7s
 ✔ Container code-golf-e2e-db-1       Started                                                                                                                                                               0.7s
 ✔ Container code-golf-e2e-app-1      Started                                                                                                                                                               0.5s
t/answers.t ..................... ok
t/api.t ......................... ok
t/asm-reg-dump.t ................ ok
t/cheevos.t ..................... ok
t/delete-golfer.t ............... ok
t/examples.t .................... ok
t/golfer-actions.t .............. ok
t/golfer-export.t ............... ok
t/golfer-settings.t ............. ok
t/hole-general.t ................ ok
t/hole-logged-in.t .............. ok
t/inspect.t ..................... ok
t/lang-features.t ............... ok
t/limits.t ...................... ok
t/pangramglot.t ................. ok
t/redirects.t ................... ok
t/solution.t .................... ok
t/timeout.t ..................... ok
t/truncate.t .................... ok
All tests successful.
Files=19, Tests=615,  640 wallclock secs
Result: PASS
```