### PR TITLE
Show full usernames in various tables in case they overflow

### DIFF
--- a/views/html/golfer-link.html
+++ b/views/html/golfer-link.html
@@ -1,4 +1,4 @@
-<a href="/golfers/{{ .Name }}">
+<a href="/golfers/{{ .Name }}" title="{{ .Name }}">
     <img loading=lazy src="{{ avatar .AvatarURL 48 }}">
     <span>{{ .Name }}</span>
 {{ with .CountryFlag }}


### PR DESCRIPTION
The attribute in question provides a small tooltip on hover. I think it's in the right place.

<img width="431" height="316" alt="image" src="https://github.com/user-attachments/assets/3475df92-276a-4348-9072-c08d1fc72865"/>