### PR TITLE
Calling Kotlin in an alternative way

### DIFF
--- a/config/data/langs.toml
+++ b/config/data/langs.toml
@@ -1173,8 +1173,7 @@ example = '''
 '''
 
 [Kotlin]
-args    = [ '/usr/bin/kotlin', '-Xuse-fast-jar-file-system', '-e', '$code' ]
-env     = [ 'JAVA_HOME=/opt/java' ]
+args    = [ '/opt/java/bin/java', '-jar', '/usr/lib/kotlin-compiler.jar', '-Xuse-fast-jar-file-system', '-e', '$code' ]
 size    = '140 MiB'
 version = '2.2.0'
 website = 'https://kotlinlang.org'


### PR DESCRIPTION
I also noticed that Kotlin struggles the most to pass the test during the GitHub Actions run. To make the test pass, I considered several possible solutions. I'll start with the least ugly: calling Kotlin in a different way. From what I've seen, this seems to be slightly faster.