### PR TITLE
Fix Luau's version

### DIFF
--- a/config/data/langs.toml
+++ b/config/data/langs.toml
@@ -1233,7 +1233,7 @@ end
 [Luau]
 args       = [ '/usr/bin/luau', '-' ]
 experiment = 1044
-size       = '5.05 MiB'
+size       = '5.09 MiB'
 version    = '0.698'
 website    = 'https://luau.org'
 example    = '''

--- a/langs/luau/Dockerfile
+++ b/langs/luau/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache curl g++ linux-headers make
 
 ENV VER=0.698
 
-RUN curl -#L https://github.com/luau-lang/luau/archive/refs/tags/696.tar.gz \
+RUN curl -#L https://github.com/luau-lang/luau/archive/refs/tags/$VER.tar.gz \
   | tar xz --strip-components 1
 
 RUN make config=release luau \


### PR DESCRIPTION
In reality, it was stuck at version 0.696. This was an error on their part, as the tag was originally called "696" and was released as such.