### PR TITLE
Some adjustments to the Hare language

### DIFF
--- a/build-langs
+++ b/build-langs
@@ -53,7 +53,7 @@ for %langs{@langs}:p -> (:key($name), :value(%lang)) {
     }
 
     # Version.
-    if $id ~~ any <05ab1e apl arturo assembly befunge brainfuck cjam erlang fish golfscript hare hexagony j k knight luau stax umka> {
+    if $id ~~ any <05ab1e apl arturo assembly befunge brainfuck cjam erlang fish golfscript hexagony j k knight luau stax umka> {
         "langs/$id/Dockerfile".IO.slurp ~~ / ' VER=' (\S+) | ' VERSION=' (\S+) /;
 
         %lang<version> = do given $id {

--- a/config/data/langs.toml
+++ b/config/data/langs.toml
@@ -891,11 +891,11 @@ NEXT
 '''
 
 [Hare]
-args       = [ '/usr/bin/hare', '-' ]
+args       = [ '/usr/bin/harewrapper', '-' ]
 env        = [ 'PATH=/usr/local/bin:/usr/bin' ]
 experiment = 1323
-size       = '11.5 MiB'
-version    = '0.24.2'
+size       = '10.9 MiB'
+version    = '0.25.2'
 website    = 'https://harelang.org'
 example    = '''
 use fmt;

--- a/langs/hare/Dockerfile
+++ b/langs/hare/Dockerfile
@@ -1,8 +1,10 @@
 FROM alpine:3.22 AS builder
 
-RUN apk add --no-cache build-base curl qbe scdoc
+RUN apk add --no-cache curl gcc make musl-dev qbe scdoc
 
-ENV VER=0.24.2
+ENV VER=0.25.2
+
+WORKDIR /harec
 
 RUN curl -#L https://git.sr.ht/~sircmpwn/harec/archive/$VER.tar.gz \
   | tar xz --strip-components 1
@@ -10,22 +12,26 @@ RUN curl -#L https://git.sr.ht/~sircmpwn/harec/archive/$VER.tar.gz \
 RUN mv configs/linux.mk config.mk \
  && make install
 
-RUN curl -# https://git.sr.ht/~sircmpwn/hare/archive/$VER.tar.gz | tar xz
+WORKDIR /hare
 
-WORKDIR /hare-$VER
+RUN curl -# https://git.sr.ht/~sircmpwn/hare/archive/$VER.tar.gz \
+  | tar xz --strip-components 1
 
 RUN mv configs/linux.mk config.mk \
  && make && make install
 
+RUN strip /usr/local/bin/hare \
+          /usr/local/bin/harec
+
 COPY hare.c /
 
-RUN gcc -Wall -Werror -Wextra -o /usr/bin/hare -s /hare.c
+RUN gcc -Wall -Werror -Wextra -o /usr/bin/harewrapper -s /hare.c
 
 FROM codegolf/lang-base
 
 COPY --from=0 /lib/ld-musl-*.so.1        /lib/
 COPY --from=0 /usr/bin/as                \
-              /usr/bin/hare              \
+              /usr/bin/harewrapper       \
               /usr/bin/ld                \
               /usr/bin/qbe               /usr/bin/
 COPY --from=0 /usr/lib/libbfd-2.44.so    \
@@ -38,6 +44,6 @@ COPY --from=0 /usr/local/bin/hare        \
               /usr/local/bin/harec       /usr/local/bin/
 COPY --from=0 /usr/local/src/hare/stdlib /usr/local/src/hare/stdlib
 
-ENTRYPOINT ["hare"]
+ENTRYPOINT ["harewrapper"]
 
 CMD ["--version"]

--- a/latest-langs
+++ b/latest-langs
@@ -52,7 +52,7 @@ constant %paths = (
     'GolfScript'   => 'github.com/lynn/golfscript/tree/code-golf',
     'Groovy'       => 'endoflife.date/api/apache-groovy.json',
     'Harbour'      => 'sourceforge.net/projects/harbour-project/files',
-    'Hare'         => 'lists.sr.ht/~sircmpwn/hare-announce?search=release',
+    'Hare'         => 'git.sr.ht/~sircmpwn/hare',
     'Haskell'      => 'pkgs.alpinelinux.org/package/edge/community/x86_64/ghc',
     'Haxe'         => 'github.com/HaxeFoundation/haxe/releases/latest',
     'Hexagony'     => 'github.com/SirBogman/Hexagony',
@@ -133,11 +133,11 @@ for %langs{ @langs || * }:p.sort: *.key.fc -> (:key($name), :value(%lang)) {
         when / 'fennel-lang'       / { $res ~~ / 'fennel-' <(<ver>)> / }
         when / 'ftp.gnu.org'       / { $res ~~ / '-' <(<ver>)> '.tar.gz' / }
         when / 'gentoo.org'        / { $res ~~ / 'Version' .+? <(<ver>)> / }
+        when / 'git.sr.ht'         / { $res ~~ / 'refs/' <(<ver>)> / }
         when / 'githubusercontent' / { $res ~~ / <(<ver>)> / }
         when / 'gnome.org'         / { $res ~~ / 'Release ' <(<ver>)> / }
         when / 'golfscript.com'    / { $res ~~ / 'iogii-' <(<ver>)> / }
         when / 'jmvdveer'          / { $res ~~ / 'algol68g-' <(<ver>)> / }
-        when / 'lists.sr.ht'       / { $res ~~ / 'Hare ' <(<ver>)> ' release' / }
         when / 'npmjs.org'         / { $res.&from-json[0]<version> }
         when / 'picat-lang.org'    / { $res ~~ / 'Version ' <(<ver>)> / }
         when / 'pypi.org'          / { $res.&from-json<info><version> }


### PR DESCRIPTION
Initially, I worked on a way to remove Hare from the "build-langs" script, and while that worked, one thing led to another. Here's a summary:

* The "latest-langs" script was no longer correctly displaying the latest release and was therefore modified to do so again.
* The Dockerfile entry was calling the actual binary in "/usr/local/bin" instead of the custom runner, which was renamed as a result.
* Modifying the "latest-langs" script showed that a new release was available, and Hare was updated accordingly.
* The final image size was reduced by removing symbols and sections from the built binaries.
* Ultimately, Hare was removed from the "build-langs" script because the issue with retrieving version information had apparently been resolved.

Now only the giant rabbit remains...