### PR TITLE
Use an actively maintained fork of the "ngn/k" implementation

### DIFF
--- a/config/data/langs.toml
+++ b/config/data/langs.toml
@@ -1154,9 +1154,9 @@ end
 
 [K]
 args    = [ '/usr/bin/k', '/proc/self/fd/0' ]
-size    = '605 KiB'
-version = '544d014afd'
-website = 'https://codeberg.org/ngn/k'
+size    = '668 KiB'
+version = '13a5a5afeb'
+website = 'https://codeberg.org/growler/k'
 example = '''
 /Printing
 `0:"Hello, World!"

--- a/langs/k/Dockerfile
+++ b/langs/k/Dockerfile
@@ -1,12 +1,12 @@
 FROM alpine:3.22 AS builder
 
-RUN apk add --no-cache build-base curl
+RUN apk add --no-cache curl gcc make musl-dev
 
-ENV CC='gcc -static' VER=544d014afd
+ENV CC='gcc -static' VER=13a5a5afeb
 
 WORKDIR /usr/bin
 
-RUN curl -#L https://codeberg.org/ngn/k/archive/$VER.tar.gz \
+RUN curl -#L https://codeberg.org/growler/k/archive/$VER.tar.gz \
   | tar xz --strip-components 1
 
 RUN sed -i s/march=native/march=x86-64-v3/ makefile | make

--- a/latest-langs
+++ b/latest-langs
@@ -67,7 +67,7 @@ constant %paths = (
     ).&from-json.first(*<channel> eq 'Stable')<hashes><v8>,
     'jq'           => 'github.com/jqlang/jq/releases/latest',
     'Julia'        => 'api.github.com/repos/JuliaLang/julia/releases',
-    'K'            => 'codeberg.org/ngn/k',
+    'K'            => 'codeberg.org/growler/k',
     'Knight'       => 'github.com/synt7x/knightjit',
     'Kotlin'       => 'github.com/JetBrains/kotlin/releases/latest',
     'Lua'          => 'github.com/lua/lua/releases/latest',


### PR DESCRIPTION
This would use an actively maintained fork, based on the most recent commit [`544d014afd`](https://codeberg.org/ngn/k/commit/544d014afd) in the repository currently being used here. The implementation remains essentially the same, but the fork in question already contains numerous updates.