### PR TITLE
Fix trailing spaces in TeX

### DIFF
--- a/langs/tex/tex.c
+++ b/langs/tex/tex.c
@@ -65,7 +65,11 @@ int main(int argc, char* argv[]) {
         // ensures that arg0 is preceded by a digit (which removes the space), or a macro which doesn't get expanded (which removes the space).
         //
         // Note: If you ever come back to this, make sure it works for argv{\the\i}, argv\i, and argv{\count0}, and hole args starting with digits.
-        if (!snprintf(body, sizeof(body), "\x05global\x05""def\x05""argv\x06""1\x01\x05ifnum\x06""1=0\x04%s\x05""else\x05ifcase\x06""1\x05or\x04%s\x05""fi\x05""fi\x02\x02", argv[1], each_join(&argv[1], argc, "\05or\x04")))
+        const char* first = argv[1];
+        const char* rest = each_join(&argv[1], argc, "\05or\x04");
+        //                         \global     \def     \argv     #1   {   \ifnum     #1=0 [first]   \else   \ifcase     #1   \or [rest]    \fi     \fi   }   }
+        const char* template = "\x05global\x05""def\x05""argv\x06""1\x01\x05ifnum\x06""1=0\x04%s\x05""else\x05ifcase\x06""1\x05or\x04%s\x05""fi\x05""fi\x02\x02";
+        if (!snprintf(body, sizeof(body), template, first, rest))
             ERR_AND_EXIT("snprintf");
 
         strcat(init, body);

--- a/langs/tex/tex.c
+++ b/langs/tex/tex.c
@@ -38,12 +38,12 @@ int main(int argc, char* argv[]) {
         // All the special characters \{}%&#^_%~ are set to catcode 12 ("other").
         // Also set the whitespace characters to catcode 12, unlike \dospecials.
         // But we still need access to some to finish the definition, so we use
-        //   byte 1 = begin group (previously {)
-        //   byte 2 = end group (previously })
-        //   byte 4 = space
-        //   byte 5 = escape (previously \)
-        //   byte 6 = parameter (previously #)
-        //   byte 7 = comment (previously %)
+        //   \x01 = begin group (previously {)
+        //   \x02 = end group (previously })
+        //   \x04 = space
+        //   \x05 = escape (previously \)
+        //   \x06 = parameter (previously #)
+        //   \x07 = comment (previously %)
         // The end of the group resets all the catcodes for future tokenizing, but it does not change the catcodes of the tokens already created.
         strcat(init, "{\\catcode1=1\\catcode2=2\\catcode5=0\\catcode6=6\\catcode4=10\\catcode7=14\\catcode`$=12\\catcode`&=12\\catcode`^=12\\catcode`_=12\\catcode37=12"
             "\\catcode`~=12\\catcode`#=12\\catcode`{=12\\catcode`}=12\\catcode9=12\\catcode32=12\\catcode10=12\\catcode12=12\\catcode13=13\\catcode92=12");
@@ -65,7 +65,7 @@ int main(int argc, char* argv[]) {
         // ensures that arg0 is preceded by a digit (which removes the space), or a macro which doesn't get expanded (which removes the space).
         //
         // Note: If you ever come back to this, make sure it works for argv{\the\i}, argv\i, and argv{\count0}, and hole args starting with digits.
-        if (!snprintf(body, sizeof(body), "globaldefargv1ifnum1=0%selseifcase1or%sfifi", argv[1], each_join(&argv[1], argc, "or")))
+        if (!snprintf(body, sizeof(body), "\x05global\x05""def\x05""argv\x06""1\x01\x05ifnum\x06""1=0\x04%s\x05""else\x05ifcase\x06""1\x05or\x04%s\x05""fi\x05""fi\x02\x02", argv[1], each_join(&argv[1], argc, "\05or\x04")))
             ERR_AND_EXIT("snprintf");
 
         strcat(init, body);

--- a/langs/tex/tex.c
+++ b/langs/tex/tex.c
@@ -9,7 +9,8 @@
 #define RAND_MAX __UINT16_MAX__
 #define ERR_AND_EXIT(msg) do { perror(msg); exit(EXIT_FAILURE); } while (0)
 
-char* each_join(char* arr[], int cnt, const char* sep);
+char* each_join(const char* arr[], int cnt, const char* sep);
+const char* sanitize_arg(const char* str);
 
 const char* tex = "/usr/local/bin/tex";
 
@@ -23,12 +24,23 @@ int main(int argc, char* argv[]) {
         ERR_AND_EXIT("chdir");
 
     char* code = argv[1];
+    
+    argc -= 2;
+    
+    // Now `argv[0]` is the executable name, `argv[1]` is the user code,
+    // and `argv[2]` to `argv[2 + (argv - 1)]` are the expected args. 
 
-    memmove(&argv[1], &argv[2], argc-- * sizeof(char*));
+    const char** sanitized_argv;
+    if (!(sanitized_argv = malloc(argc * sizeof(char**))))
+        ERR_AND_EXIT("malloc");
+
+    for (int i = 0; i < argc; i++) {
+        sanitized_argv[i] = sanitize_arg(argv[i + 2]);
+    }
 
     char init[RAND_MAX+1], body[RAND_MAX+1];
 
-    if (!snprintf(init, sizeof(init), "\\def\\argc{%d}", --argc))
+    if (!snprintf(init, sizeof(init), "\\def\\argc{%d}", argc))
         ERR_AND_EXIT("snprintf");
 
     if (argc == 0)
@@ -40,12 +52,13 @@ int main(int argc, char* argv[]) {
         // But we still need access to some to finish the definition, so we use
         //   \x01 = begin group (previously {)
         //   \x02 = end group (previously })
+        //   \x03 = superscript (previously ^)
         //   \x04 = space
         //   \x05 = escape (previously \)
         //   \x06 = parameter (previously #)
         //   \x07 = comment (previously %)
         // The end of the group resets all the catcodes for future tokenizing, but it does not change the catcodes of the tokens already created.
-        strcat(init, "{\\catcode1=1\\catcode2=2\\catcode5=0\\catcode6=6\\catcode4=10\\catcode7=14\\catcode`$=12\\catcode`&=12\\catcode`^=12\\catcode`_=12\\catcode37=12"
+        strcat(init, "{\\catcode1=1\\catcode2=2\\catcode3=7\\catcode5=0\\catcode6=6\\catcode4=10\\catcode7=14\\catcode`$=12\\catcode`&=12\\catcode`^=12\\catcode`_=12\\catcode37=12"
             "\\catcode`~=12\\catcode`#=12\\catcode`{=12\\catcode`}=12\\catcode9=12\\catcode32=12\\catcode10=12\\catcode12=12\\catcode13=13\\catcode92=12");
         // The following line reads something like
         //   \global\def\argv#1{
@@ -65,8 +78,8 @@ int main(int argc, char* argv[]) {
         // ensures that arg0 is preceded by a digit (which removes the space), or a macro which doesn't get expanded (which removes the space).
         //
         // Note: If you ever come back to this, make sure it works for argv{\the\i}, argv\i, and argv{\count0}, and hole args starting with digits.
-        const char* first = argv[1];
-        const char* rest = each_join(&argv[2], argc - 1, "\05or\x04");
+        const char* first = sanitized_argv[0];
+        const char* rest = each_join(&sanitized_argv[1], argc - 1, "\05or\x04");
         //                         \global     \def     \argv     #1   {   \ifnum     #1=0 [first]   \else   \ifcase     #1   \or [rest]    \fi     \fi   }   }
         const char* template = "\x05global\x05""def\x05""argv\x06""1\x01\x05ifnum\x06""1=0\x04%s\x05""else\x05ifcase\x06""1\x05or\x04%s\x05""fi\x05""fi\x02\x02";
         if (!snprintf(body, sizeof(body), template, first, rest))
@@ -153,7 +166,7 @@ int main(int argc, char* argv[]) {
 }
 
 // Join the length-`cnt` array `arr` of strings with separator `sep`.
-char* each_join(char* arr[], int cnt, const char* sep) {
+char* each_join(const char* arr[], int cnt, const char* sep) {
     if (cnt == 0) return "";
     size_t len;
 
@@ -171,4 +184,54 @@ char* each_join(char* arr[], int cnt, const char* sep) {
     }
 
     return rt;
+}
+
+int count_newlines(const char* str) {
+    const char* from_tmp = str;
+    const char* next_newline;
+    int count;
+    for (count = 0; (next_newline = strchr(from_tmp, '\n')); ++count) {
+        from_tmp = next_newline + 1;
+    }
+    return count;
+}
+
+const char* replace_newline_with(const char* str, const char* replacement) {
+    char from = '\n';
+
+    int count = count_newlines(str);
+
+    if (count == 0) {
+        // Argument doesn't contain newline. Just return the original.
+        return str;
+    }
+
+    int len_replacement = strlen(replacement);
+    int final_len = strlen(str) + (len_replacement - 1) * count;
+    
+    char* result;
+    if (!(result = malloc(final_len + 1)))
+        ERR_AND_EXIT("malloc");
+
+    char* to_tmp = result;
+	const char* from_tmp = str;
+    const char* next_newline;
+    
+    while((next_newline = strchr(from_tmp, from))) {
+        int len_before = next_newline - from_tmp;
+        to_tmp = strncpy(to_tmp, from_tmp, len_before) + len_before;
+        to_tmp = strcpy(to_tmp, replacement) + len_replacement;
+        from_tmp = next_newline + 1;
+    }
+    strcpy(to_tmp, from_tmp);
+
+    return result;
+}
+
+const char* sanitize_arg(const char* str) {
+    // Most sanitization is already handled by the \catcode stuff.
+    // We just need to replace newlines with ^^M to avoid a weird
+    // quirk where trailing spaces get removed when they precede a newline.
+    // Note we use \x03 instead of ^ since ^ is catcode'd to be "Other".
+    return replace_newline_with(str, "\x03\x03M");
 }

--- a/langs/tex/tex.c
+++ b/langs/tex/tex.c
@@ -66,7 +66,7 @@ int main(int argc, char* argv[]) {
         //
         // Note: If you ever come back to this, make sure it works for argv{\the\i}, argv\i, and argv{\count0}, and hole args starting with digits.
         const char* first = argv[1];
-        const char* rest = each_join(&argv[1], argc, "\05or\x04");
+        const char* rest = each_join(&argv[2], argc - 1, "\05or\x04");
         //                         \global     \def     \argv     #1   {   \ifnum     #1=0 [first]   \else   \ifcase     #1   \or [rest]    \fi     \fi   }   }
         const char* template = "\x05global\x05""def\x05""argv\x06""1\x01\x05ifnum\x06""1=0\x04%s\x05""else\x05ifcase\x06""1\x05or\x04%s\x05""fi\x05""fi\x02\x02";
         if (!snprintf(body, sizeof(body), template, first, rest))
@@ -152,9 +152,9 @@ int main(int argc, char* argv[]) {
     }
 }
 
-// Based on the original Bash implementation:
-// https://stackoverflow.com/a/17841619/7481517
+// Join the length-`cnt` array `arr` of strings with separator `sep`.
 char* each_join(char* arr[], int cnt, const char* sep) {
+    if (cnt == 0) return "";
     size_t len;
 
     for (int i = 0; i < cnt; i++)
@@ -165,7 +165,7 @@ char* each_join(char* arr[], int cnt, const char* sep) {
     if (!(rt = malloc(len + 1)))
         ERR_AND_EXIT("malloc");
 
-    for (int i = 1; i < cnt; i++) {
+    for (int i = 0; i < cnt; i++) {
         strcat(rt, arr[i]);
         strcat(rt, sep);
     }


### PR DESCRIPTION
### Description

This PR replaces all newlines with `^^M` in TeX args, to work around a bug (?) in TeX, where trailing spaces would get removed before a newline, even though the spaces and newlines all have their category codes set to 12 (Other). This should only affect QR Decoder, since it is the only hole with trailing spaces before a newline. The newlines are converted to `^^M` regardless, though, just for consistency. This shouldn't be a performance bottleneck.

The first three commits are pure refactors; the fourth is what makes the actual change.

### Testing behavior change

The following code replaces all spaces in the input with `.`:
```
\def\f#1#2;{%
  \if#1,\else
      \ifnum32=`#1.\else#1\fi
      \f#2;
  \fi
}
\edef\C{\argv0}
\expandafter\f\C,;
```

Before PR, it could give the following output on https://code.golf/qr-decoder#tex:

```
#######...###.#######
#.....#..##...#.....#
#.###.#.####..#.###.#
#.###.#..##.#.#.###.#
#.###.#...###.#.###.#
#.....#..#....#.....#
#######.#.#.#.#######
........##..#
###.#####.#.###...#
####.#.#.###.##.#..#
.#.##.#.##.##.###..##
###.#.....#..#...#
.....####......##..#
........##.#..###.###
#######.#..###.##.###
#.....#.#.##...#
#.###.#.##.##..##.#.#
#.###.#...##.#.#.#
#.###.#.#########.#.#
#.....#.##.....##..#
#######.#..#......###
```

The trailing spaces are lost!

I checked:
- [x] Make sure the trailing spaces stick around after PR (positive change).
- [x] Make sure my solutions to multiline holes like sudoku don't break.
- [x] Try a few random holes.