### PR TITLE
Correct a typo

### DIFF
--- a/js/vendor/codemirror-clike.js
+++ b/js/vendor/codemirror-clike.js
@@ -515,7 +515,7 @@ function tokenKotlinString(tripleString){
         "ByteArray Char CharArray DeprecationLevel DoubleArray Enum FloatArray Function Int IntArray Lazy " +
         "LazyThreadSafetyMode LongArray Nothing ShortArray Unit"
     ),
-    intendSwitch: false,
+    indentSwitch: false,
     indentStatements: false,
     multiLineStrings: true,
     number: /^(?:0x[a-f\d_]+|0b[01_]+|(?:[\d_]+(\.\d+)?|\.\d+)(?:e[-+]?[\d_]+)?)(u|ll?|l|f)?/i,


### PR DESCRIPTION
[`7039072`](https://github.com/codemirror/codemirror5/pull/7142/commits/70390721541990f6bb7cd92ca472e7abf73486fd)