### PR TITLE
Restore version 9.6.3 for J

### DIFF
--- a/langs/j/Dockerfile
+++ b/langs/j/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update                   \
 
 ENV CC='clang' CFLAGS='-Wno-error' VER=9.6
 
-RUN git clone --branch J$VER-beta3 --progress \
+RUN git clone --branch $VER --progress \
     https://github.com/jsoftware/jsource
 
 WORKDIR /jsource/make2


### PR DESCRIPTION
In response to the [comment](https://github.com/code-golf/code-golf/pull/2414#discussion_r2413145947), this commit fixes version 9.6.3 for J. I really thought it was the branch with "beta3" because I couldn't find "9.6.3" anywhere. Now I do, and it's branch "[9.6](https://github.com/jsoftware/jsource/blob/9.6/version.txt)".