### PR TITLE
Hide non-functioning Page Settings button on the code search page

### DIFF
--- a/views/html/golfer.html
+++ b/views/html/golfer.html
@@ -25,7 +25,8 @@
                 <button class="btn blue">{{ svg "person-plus" }} Follow Golfer</button>
             </form>
         {{ end }}
-        {{ if $.Settings }}
+        {{/* FIXME Stop misusing settings on code-search */}}
+        {{ if and $.Settings (ne $.Name "golfer/code-search") }}
             <button class="btn blue" command=show-modal
                 commandfor=settings-dialog title=Settings>
                 {{ svg "gear-fill" }}


### PR DESCRIPTION
The code search page doesn't have a settings dialog modal but it does display a "Page Settings" button due to it having settings that are part of the page. 

The button does nothing which makes it look broken, so probably best to hide it.