### PR TITLE
Add a green border around language selectors with valid solutions

### DIFF
--- a/css/hole.css
+++ b/css/hole.css
@@ -332,6 +332,8 @@ h2 {
 
     > a:not([href]), select.selectActive { border-color: var(--color) }
 
+    > a.has-solution { border-color: var(--green) }
+
     > a {
         align-items: center;
         border: 1px solid var(--grey);

--- a/js/_hole-common.tsx
+++ b/js/_hole-common.tsx
@@ -267,6 +267,8 @@ function updateLangPicker() {
             if (chars && bytes != chars) text += '/' + comma(chars);
 
             tab.append(<sup>{text}</sup>);
+
+            tab.classList.add('has-solution');
         }
         else if (!localStorage.getItem(getAutoSaveKey(l.id, 0)) &&
                  !localStorage.getItem(getAutoSaveKey(l.id, 1))) {


### PR DESCRIPTION
This commit would display a green border around language selectors with valid solutions, similar to the colored border that appears around the editor when submitted solutions are successful.

<img width="947" height="544" alt="image" src="https://github.com/user-attachments/assets/c1f6c8cd-f1c5-40b7-be04-9a1b6feb89f2"/>

<img width="947" height="544" alt="image" src="https://github.com/user-attachments/assets/1d104bd5-1d7e-4743-8260-b587c21d000e"/>