### PR TITLE
Fix: NFA Simulator output incorrectly says "Accept" twice

### DIFF
--- a/config/data/holes.toml
+++ b/config/data/holes.toml
@@ -2759,7 +2759,7 @@ acbcab
     processing the entirety of <b>each</b> input string, followed by a space,
     followed by either <code>Accept</code> (if the NFA can reach any accept
     state by processing the string, or, in other words, if the final set of
-    valid states contains an accept state) or <code>Accept</code> (otherwise).
+    valid states contains an accept state) or <code>Reject</code> (otherwise).
     In this case, we may end at either <code>0</code> or <code>3</code> and
     one of them is an accept state (<code>3</code>), so we print
     <code>{0,3} Accept</code>.


### PR DESCRIPTION
Found a tiny typo while exploring the docs. The NFA Simulator description repeats "Accept" twice - changed the second one to "Reject" as intended.