### PR TITLE
Fix input to iogii engine

### DIFF
--- a/langs/iogii/iogii.c
+++ b/langs/iogii/iogii.c
@@ -7,7 +7,7 @@
 
 #define ERR_AND_EXIT(msg) do { perror(msg); exit(EXIT_FAILURE); } while (0)
 
-const char* iogii = "/usr/local/bin/iogii", *ghcii = "/usr/bin/ghcii", *code[2] = {"code.iog", "code.ism"}, *input = "argv.txt";
+const char* iogii = "/usr/local/bin/iogii", *ghcii = "/usr/bin/ghcii", *code[2] = {"code.iog", "code.ism"};
 
 int main(int argc, char* argv[]) {
     if (!strcmp(argv[1], "--version")) {
@@ -34,9 +34,10 @@ int main(int argc, char* argv[]) {
         ERR_AND_EXIT("fclose");
 
     pid_t pid;
-    int fd;
 
     if (!(pid = fork())) {
+        int fd;
+
         if (!dup2(fd = open(code[1], O_CREAT | O_TRUNC | O_WRONLY, 0644), STDOUT_FILENO))
             ERR_AND_EXIT("dup2");
 


### PR DESCRIPTION
Pass input args as args instead of stdin

Note I am unable to create the code.golf test environment on my computer so I have not run this code to test it.

Also I didn't know what the fork was for so I removed it.

To test input could test with the args `asdf<newline>1234` and `qwert`

with program `show` and it should print: 

`[["asdf","1234"],["qwert"]]`