### PR TITLE
Prevent future hardcoding of OpenJDK version numbers without decimals

### DIFF
--- a/build-langs
+++ b/build-langs
@@ -94,7 +94,10 @@ for %langs{@langs}:p -> (:key($name), :value(%lang)) {
             when 'Common Lisp' { $ver = "GNU CLISP $digits" }
             when 'D'           { $ver = "DMD $digits" }
             when 'Haskell'     { $ver = "GHC $digits" }
-            when 'Java'        { $ver = "OpenJDK 25.0" } # FIXME no decimal place.
+            when 'Java'        {
+                $ver = $ver.match(/ \d+ ( \. \d+ )* ( \+ \d+ )? /);
+                $ver = "OpenJDK $ver" ~ ( ".0" if $ver ne $digits );
+            }
             when 'JavaScript'  { $ver = "V8 $digits" }
             when 'Pascal'      { $ver = "FPC $digits" }
             when 'Prolog'      { $ver = "SWI-Prolog $digits" }


### PR DESCRIPTION
Every time that comment pops up again, we put it back when the time comes, and let it go when it's no longer needed. 😂 Certainly guilty, that's for sure, so maybe it's time to take the bull by the horns.