### PR TITLE
On Mac, handle Cmd+P the same way as Ctrl+P.

### DIFF
--- a/js/base.tsx
+++ b/js/base.tsx
@@ -56,7 +56,7 @@ for (const btn of $$<HTMLElement>('[data-dialog]'))
 
 // Search navigation dialog
 document.addEventListener('keydown', e => {
-    if (e.ctrlKey && e.key === 'p') {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'p') {
         const dialog = $<HTMLDialogElement>('#search-nav-dialog');
         if (!dialog) return;
 


### PR DESCRIPTION
Cmd+P is the default for print on macOS. I just learned about this feature by using ctrl+p by accident.

This is the same as what we do for Ctrl+Enter or Cmd+Enter.