### PR TITLE
Test examples with an alternative hole

### DIFF
--- a/config/data/langs.toml
+++ b/config/data/langs.toml
@@ -757,7 +757,7 @@ version = 'GNU Fortran 15.1.0'
 website = 'https://gcc.gnu.org/fortran/'
 example = '''
 integer :: i
-character(len=2048) :: arg
+character(len=256) :: arg
 
 ! Printing
 print "(a)", "Hello, World!"

--- a/t/examples.t
+++ b/t/examples.t
@@ -5,7 +5,7 @@ for 'config/data/langs.toml'.IO.&from-toml.map({
 }).sort -> (:key($lang), :value($code)) {
     for (
         # Pick a hole that will definitely have unicode arguments.
-        $lang eq 'kotlin' ?? 'musical-chords' !! 'rock-paper-scissors-spock-lizard',
+        'musical-chords',
 
         # Ensure PowerShell example works on Quine with explicit output.
         ( 'quine' if $lang eq 'powershell' ),


### PR DESCRIPTION
In general, Mahjong and Musical Chords, which are also full of Unicode arguments, are always faster than Rock-paper-scissors-Spock-lizard. I started with Mahjong because it only has two runs, but Musical Chords has only one and is even faster than Mahjong. It might be wise to test Kotlin with Musical Chords.