### PR TITLE
Enable extensive use of Unicode for Erlang

### DIFF
--- a/config/data/langs.toml
+++ b/config/data/langs.toml
@@ -653,8 +653,9 @@ for arg <- System.argv, do: IO.puts arg
 
 [Erlang]
 args     = [ '/usr/bin/erlang', '-' ]
+env      = [ 'LANG=C.UTF-8' ]
 released = 2025-11-27
-size     = '49.7 MiB'
+size     = '50.1 MiB'
 version  = 'OTP 28.2'
 website  = 'https://www.erlang.org'
 example  = '''
@@ -777,7 +778,7 @@ end
 '''
 
 [Gleam]
-args    = [ '/usr/bin/gleam', '-', '--' ]
+args    = [ '/usr/bin/gleam', '-' ]
 env     = [ 'LANG=C.UTF-8' ]
 size    = '75.1 MiB'
 version = '1.13.0'

--- a/langs/elixir/Dockerfile
+++ b/langs/elixir/Dockerfile
@@ -19,7 +19,6 @@ RUN make
 
 FROM codegolf/lang-erlang
 
-COPY --from=1 /usr/lib/locale            /usr/lib/locale
 COPY --from=1 /usr/local/bin/elixir      /usr/local/bin/
 COPY --from=1 /usr/local/lib/elixir/ebin /usr/local/lib/elixir/ebin
 

--- a/langs/erlang/Dockerfile
+++ b/langs/erlang/Dockerfile
@@ -59,6 +59,7 @@ COPY --from=0 /usr/bin/basename                      \
 COPY --from=0 /usr/local                             /usr/lib/erlang
 COPY --from=0 /usr/lib/erlang/bin/no_dot_erlang.boot \
               /usr/lib/erlang/bin/start.boot         /usr/lib/erlang/bin/
+COPY --from=0 /usr/lib/locale                        /usr/lib/locale
 
 ENTRYPOINT ["erlang"]
 

--- a/langs/gleam/Dockerfile
+++ b/langs/gleam/Dockerfile
@@ -1,5 +1,3 @@
-FROM codegolf/lang-erlang
-
 FROM rust:1.91.1-slim-trixie AS builder
 
 RUN apt-get update                   \
@@ -25,21 +23,19 @@ COPY gleam.c /
 
 RUN gcc -Wall -Werror -Wextra -o /usr/bin/gleam -s /gleam.c
 
-FROM codegolf/lang-base
+FROM codegolf/lang-erlang
 
-COPY --from=0 /                                   /
-COPY --from=1 /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/
-COPY --from=1 /usr/bin/gleam                      /usr/bin/
-COPY --from=1 /usr/lib/locale                     /usr/lib/locale
+COPY --from=0 /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/
+COPY --from=0 /usr/bin/gleam                      /usr/bin/
 COPY --chown=nobody                               \
-     --from=1 /usr/local/gleam.toml               \
+     --from=0 /usr/local/gleam.toml               \
               /usr/local/manifest.toml            /usr/local/
 COPY --chown=nobody                               \
-     --from=1 /usr/local/cargo/bin/gleam          /usr/local/bin/
+     --from=0 /usr/local/cargo/bin/gleam          /usr/local/bin/
 COPY --chown=nobody                               \
-     --from=1 /usr/local/build/packages           /usr/local/build/packages
+     --from=0 /usr/local/build/packages           /usr/local/build/packages
 COPY --chown=nobody                               \
-     --from=1 /usr/local/src                      /usr/local/src
+     --from=0 /usr/local/src                      /usr/local/src
 
 ENTRYPOINT ["gleam"]
 

--- a/langs/gleam/gleam.c
+++ b/langs/gleam/gleam.c
@@ -59,12 +59,13 @@ int main(int argc, char* argv[]) {
     if (WEXITSTATUS(status))
         return WEXITSTATUS(status);
 
-    int gargc = argc + 2;
+    int gargc = argc + 3;
     char** gargv = malloc(gargc * sizeof(char*));
     gargv[0] = (char*) gleam;
     gargv[1] = "run";
     gargv[2] = "--no-print-progress";
-    memcpy(&gargv[3], &argv[2], (argc - 2) * sizeof(char*));
+    gargv[3] = "--";
+    memcpy(&gargv[4], &argv[2], (argc - 2) * sizeof(char*));
     gargv[gargc - 1] = NULL;
 
     execv(gleam, gargv);


### PR DESCRIPTION
Actually, I'm not surprised, because Elixir, Gleam, and 05AB1E require exactly the same thing, and I already found it odd that Erlang was the only one that worked without the locale setting. So I used `LANG=C.UTF-8` in a similar way and adjusted a few minor things. I retested them all, and they all worked fine.

See: https://discord.com/channels/756829356155731988/758369341460054038/1444798164770226330

Also thanks to @edsrzf for pointing this out.