### PR TITLE
Make VimL faster

### DIFF
--- a/langs/viml/viml.c
+++ b/langs/viml/viml.c
@@ -74,7 +74,7 @@ int main(int argc, char* argv[]) {
     if (fclose(fp))
         ERR_AND_EXIT("fclose");
 
-    system("/usr/bin/vim --clean --not-a-term --noplugin -eZ -V1 +0 -S code.vim output >&2");
+    system("/usr/bin/vim --clean --not-a-term --noplugin -eZ -V1 -S code.vim output >&2");
 
     if (!(fp = fopen("output", "r")))
         ERR_AND_EXIT("fopen");


### PR DESCRIPTION
Drop `+0` from vim's invocation. Output buffer is always empty, so `+0` always raises `E749: Empty Buffer` which makes vim wait ~1s before certain actions.

Pretty confident that this shouldn't break any solutions and only effect should be some of the vim solutions getting ~1s faster.