### PR TITLE
Make the dot for visible whitespace much smaller, like it used to be.

### DIFF
--- a/css/hole.css
+++ b/css/hole.css
@@ -366,6 +366,12 @@ h2 {
 
 .show-whitespace :is(.cm-highlightSpace, .cm-highlightTab) { opacity: .5 }
 
+.cm-highlightSpace {
+    /* The default whitespace circle is too big.
+       The built in styling has a higher specificity, since it also uses an internal class `.ͼ1`. */
+    background-image: radial-gradient(circle 0.5rem at 50% 55%, #aaa 20%, transparent 5%) !important;
+}
+
 #diffKindSettings {
     margin: 0.5rem;
 }


### PR DESCRIPTION
A code mirror update last year changed the styling.

Before:
<img width="282" height="107" alt="befores" src="https://github.com/user-attachments/assets/bf4920fa-9701-40db-bffd-888cda87a2d8" />

After:
<img width="289" height="100" alt="afters" src="https://github.com/user-attachments/assets/1fcd0771-4290-4932-8f05-8e463721b489" />
