### PR TITLE
Use `System::none` instead of `System::print` in the Egel sample code

### DIFF
--- a/config/data/langs.toml
+++ b/config/data/langs.toml
@@ -630,8 +630,7 @@ def main =
 
     # Accessing arguments
     map [ ARG -> print ARG "\n" ] (drop 2 args);
-
-    print
+none
 '''
 
 [Elixir]


### PR DESCRIPTION
This seems more logical than calling `System::print` and then not printing anything.