### PR TITLE
Save code search hole/lang parameters in local storage

### DIFF
--- a/js/golfer/code-search.tsx
+++ b/js/golfer/code-search.tsx
@@ -22,12 +22,12 @@ form.onsubmit = e => e.preventDefault();
 
 form.onchange = form.q.onkeyup = async () => {
     const hole    = form.hole.value;
-    const lang    = (form.lang as HTMLFormElement[string]).value;
+    const lang    = (form.lang as any).value;
     const pattern = form.regex.checked
         ? form.q.value : form.q.value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-    localStorage.setItem('code-search-lang', lang);
     localStorage.setItem('code-search-hole', hole);
+    localStorage.setItem('code-search-lang', lang);
 
     try {
         new RegExp(pattern);


### PR DESCRIPTION
Addresses #2564 

Adding settings for this is more awkward than expected as they're used both by the settings dialog and on the page, but it needs to not have the labels on the page itself

But local storage probably works better here anyway