### PR TITLE
Give the golden container a min-height that is approx. equal to default

### DIFF
--- a/css/hole/tabs.css
+++ b/css/hole/tabs.css
@@ -107,7 +107,8 @@ section header {
 
 #golden-container {
     grid-row: 5 / 6;
-    width: 100%; 
+    width: 100%;
+    min-height: 40rem;
     position: relative;
     /* Prevent overflow from maximized panels */
     overflow: hidden;


### PR DESCRIPTION
Resolves #2120

The screenshot was taken with a zoom factor of 200%.

<img width="3840" height="1930" alt="image" src="https://github.com/user-attachments/assets/c97e35bc-5a81-4746-8fd3-a8e57ce29990"/>