### PR TITLE
FFI can be removed from Cargo's dependency manifest

### DIFF
--- a/langs/uiua/Dockerfile
+++ b/langs/uiua/Dockerfile
@@ -1,23 +1,15 @@
 FROM rust:1.93.0-slim-trixie AS builder
 
-RUN apt-get update                   \
- && DEBIAN_FRONTEND='noninteractive' \
-    apt-get install --yes curl
-
 ENV CRT='x86_64-unknown-linux-musl' VER=0.18.0
 
-RUN curl -#L https://github.com/uiua-lang/uiua/archive/refs/tags/$VER.tar.gz \
-  | tar xz --strip-components 1
+RUN rustup target add $CRT
 
-RUN rustup target add $CRT \
- && cargo add ffi
-
-RUN cargo install         \
+RUN cargo install uiua    \
     --features binary     \
     --no-default-features \
-    --path /              \
     --root /usr           \
     --target $CRT         \
+    --version $VER        \
  && strip /usr/bin/uiua
 
 FROM codegolf/lang-base


### PR DESCRIPTION
This fixes issue [867](https://github.com/uiua-lang/uiua/issues/867) in the upstream repository.