### PR TITLE
Add Gray Code Encoder run with 0 as first argument

### DIFF
--- a/hole/gray-code.go
+++ b/hole/gray-code.go
@@ -1,6 +1,9 @@
 package hole
 
-import "strconv"
+import (
+	"slices"
+	"strconv"
+)
 
 var _ = answerFunc("gray-code-decoder", func() []Answer { return grayCode(true) })
 var _ = answerFunc("gray-code-encoder", func() []Answer { return grayCode(false) })
@@ -21,7 +24,8 @@ func grayCode(reverse bool) []Answer {
 
 	tests := make([]test, count)
 	sequential := make([]test, count)
-	for i, n := range shuffle(numbers) {
+	numbers_copy := slices.Clone(numbers)
+	for i, n := range shuffle(numbers_copy) {
 		dec := strconv.Itoa(n)
 		rbc := strconv.FormatInt(int64(n^n>>1), 2)
 
@@ -29,7 +33,7 @@ func grayCode(reverse bool) []Answer {
 			tests[i] = test{rbc, dec}
 		} else {
 			tests[i] = test{dec, rbc}
-			sequential[i] = test{strconv.Itoa(i), strconv.FormatInt(int64(i^i>>1), 2)}
+			sequential[i] = test{strconv.Itoa(numbers[i]), strconv.FormatInt(int64(numbers[i]^numbers[i]>>1), 2)}
 		}
 	}
 

--- a/hole/gray-code.go
+++ b/hole/gray-code.go
@@ -23,9 +23,9 @@ func grayCode(reverse bool) []Answer {
 	}
 
 	tests := make([]test, count)
-	sequential := make([]test, count)
-	numbers_copy := slices.Clone(numbers)
-	for i, n := range shuffle(numbers_copy) {
+	unpermuted := make([]test, count)
+	numbersCopy := slices.Clone(numbers)
+	for i, n := range shuffle(numbersCopy) {
 		dec := strconv.Itoa(n)
 		rbc := strconv.FormatInt(int64(n^n>>1), 2)
 
@@ -33,12 +33,12 @@ func grayCode(reverse bool) []Answer {
 			tests[i] = test{rbc, dec}
 		} else {
 			tests[i] = test{dec, rbc}
-			sequential[i] = test{strconv.Itoa(numbers[i]), strconv.FormatInt(int64(numbers[i]^numbers[i]>>1), 2)}
+			unpermuted[i] = test{strconv.Itoa(numbers[i]), strconv.FormatInt(int64(numbers[i]^numbers[i]>>1), 2)}
 		}
 	}
 
 	if reverse {
 		return outputTests(tests)
 	}
-	return outputTests(tests, sequential)
+	return outputTests(tests, unpermuted)
 }

--- a/hole/gray-code.go
+++ b/hole/gray-code.go
@@ -20,6 +20,7 @@ func grayCode(reverse bool) []Answer {
 	}
 
 	tests := make([]test, count)
+	sequential := make([]test, count)
 	for i, n := range shuffle(numbers) {
 		dec := strconv.Itoa(n)
 		rbc := strconv.FormatInt(int64(n^n>>1), 2)
@@ -28,8 +29,12 @@ func grayCode(reverse bool) []Answer {
 			tests[i] = test{rbc, dec}
 		} else {
 			tests[i] = test{dec, rbc}
+			sequential[i] = test{strconv.Itoa(i), strconv.FormatInt(int64(i^i>>1), 2)}
 		}
 	}
 
-	return outputTests(tests)
+	if reverse {
+		return outputTests(tests)
+	}
+	return outputTests(tests, sequential)
 }


### PR DESCRIPTION
In the same spirit as #2685, this should fail my GolfScript 17-byte/char solution (and potentially the others), which is flaky with a 1/4096 probability to fail.