### PR TITLE
Rebuild ALGOL 68

### DIFF
--- a/config/data/langs.toml
+++ b/config/data/langs.toml
@@ -40,9 +40,9 @@ x is a no-op.
 '''
 
 ['ALGOL 68']
-args     = [ '/usr/bin/algol-68', '--execute', '$code', '--exit' ]
+args     = [ '/usr/bin/algol-68', '--execute', '$code', '--' ]
 released = 2026-02-21
-size     = '1.40 MiB'
+size     = '1.37 MiB'
 version  = 'Algol 68 Genie 3.10.10'
 website  = 'https://jmvdveer.home.xs4all.nl/en.algol-68-genie.html'
 example  = '''

--- a/langs/algol-68/Dockerfile
+++ b/langs/algol-68/Dockerfile
@@ -7,9 +7,12 @@ ENV LDFLAGS='-static' VER=3.10.10
 RUN curl -#L https://jmvdveer.home.xs4all.nl/algol68g-$VER.tar.gz \
   | tar xz --strip-components 1
 
-RUN ./configure   \
-    --prefix=/usr \
- && make install  \
+RUN ./configure             \
+    --enable-arch=x86-64-v3 \
+    --enable-generic        \
+    --enable-stable         \
+    --prefix=/usr           \
+ && make install            \
  && strip /usr/bin/a68g
 
 FROM codegolf/lang-base


### PR DESCRIPTION
* Build for non-GNU systems, without optional libraries
* Enable emitting architecture-tuned assembly code
* Reduce file size of the final image, slightly