### PR TITLE
 Run VimL program without storing them in a file

### DIFF
--- a/config/data/langs.toml
+++ b/config/data/langs.toml
@@ -1976,7 +1976,7 @@ int main(string[] args) {
 
 [VimL]
 args    = [ '/usr/bin/viml', '-' ]
-size    = '35.6 MiB'
+size    = '35.5 MiB'
 version = '9.2'
 website = 'https://www.vim.org'
 example = '''

--- a/config/data/langs.toml
+++ b/config/data/langs.toml
@@ -1976,7 +1976,7 @@ int main(string[] args) {
 
 [VimL]
 args    = [ '/usr/bin/viml', '-' ]
-size    = '35.1 MiB'
+size    = '35.6 MiB'
 version = '9.2'
 website = 'https://www.vim.org'
 example = '''

--- a/langs/viml/Dockerfile
+++ b/langs/viml/Dockerfile
@@ -24,7 +24,6 @@ RUN gcc -Wall -Werror -Wextra -o /usr/bin/viml -s -static /viml.c
 
 FROM codegolf/lang-base
 
-COPY --from=0           /usr/bin/dash        /bin/sh
 COPY --from=0 --parents /lib/ld-musl-*.so.1  \
                         /usr/bin/vim         \
                         /usr/bin/viml        \

--- a/langs/viml/Dockerfile
+++ b/langs/viml/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.24 AS builder
 
 RUN apk add --no-cache dash gcc make musl-dev ncurses-dev ncurses-static
 
-ENV LDFLAGS='-static' VER=9.2.0010
+ENV LDFLAGS='-static' VER=9.2.0958
 
 ADD https://github.com/vim/vim.git#v$VER /vim
 

--- a/langs/viml/viml.c
+++ b/langs/viml/viml.c
@@ -1,11 +1,53 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #define ERR_AND_EXIT(msg) do { perror(msg); exit(EXIT_FAILURE); } while (0)
 
-const char* viml = "/usr/bin/vim", *code = "code.vim";
+const char* viml = "/usr/bin/vim";
+
+char* make_args_list(int argc, char* argv[]) {
+    size_t capacity = sizeof("let args = []");
+    for (int i = 2; i < argc; i++) {
+        capacity += 2 * strlen(argv[i]); // Assume worst-case escaping.
+        capacity += 3; // Quotes and comma.
+    }
+
+    char* ret = malloc(capacity);
+    char* out = stpcpy(ret, "let args = [");
+
+    for (int i = 2; i < argc; i++) {
+        *out++ = '"';
+
+        for (const char* c = argv[i]; *c; c++)
+            switch (*c) {
+                case '\\':
+                    *out++ = '\\';
+                    *out++ = '\\';
+                    break;
+                case '\"':
+                    *out++ = '\\';
+                    *out++ = '"';
+                    break;
+                case '\n':
+                    *out++ = '\\';
+                    *out++ = 'n';
+                    break;
+                default:
+                    *out++ = *c;
+            }
+
+        *out++ = '"';
+        *out++ = ',';
+    }
+
+    *out++ = ']';
+    *out++ = '\0';
+
+    return ret;
+}
 
 int main(int argc, char* argv[]) {
     if (!strcmp(argv[1], "--version")) {
@@ -18,63 +60,41 @@ int main(int argc, char* argv[]) {
 
     FILE* fp;
 
-    if (!(fp = fopen(code, "w")))
-        ERR_AND_EXIT("fopen");
-
-    if (!fprintf(fp, "let args = ["))
-        ERR_AND_EXIT("fprintf");
-
-    for (int i = 2; i < argc; i++) {
-        if (i > 2)
-            if (!fprintf(fp, ", "))
-                ERR_AND_EXIT("fprintf");
-
-        if (!fputc('"', fp))
-            ERR_AND_EXIT("fputc");
-
-        for (const char* c = argv[i]; *c; c++)
-            switch (*c) {
-                case '\\':
-                    if (fputs("\\\\", fp))
-                        ERR_AND_EXIT("fputs");
-                    break;
-                case '\"':
-                    if (fputs("\\\"", fp))
-                        ERR_AND_EXIT("fputs");
-                    break;
-                case '\n':
-                    if (fputs("\\n", fp))
-                        ERR_AND_EXIT("fputs");
-                    break;
-                default:
-                    if (!fputc(*c, fp))
-                        ERR_AND_EXIT("fputc");
-            }
-
-        if (!fputc('"', fp))
-            ERR_AND_EXIT("fputc");
-    }
-
-    if (fputs("]\n", fp))
-        ERR_AND_EXIT("fputs");
-
-    char stdout_buf[4096];
-    ssize_t nbytes;
-
-    while ((nbytes = read(STDIN_FILENO, stdout_buf, sizeof(stdout_buf))))
-        if (fwrite(stdout_buf, sizeof(char), nbytes, fp) != (size_t) nbytes)
-            ERR_AND_EXIT("fwrite");
-
-    if (fclose(fp))
-        ERR_AND_EXIT("fclose");
-
     if (!(fp = fopen("output", "w")))
         ERR_AND_EXIT("fopen");
 
     if (fclose(fp))
         ERR_AND_EXIT("fclose");
 
-    system("/usr/bin/vim --clean --not-a-term --noplugin -eZ -V1 -S code.vim output >&2");
+    pid_t pid;
+
+    if (!(pid = fork())) {
+        if (!dup2(STDERR_FILENO, STDOUT_FILENO))
+            ERR_AND_EXIT("dup2");
+
+        execl(
+            viml,
+            viml,
+            "--clean",
+            "--not-a-term",
+            "--noplugin",
+            "-eZ",
+            "-V1",
+            "-c", make_args_list(argc, argv),
+            "-S", "/proc/self/fd/0",
+            "output",
+            NULL
+        );
+
+        ERR_AND_EXIT("execl");
+    }
+
+    int status;
+
+    waitpid(pid, &status, 0);
+
+    char stdout_buf[4096];
+    ssize_t nbytes;
 
     if (!(fp = fopen("output", "r")))
         ERR_AND_EXIT("fopen");
@@ -85,4 +105,9 @@ int main(int argc, char* argv[]) {
 
     if (fclose(fp))
         ERR_AND_EXIT("fclose");
+
+    if (!WIFEXITED(status))
+        exit(EXIT_FAILURE);
+
+    return WEXITSTATUS(status);
 }


### PR DESCRIPTION
The main motivation for this change is to invalidate the current top VimL quines, which read their own source files.

I've also removed `/bin/sh` from the final container. It appears to have only been required for `system()` in the previous implementation, which is no longer used.

This also bumps Vim to the latest patch release. Vim seems prone to allocation patterns that musl's malloc handles poorly, causing small command-line changes to produce large, otherwise unrelated performance swings. The newer Vim version appears less sensitive to this, though it may still be worth considering glibc instead of musl.