### PR TITLE
Fix URL in "Happy Birthday, Code Golf" description

### DIFF
--- a/config/data/cheevos.toml
+++ b/config/data/cheevos.toml
@@ -37,7 +37,7 @@ description = 'Solve <a href=/united-states>United States</a> on <a href=//www.w
 name        = 'Happy Birthday, Code Golf'
 emoji       = '🎂'
 dates       = [2000-10-02, 2000-10-03]
-description = 'Solve any hole on <a href=//github.com/code-golf/code-golf/commit/4b44>2 Oct</a>.'
+description = 'Solve any hole on <a href=//github.com/code-golf/code-golf/commit/4b442>2 Oct</a>.'
 
 [['Date Specific']]
 name        = 'Vampire Byte'


### PR DESCRIPTION
I noticed the link in the description of the *Happy Birthday, Code Golf* hole 404's, I'm guessing it's not enough characters for GitHub to try and identify the commit. Adding another character fixes it.