### PR TITLE
Remove default vimrc

### DIFF
--- a/langs/viml/viml.c
+++ b/langs/viml/viml.c
@@ -74,7 +74,7 @@ int main(int argc, char* argv[]) {
     if (fclose(fp))
         ERR_AND_EXIT("fclose");
 
-    system("/usr/bin/vim --clean --not-a-term --noplugin -eZ -V1 -S code.vim output >&2");
+    system("/usr/bin/vim --clean -u NONE --not-a-term --noplugin -eZ -V1 -S code.vim output >&2");
 
     if (!(fp = fopen("output", "r")))
         ERR_AND_EXIT("fopen");

--- a/langs/viml/viml.c
+++ b/langs/viml/viml.c
@@ -74,7 +74,7 @@ int main(int argc, char* argv[]) {
     if (fclose(fp))
         ERR_AND_EXIT("fclose");
 
-    system("/usr/bin/vim --clean -u NONE --not-a-term --noplugin -eZ -V1 -S code.vim output >&2");
+    system("/usr/bin/vim --clean -u NONE -N --not-a-term --noplugin -eZ -V1 -S code.vim output >&2");
 
     if (!(fp = fopen("output", "r")))
         ERR_AND_EXIT("fopen");


### PR DESCRIPTION
Currently, vimL is using defaults.vim as a vimrc.

defaults.vim does not have much in it. The executed lines are:
```vim
if &compatible
  set nocompatible
endif
set ttimeout
set ttimeoutlen=100
set display=truncate
set scrolloff=5
if has('reltime')
  set incsearch
endif
set nrformats-=octal
map Q gq
sunmap Q
inoremap <C-U> <C-G>u<C-U>
if has('mouse')
  if &term =~ 'xterm'
    set mouse=a
  else
    set mouse=nvi
  endif
endif
if 1
  filetype plugin indent on
  augroup vimStartup
    autocmd!
    autocmd BufReadPost *
      \ let line = line("'\"")
      \ | if line >= 1 && line <= line("$") && &filetype !~# 'commit'
      \      && index(['xxd', 'gitrebase', 'tutor'], &filetype) == -1
      \      && !&diff
      \ |   execute "normal! g`\""
      \ | endif
    autocmd TermResponse * if v:termresponse == "\e[>0;136;0c" | set bg=dark | endif
  augroup END
  augroup vimHints
    au!
    autocmd CmdwinEnter *
	  \ echohl Todo |
	  \ echo gettext('You discovered the command-line window! You can close it with ":q".') |
	  \ echohl None
  augroup END
endif
if !exists(":DiffOrig")
  command DiffOrig vert new | set bt=nofile | r ++edit # | 0d_ | diffthis
		  \ | wincmd p | diffthis
endif
```
I believe that the only possibly relevant commands here are:
```vim
set nocompatible
set scrolloff=5
set nrformats-=octal
map Q gq
inoremap <C-U> <C-G>u<C-U>
filetype plugin indent on
```
 - `set scrolloff=5`, `map Q gq` are idiosyncratic. Removing these may break some solutions (unlikely)
 - `fitetype plugin indent on` does too much, although I think it's mostly irrelevant to codegolf
 - `inoremap <C-U> <C-G>u<C-U>` is a small, unnecessary change. It's hard to guess if this is relevant to codegolf
 - `set nrformats-=octal` is nice too have, but not necessary and should be reset to default. **This may break some solutions**
 - `set nocompatible` should probably be kept. This PR include the `-N` argument to achieve this.

As a side effect, this change should speed up some vimL solutions