### PR TITLE
Make Erlang's Dockerfile more efficient by using `COPY --parents`

### DIFF
--- a/config/data/langs.toml
+++ b/config/data/langs.toml
@@ -658,7 +658,7 @@ none
 [Elixir]
 args    = [ '/usr/local/bin/elixir', '--color', '-e', '$code', '--' ]
 env     = [ 'LANG=C.UTF-8' ]
-size    = '57.2 MiB'
+size    = '57.0 MiB'
 version = '1.19.5'
 website = 'https://elixir-lang.org'
 example = '''
@@ -676,8 +676,8 @@ for arg <- System.argv, do: IO.puts arg
 args     = [ '/usr/bin/erlang', '-' ]
 env      = [ 'LANG=C.UTF-8' ]
 released = 2025-11-27
-size     = '50.1 MiB'
-version  = 'OTP 28.3.1'
+size     = '50.0 MiB'
+version  = 'OTP 28.3.3'
 website  = 'https://www.erlang.org'
 example  = '''
 main(Args) ->
@@ -801,7 +801,7 @@ end
 [Gleam]
 args    = [ '/usr/bin/gleam', '-' ]
 env     = [ 'LANG=C.UTF-8' ]
-size    = '70.4 MiB'
+size    = '70.2 MiB'
 version = '1.14.0'
 website = 'https://gleam.run'
 example = '''

--- a/langs/erlang/Dockerfile
+++ b/langs/erlang/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update                   \
     apt-get install --yes curl gcc make perl
 
 # Also rebuild Elixir, Gleam.
-ENV VER=28.3.1
+ENV VER=28.3.3
 
 WORKDIR /erlang
 
@@ -20,46 +20,37 @@ RUN ./configure            \
  && make install           \
  && strip /usr/bin/escript
 
-WORKDIR /usr/lib/erlang/lib
+COPY erlang.c .
 
-RUN mv ../erts* /usr/local          \
- && find /usr/local -type f -not \( \
-    -name 'beam.smp'        -or     \
-    -name 'erl_child_setup' -or     \
-    -name 'erlexec'         -or     \
-    -name 'inet_gethost' \) -delete
-
-RUN mv compiler*                        \
-       kernel*                          \
-       parsetools*                      \
-       stdlib*                          \
-       tools* /usr/local/lib            \
- && find /usr/local/lib -type f -not \( \
-    -name '*.*a*'     -or               \
-    -name 'file.hrl'  -or               \
-    -name 'make.beam' -or               \
-    -name 'yecc*' \) -delete
-
-COPY erlang.c /
-
-RUN gcc -Wall -Werror -Wextra -o /usr/bin/erlang -s /erlang.c
+RUN gcc -Wall -Werror -Wextra -o /usr/bin/erlang -s erlang.c
 
 FROM codegolf/lang-base
 
-COPY --from=0 /bin/dash                              /bin/sh
-COPY --from=0 /lib/x86_64-linux-gnu/libc.so.6        \
-              /lib/x86_64-linux-gnu/libm.so.6        /lib/
-COPY --from=0 /lib64/ld-linux-x86-64.so.2            /lib64/
-COPY --from=0 /usr/bin/basename                      \
-              /usr/bin/dirname                       \
-              /usr/bin/erl                           \
-              /usr/bin/erlang                        \
-              /usr/bin/erlc                          \
-              /usr/bin/escript                       /usr/bin/
-COPY --from=0 /usr/local                             /usr/lib/erlang
-COPY --from=0 /usr/lib/erlang/bin/no_dot_erlang.boot \
-              /usr/lib/erlang/bin/start.boot         /usr/lib/erlang/bin/
-COPY --from=0 /usr/lib/locale                        /usr/lib/locale
+COPY --from=0 /bin/dash                                    /bin/sh
+COPY --from=0 /lib/x86_64-linux-gnu/libc.so.6              \
+              /lib/x86_64-linux-gnu/libm.so.6              /lib/
+COPY --from=0 /lib64/ld-linux-x86-64.so.2                  /lib64/
+COPY --from=0 /usr/bin/basename                            \
+              /usr/bin/dirname                             \
+              /usr/bin/erl                                 \
+              /usr/bin/erlang                              \
+              /usr/bin/erlc                                \
+              /usr/bin/escript                             /usr/bin/
+COPY --parents                                             \
+     --from=0 /usr/lib/erlang/./erts-*/bin/beam.smp        \
+              /usr/lib/erlang/./erts-*/bin/erl_child_setup \
+              /usr/lib/erlang/./erts-*/bin/erlexec         \
+              /usr/lib/erlang/./erts-*/bin/inet_gethost    \
+              /usr/lib/erlang/./bin/no_dot_erlang.boot     \
+              /usr/lib/erlang/./bin/start.boot             \
+              /usr/lib/erlang/./lib/compiler-*/ebin        \
+              /usr/lib/erlang/./lib/kernel-*/ebin          \
+              /usr/lib/erlang/./lib/kernel-*/include       \
+              /usr/lib/erlang/./lib/parsetools-*/ebin      \
+              /usr/lib/erlang/./lib/parsetools-*/include   \
+              /usr/lib/erlang/./lib/stdlib-*/ebin          \
+              /usr/lib/erlang/./lib/tools-*/ebin           /usr/lib/erlang/
+COPY --from=0 /usr/lib/locale                              /usr/lib/locale
 
 ENTRYPOINT ["erlang"]
 


### PR DESCRIPTION
When I was working on #2284, this was EXACTLY what I was looking for, so we didn't have to worry about versioned folders being updated with every release.

```Dockerfile
COPY --parents                                             \
     --from=0 /usr/lib/erlang/./erts-*/bin/beam.smp        \
              /usr/lib/erlang/./erts-*/bin/erl_child_setup \
              /usr/lib/erlang/./erts-*/bin/erlexec         \
              /usr/lib/erlang/./erts-*/bin/inet_gethost    \
              /usr/lib/erlang/./bin/no_dot_erlang.boot     \
              /usr/lib/erlang/./bin/start.boot             \
              /usr/lib/erlang/./lib/compiler-*/ebin        \
              /usr/lib/erlang/./lib/kernel-*/ebin          \
              /usr/lib/erlang/./lib/kernel-*/include       \
              /usr/lib/erlang/./lib/parsetools-*/ebin      \
              /usr/lib/erlang/./lib/parsetools-*/include   \
              /usr/lib/erlang/./lib/stdlib-*/ebin          \
              /usr/lib/erlang/./lib/tools-*/ebin           /usr/lib/erlang/
```

The period indicates the point from which the parent structure should remain intact.

While I was in `langs/erlang`, I also upgraded the version from 28.3.1 to **28.3.3**.