### PR TITLE
Reduce number of Connect Four from 1000 to 500 per run

### DIFF
--- a/hole/connect-four.go
+++ b/hole/connect-four.go
@@ -381,7 +381,7 @@ var _ = answerFunc("connect-four", func() []Answer {
 		tests = append(tests, test{moves, "Yellow"})
 	}
 
-	const argc = 1000 // Preserve original argc
+	const argc = 500
 
 	for range argc*2 - len(tests) {
 		moves, expected := emulPlay()


### PR DESCRIPTION
This reduces the size of ARGV (45kB -> 22.5kB), allowing the hole to be solved in J.

Currently, there are about 280 fixed cases and 1720 randomly generated test cases tested across two runs. This change would reduce this to 280 fixed and 720 random cases. I'm not aware of issues with flakyness on that hole, if we need more testcases, we could increase the number of runs instead.

This does change `argc`, so solutions relying on the fixed value might break and need to be updated accordingly.