### PR TITLE
Redesign list of holes

### DIFF
--- a/assets/css/common/base.css
+++ b/assets/css/common/base.css
@@ -668,17 +668,67 @@ body > .tabs {
 
 #error h1 { text-align: center }
 
-#home { grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)) }
+#home {
+    column-gap: 3rem;
+    columns: 18rem;
+    display: block;
+}
 
 #home > nav {
+    column-span: all;
     display: flex;
     justify-content: flex-end;
+    margin-bottom: 1rem;
+}
+
+#home > h1 {
+    column-span: all;
+    margin-bottom: 1rem;
 }
 
 #home > .grid {
     border: 2px solid var(--color);
     padding: 1rem;
 }
+
+#home > a {
+    align-items: center;
+    break-inside: avoid;
+    color: var(--color);
+    column-gap: .5rem;
+    display: grid;
+    grid-template-columns: 1rem 1fr 1rem 3rem;
+    padding: .25rem .25rem;
+    text-decoration: none;
+}
+
+#home > a:hover h2 { text-decoration: underline }
+
+#home > a > h2 {
+    font-size: 1rem;
+    font-weight: normal;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+#home > a > span {
+    color: var(--grey);
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+}
+
+#home > a > svg {
+    height: 1rem;
+    width: 1rem;
+}
+
+#home > a > svg.red    { background: none; color: var(--red-fg)    }
+#home > a > svg.orange { background: none; color: var(--orange-fg) }
+#home > a > svg.yellow { background: none; color: var(--yellow-fg) }
+#home > a > svg.green  { background: none; color: var(--green-fg)  }
+#home > a > svg.blue   { background: none; color: var(--blue-fg)   }
+#home > a > svg.purple { background: none; color: var(--purple-fg) }
 
 #popups {
     align-items: flex-end;

--- a/assets/css/common/dark.css
+++ b/assets/css/common/dark.css
@@ -16,6 +16,14 @@
     --blue:       hsl(205, 80%, 36%);
     --purple:     hsl(265, 60%, 36%);
 
+    /* Foreground/icon colors — brighter so they read well on dark. */
+    --red-fg:     hsl(357, 80%, 65%);
+    --orange-fg:  hsl( 27, 90%, 60%);
+    --yellow-fg:  hsl( 50, 85%, 60%);
+    --green-fg:   hsl(150, 65%, 55%);
+    --blue-fg:    hsl(205, 80%, 65%);
+    --purple-fg:  hsl(265, 70%, 70%);
+
     /* For dark mode, the light colors are darker than the typical ones. */
     --light-blue:   hsl(210, 50%, 15%);
     --light-green:  hsl(150, 80%, 15%);

--- a/assets/css/common/light.css
+++ b/assets/css/common/light.css
@@ -14,6 +14,14 @@
     --blue:       #45AAF2BB;
     --purple:     #8C7AE6BB;
 
+    /* Foreground/icon colors — darker so they read well on white. */
+    --red-fg:     #d32f2f;
+    --orange-fg:  #e68100;
+    --yellow-fg:  #f8b60b;
+    --green-fg:   #2ebd32;
+    --blue-fg:    #1565e0;
+    --purple-fg:  #8a1bca;
+
     --light-blue:   #def;
     --light-green:  #efd;
     --light-grey:   #eee;

--- a/views/html/home.html
+++ b/views/html/home.html
@@ -21,8 +21,9 @@
         {{ template "page-settings" . }}
     </nav>
 {{ end }}
+    <h1 class=span>Holes</h1>
 {{ range .Data }}
-    <a class="card {{ .Hole.CategoryColor }}"
+    <a
     {{ if $.Golfer }}
         {{ $lang    := index $.SettingValues $.Name "points-for" }}
         {{ $scoring := index $.SettingValues $.Name "scoring"    }}
@@ -35,13 +36,11 @@
         href="{{ .Hole.ID }}"
     {{ end }}
        title="{{ .Hole.Name }} ({{ .Hole.Category }})">
+        {{ svg .Hole.CategoryIcon "class" .Hole.CategoryColor }}
         <h2>{{ .Hole.Name }}</h2>
-        {{ svg .Hole.CategoryIcon }}
     {{ if .Lang }}
-        <span title="{{ comma .Points }} points in {{ .Lang.Name }}">
-            {{ comma .Points }}
-            {{ svg .Lang.ID }}
-        </span>
+        {{ svg .Lang.ID }}
+        <span title="{{ comma .Points }} points in {{ .Lang.Name }}">{{ comma .Points }}</span>
     {{ end }}
     </a>
 {{ end }}


### PR DESCRIPTION
I think our current front page looks garish, and doesn't scale to having 100+ holes.

<img width="2536" height="1704" alt="image" src="https://github.com/user-attachments/assets/d73acb04-cd08-4dcc-aefc-8f97f4386ad2" />

This PR introduces a simpler design that's easier to parse:

<img width="2548" height="1564" alt="image" src="https://github.com/user-attachments/assets/4b56f36c-1498-4edc-b4be-d7b84e446711" />
