### PR TITLE
Fixing column widths on *Rankings: Holes* pages in Safari on macOS.

### DIFF
--- a/css/rankings/holes.css
+++ b/css/rankings/holes.css
@@ -7,6 +7,7 @@
 }
 
 th:has(#chart-container) {
+    max-width: 0;  /* Issue #2583 WebKit fix */
     padding: 0;
     position: initial;
 }


### PR DESCRIPTION
Similar to https://github.com/code-golf/code-golf/commit/635564280639bab5081df2e82bccc1e452571cfc for https://github.com/code-golf/code-golf/issues/722.

Tested via web inspector in Safari on macOS:

![code-golf-ln-2-hole-Golfer-table-comparison](https://github.com/user-attachments/assets/3c82df91-3ee7-40e0-b68e-4ef4fb41edf5)

Tested via DevTools in Google Chrome on macOS -- no change in appearance.

Updates #2583