### PR TITLE
Limit the number of arguments for the tutorial hole to 99.

### DIFF
--- a/hole/tutorial.go
+++ b/hole/tutorial.go
@@ -8,7 +8,7 @@ var _ = answerFunc("tutorial", func() []Answer {
 	for r := range runs {
 		var tests []test
 
-		for range randInt(1, 100) {
+		for range randInt(1, 99) {
 			word := randWord()
 			tests = append(tests, test{word, word})
 		}


### PR DESCRIPTION
This is mainly for Fortran, where it's shortest to hardcode the maximum number of arguments. Most of the time you can get away with hardcoding to 99. So we should either limit to 99 or guarantee that 100 arguments will always occur, otherwise the solutions will pass occasionally.