### PR TITLE
Separate Floyd-Steinberg tests into individual runs

### DIFF
--- a/hole/floyd-steinberg-dithering.go
+++ b/hole/floyd-steinberg-dithering.go
@@ -2,9 +2,9 @@ package hole
 
 var _ = answerFunc("floyd-steinberg-dithering", func() []Answer {
     tests := fixedTests("floyd-steinberg-dithering")
-    runs := make([]Run, len(tests))
+    runs := make([]Answer, len(tests))
     for i, test := range tests {
-        runs[i] = Run{Args: []string{test.in}, Answer: test.out}
+        runs[i] = Answer{Args: []string{test.in}, Answer: test.out}
     }
     return shuffle(runs)
 })

--- a/hole/floyd-steinberg-dithering.go
+++ b/hole/floyd-steinberg-dithering.go
@@ -1,0 +1,10 @@
+package hole
+
+var _ = answerFunc("floyd-steinberg-dithering", func() []Answer {
+    tests := fixedTests("floyd-steinberg-dithering")
+    runs := make([]Run, len(tests))
+    for i, test := range tests {
+        runs[i] = Run{Args: []string{test.in}, Answer: test.out}
+    }
+    return shuffle(runs)
+}

--- a/hole/floyd-steinberg-dithering.go
+++ b/hole/floyd-steinberg-dithering.go
@@ -7,4 +7,4 @@ var _ = answerFunc("floyd-steinberg-dithering", func() []Answer {
         runs[i] = Run{Args: []string{test.in}, Answer: test.out}
     }
     return shuffle(runs)
-}
+})

--- a/hole/floyd-steinberg-dithering.go
+++ b/hole/floyd-steinberg-dithering.go
@@ -1,10 +1,10 @@
 package hole
 
 var _ = answerFunc("floyd-steinberg-dithering", func() []Answer {
-    tests := fixedTests("floyd-steinberg-dithering")
-    runs := make([]Answer, len(tests))
-    for i, test := range tests {
-        runs[i] = Answer{Args: []string{test.in}, Answer: test.out}
-    }
-    return shuffle(runs)
+	tests := fixedTests("floyd-steinberg-dithering")
+	runs := make([]Answer, len(tests))
+	for i, test := range tests {
+		runs[i] = Answer{Args: []string{test.in}, Answer: test.out}
+	}
+	return shuffle(runs)
 })

--- a/hole/play.go
+++ b/hole/play.go
@@ -75,7 +75,7 @@ func Play(
 		answers = outputTests(shuffle(fixedTests(hole.ID)))
 	case "emojify", "flags", "rock-paper-scissors-spock-lizard", "tic-tac-toe", "united-states":
 		answers = outputMultirunTests(fixedTests(hole.ID))
-	case "floyd-steinberg-dithering", "hexdump", "proximity-grid", "star-wars-opening-crawl":
+	case "hexdump", "proximity-grid", "star-wars-opening-crawl":
 		answers = outputTestsWithSep("\n\n", shuffle(fixedTests(hole.ID)))
 	case "minesweeper":
 		answers = outputTestsWithSep("\n\n", fixedTests(hole.ID), shuffle(fixedTests(hole.ID)))


### PR DESCRIPTION
Warning: untested code.
This should separate the test cases into individual runs, bringing each run's input under 30KB and allowing the hole to be solved in J.