### PR TITLE
Display BOM (U+FEFF) as BM

### DIFF
--- a/js/_unprintable.ts
+++ b/js/_unprintable.ts
@@ -73,6 +73,11 @@ export default class UnprintableElement extends HTMLElement {
             l = '⌟';
             t = '(empty)';
         }
+        else if (c == '\uFEFF') {
+            h = 'B';
+            l = 'M';
+            t = '(BOM)';
+        }
         else if (c.length == 1) {
             const code = c.charCodeAt(0);
             h = '0123456789ABCDEF'[code / 16 | 0];
@@ -91,7 +96,7 @@ export default class UnprintableElement extends HTMLElement {
         this.#span.title = t;
     }
 
-    static PATTERN = /([\x00-\x08\x0B-\x1F\x7F-\xA0])/g;
+    static PATTERN = /([\x00-\x08\x0B-\x1F\x7F-\xA0\uFEFF])/g;
 
     static escape(text: string): DocumentFragment {
         const frag = document.createDocumentFragment();


### PR DESCRIPTION
Display BOM (U+FEFF) as BM similar to how low value unprintables are displayed as two hex digits 

<img width="399" height="223" alt="2025-11-22T20:17:37,082595608+05:30" src="https://github.com/user-attachments/assets/8281ac42-3573-42dc-99cc-2d5e3f0010e9" />
