### PR TITLE
Make Civet's Dockerfile more efficient by using `COPY --parents`

### DIFF
--- a/langs/civet/Dockerfile
+++ b/langs/civet/Dockerfile
@@ -32,32 +32,34 @@ COPY --from=0 /usr/lib/libada.so.3                                       \
               /usr/lib/libstdc++.so.6                                    \
               /usr/lib/libz.so.1                                         \
               /usr/lib/libzstd.so.1                                      /usr/lib/
-COPY --from=0 /package.json /register.js                                 /usr/local/
-COPY --from=0 /dist/civet                                                \
+COPY --parents                                                           \
+     --from=0 /package.json                                              \
+              /register.js                                               \
+              /dist/civet                                                \
               /dist/config.js                                            \
               /dist/main.js                                              \
-              /dist/ts-diagnostic.js                                     /usr/local/dist/
-COPY --from=0 /dist/unplugin/unplugin.js                                 /usr/local/dist/unplugin/
-COPY --from=0 /node_modules/@typescript/vfs/package.json                 /usr/local/node_modules/@typescript/vfs/
-COPY --from=0 /node_modules/@typescript/vfs/dist/index.js                \
-              /node_modules/@typescript/vfs/dist/vfs.cjs.development.js  /usr/local/node_modules/@typescript/vfs/dist/
-COPY --from=0 /node_modules/acorn/package.json                           /usr/local/node_modules/acorn/
-COPY --from=0 /node_modules/acorn/dist/acorn.js                          /usr/local/node_modules/acorn/dist/
-COPY --from=0 /node_modules/picomatch/index.js                           /usr/local/node_modules/picomatch/
-COPY --from=0 /node_modules/picomatch/lib/constants.js                   \
+              /dist/ts-diagnostic.js                                     \
+              /dist/unplugin/unplugin.js                                 \
+              /node_modules/@typescript/vfs/package.json                 \
+              /node_modules/@typescript/vfs/dist/index.js                \
+              /node_modules/@typescript/vfs/dist/vfs.cjs.development.js  \
+              /node_modules/acorn/package.json                           \
+              /node_modules/acorn/dist/acorn.js                          \
+              /node_modules/picomatch/index.js                           \
+              /node_modules/picomatch/lib/constants.js                   \
               /node_modules/picomatch/lib/parse.js                       \
               /node_modules/picomatch/lib/picomatch.js                   \
               /node_modules/picomatch/lib/scan.js                        \
-              /node_modules/picomatch/lib/utils.js                       /usr/local/node_modules/picomatch/lib/
-COPY --from=0 /node_modules/unplugin/package.json                        /usr/local/node_modules/unplugin/
-COPY --from=0 /node_modules/unplugin/dist/context-*.cjs                  \
+              /node_modules/picomatch/lib/utils.js                       \
+              /node_modules/unplugin/package.json                        \
+              /node_modules/unplugin/dist/context-*.cjs                  \
               /node_modules/unplugin/dist/index.js                       \
               /node_modules/unplugin/dist/index.cjs                      \
               /node_modules/unplugin/dist/utils-*.cjs                    \
-              /node_modules/unplugin/dist/webpack-like-*.cjs             /usr/local/node_modules/unplugin/dist/
-COPY --from=0 /node_modules/webpack-virtual-modules/package.json         /usr/local/node_modules/webpack-virtual-modules/
-COPY --from=0 /node_modules/webpack-virtual-modules/lib/index.js         \
-              /node_modules/webpack-virtual-modules/lib/virtual-stats.js /usr/local/node_modules/webpack-virtual-modules/lib/
+              /node_modules/unplugin/dist/webpack-like-*.cjs             \
+              /node_modules/webpack-virtual-modules/package.json         \
+              /node_modules/webpack-virtual-modules/lib/index.js         \
+              /node_modules/webpack-virtual-modules/lib/virtual-stats.js /usr/local/
 COPY --from=0 /usr/share/icu/76.1/icudt76l.dat                           /usr/share/icu/
 
 ENTRYPOINT ["/usr/local/dist/civet"]


### PR DESCRIPTION
The `--parents` flag allows us to preserve the parent directory structure of the source files on the destination they are copied to.

Currently, the area where a lot of files with different source structures end up in `/usr/local` looks like this:

```Dockerfile
COPY --from=0 /package.json /register.js                                 /usr/local/
COPY --from=0 /dist/civet                                                \
              /dist/config.js                                            \
              /dist/main.js                                              \
              /dist/ts-diagnostic.js                                     /usr/local/dist/
COPY --from=0 /dist/unplugin/unplugin.js                                 /usr/local/dist/unplugin/
COPY --from=0 /node_modules/@typescript/vfs/package.json                 /usr/local/node_modules/@typescript/vfs/
COPY --from=0 /node_modules/@typescript/vfs/dist/index.js                \
              /node_modules/@typescript/vfs/dist/vfs.cjs.development.js  /usr/local/node_modules/@typescript/vfs/dist/
COPY --from=0 /node_modules/acorn/package.json                           /usr/local/node_modules/acorn/
COPY --from=0 /node_modules/acorn/dist/acorn.js                          /usr/local/node_modules/acorn/dist/
COPY --from=0 /node_modules/picomatch/index.js                           /usr/local/node_modules/picomatch/
COPY --from=0 /node_modules/picomatch/lib/constants.js                   \
              /node_modules/picomatch/lib/parse.js                       \
              /node_modules/picomatch/lib/picomatch.js                   \
              /node_modules/picomatch/lib/scan.js                        \
              /node_modules/picomatch/lib/utils.js                       /usr/local/node_modules/picomatch/lib/
COPY --from=0 /node_modules/unplugin/package.json                        /usr/local/node_modules/unplugin/
COPY --from=0 /node_modules/unplugin/dist/context-*.cjs                  \
              /node_modules/unplugin/dist/index.js                       \
              /node_modules/unplugin/dist/index.cjs                      \
              /node_modules/unplugin/dist/utils-*.cjs                    \
              /node_modules/unplugin/dist/webpack-like-*.cjs             /usr/local/node_modules/unplugin/dist/
COPY --from=0 /node_modules/webpack-virtual-modules/package.json         /usr/local/node_modules/webpack-virtual-modules/
COPY --from=0 /node_modules/webpack-virtual-modules/lib/index.js         \
              /node_modules/webpack-virtual-modules/lib/virtual-stats.js /usr/local/node_modules/webpack-virtual-modules/lib/
```

Take the `/node_modules` directory for example. You could simply copy the entire directory to `/usr/local/node_modules`, but that would undoubtedly result in a _RIDICULOUSLY_ large image. Instead of preserving the parent structure on the destination by repeating everything exactly, we can use the `--parents` flag.

In the code snippet above, every copied file goes somewhere in `/usr/local`, so it's ideal to tell Docker what our destination is and to bring everything along.

```Dockerfile
COPY --parents                                                           \
     --from=0 /package.json                                              \
              /register.js                                               \
              /dist/civet                                                \
              /dist/config.js                                            \
              /dist/main.js                                              \
              /dist/ts-diagnostic.js                                     \
              /dist/unplugin/unplugin.js                                 \
              /node_modules/@typescript/vfs/package.json                 \
              /node_modules/@typescript/vfs/dist/index.js                \
              /node_modules/@typescript/vfs/dist/vfs.cjs.development.js  \
              /node_modules/acorn/package.json                           \
              /node_modules/acorn/dist/acorn.js                          \
              /node_modules/picomatch/index.js                           \
              /node_modules/picomatch/lib/constants.js                   \
              /node_modules/picomatch/lib/parse.js                       \
              /node_modules/picomatch/lib/picomatch.js                   \
              /node_modules/picomatch/lib/scan.js                        \
              /node_modules/picomatch/lib/utils.js                       \
              /node_modules/unplugin/package.json                        \
              /node_modules/unplugin/dist/context-*.cjs                  \
              /node_modules/unplugin/dist/index.js                       \
              /node_modules/unplugin/dist/index.cjs                      \
              /node_modules/unplugin/dist/utils-*.cjs                    \
              /node_modules/unplugin/dist/webpack-like-*.cjs             \
              /node_modules/webpack-virtual-modules/package.json         \
              /node_modules/webpack-virtual-modules/lib/index.js         \
              /node_modules/webpack-virtual-modules/lib/virtual-stats.js /usr/local/
```