### PR TITLE
Bump Knight

### DIFF
--- a/langs/knight/Dockerfile
+++ b/langs/knight/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.22 AS builder
 
 RUN apk add --no-cache curl clang musl-dev make git
 
-ENV VER=a4df017 COMPILER=clang STANDARD=EXTENSION
+ENV VER=73e9219 COMPILER=clang STANDARD=EXTENSION
 
 WORKDIR /usr/bin
 


### PR DESCRIPTION
Bumps to commit `73e9219`.

* `BLOCK` statements become more efficient and the overhead is reduced.
* Memory usage for `CALL` statements is reduced.
* Generally improved speed across the board.

Regarding #2360, this version also fixes an obscure edge case that may break solutions that use the result of an `OUTPUT` as a `0` value without coercion (e.g. `=cO"example"` expecting the value of `c` to be `0`). This edge case is obscure and impractical for golfing, and the bump will not affect solutions which coerce this value.