### PR TITLE
Top bar redesign

### DIFF
--- a/assets/css/common/base.css
+++ b/assets/css/common/base.css
@@ -141,6 +141,10 @@ h3 { font-size: 1.25rem }
     min-width: 2.75rem;
 }
 
+@media not (max-width: 34rem) {
+    #site-header nav > a:not([title=Profile]) { padding: 0 .75rem }
+}
+
 #site-header a:is(.on, :hover) {
     background: var(--background);
     color: var(--color);

--- a/views/html/footer.html
+++ b/views/html/footer.html
@@ -8,6 +8,8 @@
         •
         <a href=//github.com/code-golf/code-golf>Git</a>
         •
+        <a href=/stats>Statistics</a>
+        •
         <a href=//status.code.golf>Status</a>
     </nav>
 </footer>

--- a/views/html/header.html
+++ b/views/html/header.html
@@ -82,6 +82,11 @@
             href=/ title=Home>
             {{ svg "logo" }}
         </a>
+        <a {{ if eq .Path "/about" }} class=on {{ end }}
+            href=/about title=About>
+            <span class=thin>{{ svg "question-circle" }}</span>
+            <span class=wide>About</span>
+        </a>
         <a {{ if eq .Path "/ideas" }} class=on {{ end }}
             href=/ideas title=Ideas>
             <span class=thin>{{ svg "lightbulb-light" }}</span>
@@ -97,21 +102,12 @@
             <span class=thin>{{ svg "trophy" }}</span>
             <span class=wide>Rankings</span>
         </a>
-        <a {{ if hasPrefix .Path "/stats" }} class=on {{ end }}
-            href=/stats title=Statistics>
-            <span class=thin>{{ svg "graph-up" }}</span>
-            <span class=wide>Stats</span>
-        </a>
         <a {{ if hasPrefix .Path "/wiki" }} class=on {{ end }}
             href=/wiki title=Wiki>
             <span class=thin>{{ svg "journals" }}</span>
             <span class=wide>Wiki</span>
         </a>
         <div></div>
-        <a {{ if eq .Path "/about" }} class=on {{ end }}
-            href=/about title=About>
-            {{ svg "question-circle" }}
-        </a>
     {{ with .Golfer }}
         {{ $slug := (print "/golfers/" .Name) }}
 

--- a/views/html/header.html
+++ b/views/html/header.html
@@ -84,27 +84,27 @@
         </a>
         <a {{ if eq .Path "/about" }} class=on {{ end }}
             href=/about title=About>
-            <span class=thin>{{ svg "question-circle" }}</span>
+            {{ svg "question-circle" "class" "thin" }}
             <span class=wide>About</span>
         </a>
         <a {{ if eq .Path "/ideas" }} class=on {{ end }}
             href=/ideas title=Ideas>
-            <span class=thin>{{ svg "lightbulb-light" }}</span>
+            {{ svg "lightbulb-light" "class" "thin" }}
             <span class=wide>Ideas</span>
         </a>
         <a {{ if hasPrefix .Path "/recent/" }} class=on {{ end }}
             href=/recent/solutions/all/all/bytes title=Recent>
-            <span class=thin>{{ svg "clock" }}</span>
+            {{ svg "clock" "class" "thin" }}
             <span class=wide>Recent</span>
         </a>
         <a {{ if hasPrefix .Path "/rankings/" }} class=on {{ end }}
             href=/rankings/holes/all/all/bytes title=Rankings>
-            <span class=thin>{{ svg "trophy" }}</span>
+            {{ svg "trophy" "class" "thin" }}
             <span class=wide>Rankings</span>
         </a>
         <a {{ if hasPrefix .Path "/wiki" }} class=on {{ end }}
             href=/wiki title=Wiki>
-            <span class=thin>{{ svg "journals" }}</span>
+            {{ svg "journals" "class" "thin" }}
             <span class=wide>Wiki</span>
         </a>
         <div></div>
@@ -120,7 +120,7 @@
         </a>
     {{ else }}
         <a class=log-in href="{{ .LogInURL }}" title="Log In">
-            <span class=thin>{{ svg "sign-in-alt-light" }}</span>
+            {{ svg "sign-in-alt-light" "class" "thin" }}
             <span class=wide>Log In</span>
         </a>
     {{ end }}

--- a/views/html/header.html
+++ b/views/html/header.html
@@ -82,31 +82,36 @@
             href=/ title=Home>
             {{ svg "logo" }}
         </a>
+        <a {{ if eq .Path "/ideas" }} class=on {{ end }}
+            href=/ideas title=Ideas>
+            <span class=thin>{{ svg "lightbulb-light" }}</span>
+            <span class=wide>Ideas</span>
+        </a>
+        <a {{ if hasPrefix .Path "/recent/" }} class=on {{ end }}
+            href=/recent/solutions/all/all/bytes title=Recent>
+            <span class=thin>{{ svg "clock" }}</span>
+            <span class=wide>Recent</span>
+        </a>
+        <a {{ if hasPrefix .Path "/rankings/" }} class=on {{ end }}
+            href=/rankings/holes/all/all/bytes title=Rankings>
+            <span class=thin>{{ svg "trophy" }}</span>
+            <span class=wide>Rankings</span>
+        </a>
+        <a {{ if hasPrefix .Path "/stats" }} class=on {{ end }}
+            href=/stats title=Statistics>
+            <span class=thin>{{ svg "graph-up" }}</span>
+            <span class=wide>Stats</span>
+        </a>
+        <a {{ if hasPrefix .Path "/wiki" }} class=on {{ end }}
+            href=/wiki title=Wiki>
+            <span class=thin>{{ svg "journals" }}</span>
+            <span class=wide>Wiki</span>
+        </a>
+        <div></div>
         <a {{ if eq .Path "/about" }} class=on {{ end }}
             href=/about title=About>
             {{ svg "question-circle" }}
         </a>
-        <a {{ if eq .Path "/ideas" }} class=on {{ end }}
-            href=/ideas title=Ideas>
-            {{ svg "lightbulb-light" }}
-        </a>
-        <a {{ if hasPrefix .Path "/recent/" }} class=on {{ end }}
-            href=/recent/solutions/all/all/bytes title=Recent>
-            {{ svg "clock" }}
-        </a>
-        <a {{ if hasPrefix .Path "/rankings/" }} class=on {{ end }}
-            href=/rankings/holes/all/all/bytes title=Rankings>
-            {{ svg "trophy" }}
-        </a>
-        <a {{ if hasPrefix .Path "/stats" }} class=on {{ end }}
-            href=/stats title=Statistics>
-            {{ svg "graph-up" }}
-        </a>
-        <a {{ if hasPrefix .Path "/wiki" }} class=on {{ end }}
-            href=/wiki title=Wiki>
-            {{ svg "journals" }}
-        </a>
-        <div></div>
     {{ with .Golfer }}
         {{ $slug := (print "/golfers/" .Name) }}
 
@@ -119,7 +124,8 @@
         </a>
     {{ else }}
         <a class=log-in href="{{ .LogInURL }}" title="Log In">
-            {{ svg "sign-in-alt-light" }}
+            <span class=thin>{{ svg "sign-in-alt-light" }}</span>
+            <span class=wide>Log In</span>
         </a>
     {{ end }}
     </nav>


### PR DESCRIPTION
The icons are a bit hard to read, and I have to think a little every time I click them. We can just use words when the screen is wide enough:

<img height="902" alt="image" src="https://github.com/user-attachments/assets/d94d7e0a-b8bf-4b0a-98a1-47c758e20e2d" />

"Statistics" is moved to the footer.

---

FWIW I'm not alone in feeling like this:

<img width="1480" height="190" alt="image" src="https://github.com/user-attachments/assets/97828c81-5678-4cf5-b09f-9bf45cf6f46f" />

A few days ago I introduced someone to code.golf and I watched them have to hover over the icons to see what they navigate to.