### PR TITLE
Recompile Tcl with 64-bit support enabled

### DIFF
--- a/langs/tcl/Dockerfile
+++ b/langs/tcl/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR /unix
 RUN ./configure      \
     --disable-load   \
     --disable-shared \
+    --enable-64bit   \
     --prefix=/usr    \
  && make install     \
  && strip /usr/bin/tcl*


### PR DESCRIPTION
There was always one hyphen too many. [Remove the last hyphen and it will be recognized.](https://github.com/code-golf/code-golf/pull/2497#discussion_r2528563407)