### PR TITLE
Fix typo

### DIFF
--- a/views/html/about.html
+++ b/views/html/about.html
@@ -142,7 +142,7 @@
 
             <p>
                 For the language specific leaderboard, the best answer gets
-                1,000 points and the rest will get points inverseley
+                1,000 points and the rest will get points inversely
                 proportional to their length.
 
             <p>


### PR DESCRIPTION
Fix a typo in about page: `inverseley` → `inversely`