### PR TITLE
Update Gravatar avatar host list

### DIFF
--- a/routes/golfer_connect.go
+++ b/routes/golfer_connect.go
@@ -134,7 +134,7 @@ func golferConnectGET(w http.ResponseWriter, r *http.Request) {
 
 		switch u.Host {
 		// Gravatar - https://docs.gravatar.com/sdk/images/
-		case "0.gravatar.com", "1.gravatar.com", "2.gravatar.com", "gravatar.com",
+		case "0.gravatar.com", "1.gravatar.com", "2.gravatar.com", "3.gravatar.com", "gravatar.com",
 			"secure.gravatar.com", "www.gravatar.com":
 			u.Host = "gravatar.com"
 


### PR DESCRIPTION
My own avatar is served from `2.gravatar.com`, and it seems like `1.avatar.com` exists as well.