### PR TITLE
Hide whitespace markings in the editor from visitors

### DIFF
--- a/views/html/hole/classic.html
+++ b/views/html/hole/classic.html
@@ -1,7 +1,7 @@
 {{ template "header"      . }}
 {{ template "hole-header" . }}
 
-{{ $showWhitespace := index .SettingValues "hole" "show-whitespace" }}
+{{ $showWhitespace := and .Golfer (index .SettingValues "hole" "show-whitespace") }}
 <main id="hole-{{ .Data.Hole.ID }}" {{ if $showWhitespace }} class=show-whitespace {{ end }}>
     <details id=details {{ if not .Data.HideDetails }}open{{ end }}>
         <summary>Details</summary>


### PR DESCRIPTION
It feels unnatural to let visitors use an extra feature that's part of the personal page settings of logged-in users. This solves that problem.

Closes #2079