### PR TITLE
Fail solutions that output more than 128k

### DIFF
--- a/hole/play.go
+++ b/hole/play.go
@@ -52,6 +52,7 @@ type Run struct {
 	Pass                  bool          `json:"pass"`
 	Stderr                string        `json:"stderr"`
 	Stdout                string        `json:"stdout"`
+	StdoutOverflow        bool          `json:"-"`
 	Time                  time.Duration `json:"time_ns,format:nano"`
 	Timeout               bool          `json:"timeout"`
 
@@ -126,8 +127,8 @@ func play(
 	run.MultisetItemDelimiter = hole.MultisetItemDelimiter
 	run.Answer = holeJudges[hole.ID](*run)
 
-	// Timeouts and whitespace only output never pass.
-	if !run.Timeout && len(strings.TrimSpace(run.Stdout)) != 0 {
+	// Stdout overflows, timeouts, and whitespace only output never pass.
+	if !run.StdoutOverflow && !run.Timeout && len(strings.TrimSpace(run.Stdout)) != 0 {
 		if hole.CaseFold {
 			run.Pass = strings.EqualFold(run.Answer, run.Stdout)
 		} else {
@@ -327,6 +328,12 @@ func runCode(
 
 	const maxLength = 128 * 1024 // 128 KiB
 
+	stdoutBytes := stdout.Next(maxLength)
+	if stdout.Len() != 0 {
+		run.StdoutOverflow = true
+		fmt.Fprint(&stderr, "Failed for exceeding the ", maxLength, " bytes output limit.\n")
+	}
+
 	// Trim trailing whitespace.
 	stderrBytes := bytes.TrimRightFunc(stderr.Next(maxLength), unicode.IsSpace)
 
@@ -337,8 +344,6 @@ func runCode(
 	if run.Stderr == "&nbsp;" {
 		run.Stderr = ""
 	}
-
-	stdoutBytes := stdout.Next(maxLength)
 
 	// Postprocess output in apl or sed.
 	// Convert apl's carriage returns or sed's null bytes to newlines.

--- a/hole/play.go
+++ b/hole/play.go
@@ -43,16 +43,16 @@ func trimPerLine(bytesSlice []byte) string {
 
 // Run holds the results of running a given solution once.
 type Run struct {
-	Answer                string        `json:"answer"`
-	Code                  string        `json:"-"`
-	MultisetItemDelimiter string        `json:"multiset_item_delimiter"`
-	OutputDelimiter       string        `json:"output_delimiter"`
-	Args                  []string      `json:"args"`
-	ExitCode              int           `json:"exit_code"`
-	Pass                  bool          `json:"pass"`
-	Stderr                string        `json:"stderr"`
-	Stdout                string        `json:"stdout"`
-	StdoutOverflow        bool          `json:"-"`
+	Answer                string   `json:"answer"`
+	Code                  string   `json:"-"`
+	MultisetItemDelimiter string   `json:"multiset_item_delimiter"`
+	OutputDelimiter       string   `json:"output_delimiter"`
+	Args                  []string `json:"args"`
+	ExitCode              int      `json:"exit_code"`
+	Pass                  bool     `json:"pass"`
+	Stderr                string   `json:"stderr"`
+	Stdout                string   `json:"stdout"`
+	stdoutOverflow        bool
 	Time                  time.Duration `json:"time_ns,format:nano"`
 	Timeout               bool          `json:"timeout"`
 
@@ -128,7 +128,7 @@ func play(
 	run.Answer = holeJudges[hole.ID](*run)
 
 	// Stdout overflows, timeouts, and whitespace only output never pass.
-	if !run.StdoutOverflow && !run.Timeout && len(strings.TrimSpace(run.Stdout)) != 0 {
+	if !run.stdoutOverflow && !run.Timeout && len(strings.TrimSpace(run.Stdout)) != 0 {
 		if hole.CaseFold {
 			run.Pass = strings.EqualFold(run.Answer, run.Stdout)
 		} else {
@@ -330,7 +330,7 @@ func runCode(
 
 	stdoutBytes := stdout.Next(maxLength)
 	if stdout.Len() != 0 {
-		run.StdoutOverflow = true
+		run.stdoutOverflow = true
 		fmt.Fprint(&stderr, "Failed for exceeding the ", maxLength, " bytes output limit.\n")
 	}
 

--- a/t/truncate.t
+++ b/t/truncate.t
@@ -8,6 +8,14 @@ is run('say "abc", " " x 2**16  ')<runs>[0]<stdout>, 'abc', 'Really long line';
 is run('say "abc", " \n\r\t" x 9')<runs>[0]<stdout>, 'abc', 'Lots of trailing whitespace';
 is run('say "abc \t \x0B \f \r "')<runs>[0]<stdout>, 'abc', 'Different whitespace';
 
+my $code = 'say "Fizz" x !($_ % 3) . "Buzz" x !($_ % 5) || $_ for 1 .. 100';
+
+is-deeply run($code)<runs>[0]<pass>:kv.Hash,
+    { :pass }, 'Passing without overflow';
+
+is-deeply run("$code; say ' ' x (128 * 1024)")<runs>[0]<pass>:kv.Hash,
+    { :!pass }, 'Failing with overflow';
+
 sub run { post-solution :$^code, :lang<perl> }
 
 done-testing;

--- a/t/truncate.t
+++ b/t/truncate.t
@@ -10,11 +10,15 @@ is run('say "abc \t \x0B \f \r "')<runs>[0]<stdout>, 'abc', 'Different whitespac
 
 my $code = 'say "Fizz" x !($_ % 3) . "Buzz" x !($_ % 5) || $_ for 1 .. 100';
 
-is-deeply run($code)<runs>[0]<pass>:kv.Hash,
-    { :pass }, 'Passing without overflow';
+is-deeply run($code)<runs>[0]<pass stderr>:kv.Hash,
+    { :pass, :stderr('') }, 'Passing without overflow';
 
-is-deeply run("$code; say ' ' x (128 * 1024)")<runs>[0]<pass>:kv.Hash,
-    { :!pass }, 'Failing with overflow';
+$code ~= '; say " " x (128 * 1024)';
+
+is-deeply run($code)<runs>[0]<pass stderr>:kv.Hash, {
+    pass            => False,
+    stderr          => 'Failed for exceeding the 131072 bytes output limit.',
+}, 'Failing with overflow';
 
 sub run { post-solution :$^code, :lang<perl> }
 


### PR DESCRIPTION
If a solution prints non-whitespace characters after 128k, they are truncated and it could be accepted if the output matches after truncate. These kinds of solutions are technically wrong and should be rejected.

This will likely fail many top C solutions.

Thanks @HPWiz for pointing it out
https://discord.com/channels/756829356155731988/800680710964903946/1506099018940547142