### PR TITLE
Add an option to always clear the sample code

### DIFF
--- a/config/data/settings.toml
+++ b/config/data/settings.toml
@@ -50,6 +50,11 @@ id      = 'show-whitespace'
 name    = 'Show Whitespace in Editor'
 default = true
 
+[[hole]]
+id      = 'clear-sample-code'
+name    = 'Always Clear Sample Code'
+default = false
+
 [[home]]
 id      = 'order-by'
 name    = 'Order By'

--- a/js/_hole-common.tsx
+++ b/js/_hole-common.tsx
@@ -2,6 +2,7 @@ import { ASMStateField }                               from '@defasm/codemirror'
 import { $, $$, avatar, byteLen, charLen, comma, ord, strokeLen } from './_util';
 import { Vim }                                         from '@replit/codemirror-vim';
 import { EditorState, EditorView, extensions }         from './_codemirror';
+import { EditorSelection }                             from '@codemirror/state';
 import LZString                                        from 'lz-string';
 import { getAllowedStrokes }                           from './lang-allowed-strokes';
 
@@ -748,6 +749,19 @@ export function setCodeForLangAndSolution(editor: any) {
 
     setState(localStorage.getItem(getAutoSaveKey(lang, solution)) ||
         getSolutionCode(lang, solution) || currentLang.example, editor);
+
+    // Clear sample code by default if set and return focus to the editor.
+    const sampleCode = currentLang.example;
+    const currentCode = editor?.state.doc.toString();
+    if ($('#editor').className === 'clear-sample-code')
+        if (currentCode === sampleCode) {
+            setCode('', editor);
+
+            editor?.dispatch({
+                selection: EditorSelection.cursor(0), scrollIntoView: true,
+            });
+            editor.focus();
+        }
 
     if (currentLang.assembly) scoring = 0;
     const charsTab = $('#scoringTabs a:last-child');

--- a/views/html/hole-tabs.html
+++ b/views/html/hole-tabs.html
@@ -2,6 +2,7 @@
 {{ template "hole-header" . }}
 
 {{ $showWhitespace := setting .Golfer "hole" "show-whitespace" }}
+{{ $clearSampleCode := setting .Golfer "hole" "clear-sample-code" }}
 <main id="hole-{{ .Data.Hole.ID }}" {{ if $showWhitespace }} class=show-whitespace {{ end }}>
     <nav class=tabs id=picker data-style='{{ setting .Golfer "hole" "lang-picker-style" }}'></nav>
     {{ template "hole-info" . }}
@@ -23,6 +24,7 @@
             </div>
         </div>
     </div>
+    <div id=editor {{ if $clearSampleCode }} class=clear-sample-code {{ end }}></div>
     <div id=golden-container></div>
 </main>
 

--- a/views/html/hole.html
+++ b/views/html/hole.html
@@ -2,6 +2,7 @@
 {{ template "hole-header" . }}
 
 {{ $showWhitespace := setting .Golfer "hole" "show-whitespace" }}
+{{ $clearSampleCode := setting .Golfer .Name "clear-sample-code" }}
 <main id="hole-{{ .Data.Hole.ID }}" {{ if $showWhitespace }} class=show-whitespace {{ end }}>
     <details id=details {{ if not .Data.HideDetails }}open{{ end }}>
         <summary>Details</summary>
@@ -10,7 +11,7 @@
     <nav class=tabs id=picker data-style='{{ setting .Golfer "hole" "lang-picker-style" }}'></nav>
     <nav class=tabs id=solutionPicker></nav>
     <div id=editor-and-rankings>
-        <div id=editor>
+        <div id=editor {{ if $clearSampleCode }} class=clear-sample-code {{ end }}>
             <header>
                 <div id=strokes>0 bytes, 0 chars</div>
                 <a class=hide href id=restoreLink>Restore solution</a>


### PR DESCRIPTION
This clears the editor by default, if configured, and only when the current code in the editor completely matches the sample code of the active language. This applies to both layouts. In addition, the cursor is reset to its starting position and the focus returns to the editor.

<img width="484" height="391" alt="image" src="https://github.com/user-attachments/assets/af9b7cf7-95a4-49dc-92d5-01caf4f161fc"/>