### PR TITLE
fix: prefer svg favicon so colour is correct in dark mode

### DIFF
--- a/views/html/header.html
+++ b/views/html/header.html
@@ -2,7 +2,7 @@
 
 <html lang=en>
 
-<link href=/icon.svg     rel=icon>
+<link href=/icon.svg     rel=icon type="image/svg+xml">
 <link href=/icon-16.png  rel=icon sizes=16x16>
 <link href=/icon-32.png  rel=icon sizes=32x32>
 <link href=/icon-180.png rel=apple-touch-icon>

--- a/views/html/header.html
+++ b/views/html/header.html
@@ -2,7 +2,7 @@
 
 <html lang=en>
 
-<link href=/icon.svg     rel=icon type="image/svg+xml">
+<link href=/icon.svg     rel=icon type=image/svg+xml>
 <link href=/icon-16.png  rel=icon sizes=16x16>
 <link href=/icon-32.png  rel=icon sizes=32x32>
 <link href=/icon-180.png rel=apple-touch-icon>


### PR DESCRIPTION
In darkmode the favicon isn't changing to white as it looks like its picking up the fixed colour png, but favouring the svg seems to do the trick

<img width="116" height="71" alt="image" src="https://github.com/user-attachments/assets/87e83db4-3295-44ae-9aa6-a9d0be8e43b3" />
