### PR TITLE
Fixed phrasing and changed <code> tags to regular double quotes.

### DIFF
--- a/config/data/holes.toml
+++ b/config/data/holes.toml
@@ -4044,12 +4044,12 @@ preamble = '''
     You are given a series of inputs. Each input contains a text <b>corpus</b>
     and 12 <b>prompt</b> words on subsequent lines.
     For each prompt, output the word which most frequently follows it in the corpus.
-    In case of a tie, print the one whose follow-on occurrence comes first.
+    In case of a tie, print the one whose first follow-on occurrence comes earliest.
 <p>
-    For example, suppose the corpus is <code>code golf and golf and code</code>
-    and the prompt is <code>and</code>.
+    For example, suppose the corpus is "code golf and golf and code"
+    and the prompt is "and".
     Both "golf" and "code" follow the word "and" maximally frequently (once), but "golf"
-    <em>does so first</em>, and so the output is <code>golf</code>.
+    <em>does so first</em>, and so the output is "golf".
 <p>
     In this problem, each corpus is formed by concatenating two
     <a href=star-wars-opening-crawl>Star Wars Opening Crawl</a> texts together


### PR DESCRIPTION
This MR mainly fixes the phrasing that previously read "whose follow-on occurrence occurs first" to read "whose _first_ follow-on occurrence occurs earliest" (because a follow-on word may have more than one follow-on occurrence).

It also changes the `<code>` tags to be double quotes, because `<code>` tags are unreadable in dark mode for me:

<img width="1108" height="224" alt="image" src="https://github.com/user-attachments/assets/9650804c-b337-4bf9-b469-a42212ecf3c2" />