### PR TITLE
Show only most tied golds that are not diamonds

### DIFF
--- a/routes/rankings_medals.go
+++ b/routes/rankings_medals.go
@@ -116,7 +116,7 @@ func rankingsMedalsGET(w http.ResponseWriter, r *http.Request) {
 			      AND $2 IN ('all', lang::text)
 			      AND $3 IN ('all', scoring::text)
 			 GROUP BY hole, lang, scoring
-			   HAVING COUNT(*) > 1
+				HAVING COUNT(*) > 1
 			 ORDER BY rank, hole, lang, scoring
 			    LIMIT $4 OFFSET $5`
 

--- a/routes/rankings_medals.go
+++ b/routes/rankings_medals.go
@@ -116,6 +116,7 @@ func rankingsMedalsGET(w http.ResponseWriter, r *http.Request) {
 			      AND $2 IN ('all', lang::text)
 			      AND $3 IN ('all', scoring::text)
 			 GROUP BY hole, lang, scoring
+			   HAVING COUNT(*) > 1
 			 ORDER BY rank, hole, lang, scoring
 			    LIMIT $4 OFFSET $5`
 


### PR DESCRIPTION
As discussed in the discord, on the medal rankings page any most tied golds that only have 1 person with the gold (a diamond), are no longer shown.