### PR TITLE
Allow sorting of home cards by points for experimental languages

### DIFF
--- a/routes/home_cards.go
+++ b/routes/home_cards.go
@@ -66,7 +66,7 @@ func getHomeCards(r *http.Request) (cards []Card) {
 			     FROM rankings
 			    WHERE scoring = $1 AND user_id = $2
 			 ORDER BY hole, points DESC, lang
-			)  SELECT id hole, lang, COALESCE(points, 0) points
+			)  SELECT id hole, lang, COALESCE(points, -1) points
 			     FROM holes
 			LEFT JOIN points ON id = hole WHERE experiment = 0`
 
@@ -76,7 +76,7 @@ func getHomeCards(r *http.Request) (cards []Card) {
 			   SELECT hole, lang, points_for_lang
 			     FROM rankings
 			    WHERE scoring = $1 AND user_id = $2 AND lang = $3
-			)  SELECT id hole, lang, COALESCE(points_for_lang, 0) points
+			)  SELECT id hole, lang, COALESCE(points_for_lang, -1) points
 			     FROM holes
 			LEFT JOIN points ON id = hole WHERE experiment = 0`
 


### PR DESCRIPTION
Currently, cards for solved holes are only assigned a score of zero, making sorting by points pointless, as all scores are zero. When solving a whole set of holes in an experimental language, determining which ones are still unsolved remains almost as confusing. Based on this commit, the scores of unsolved holes are effectively considered "-1", meaning that sorting by points does have a visual effect.

Continued from #2106

---

**Ascending in points**

<img width="949" height="1580" alt="image" src="https://github.com/user-attachments/assets/ae0fdb24-cbfb-43d4-8782-7b74fe829fd8"/>

---

**Descending in points**

<img width="949" height="1580" alt="image" src="https://github.com/user-attachments/assets/18a8e09f-a307-4a36-97db-db39067d0ceb"/>